### PR TITLE
Revisit Resolvers per #295

### DIFF
--- a/src/NodaTime.Demo/StackOverflowExamples.cs
+++ b/src/NodaTime.Demo/StackOverflowExamples.cs
@@ -78,8 +78,11 @@ namespace NodaTime.Demo
             var shanghai = DateTimeZoneProviders.Tzdb["Asia/Shanghai"];
             var localBefore = new LocalDateTime(1900, 12, 31, 23, 54, 16);
             var localAfter = localBefore.PlusSeconds(1);
-            var instantBefore = localBefore.InZoneLeniently(shanghai).ToInstant();
-            var instantAfter = localAfter.InZoneLeniently(shanghai).ToInstant();
+
+            // Note: The behavior of NodaTime's Lenient resolver changed in 2.0, which deviates from the problem described in the original post.
+            var oldLenientResolver = Resolvers.CreateMappingResolver(Resolvers.ReturnLater, Resolvers.ReturnStartOfIntervalAfter);
+            var instantBefore = localBefore.InZone(shanghai, oldLenientResolver).ToInstant();
+            var instantAfter = localAfter.InZone(shanghai, oldLenientResolver).ToInstant();
 
             Assert.AreEqual(Duration.FromSeconds(344), instantAfter - instantBefore);
 

--- a/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
+++ b/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
@@ -318,28 +318,28 @@ namespace NodaTime.Test
 
         /// <summary>
         /// Pacific time changed from -7 to -8 at 2am wall time on November 2nd 2009,
-        /// so 2am became 1am. We'll return the later result, i.e. with the offset of -8
+        /// so 2am became 1am. We'll return the earlier result, i.e. with the offset of -7
         /// </summary>
         [Test]
-        public void AtLeniently_AmbiguousTime_ReturnsLaterMapping()
+        public void AtLeniently_AmbiguousTime_ReturnsEarlierMapping()
         {
             var local = new LocalDateTime(2009, 11, 1, 1, 30, 0);
             var zoned = Pacific.AtLeniently(local);
             Assert.AreEqual(local, zoned.LocalDateTime);
-            Assert.AreEqual(Offset.FromHours(-8), zoned.Offset);
+            Assert.AreEqual(Offset.FromHours(-7), zoned.Offset);
         }
 
         /// <summary>
         /// Pacific time changed from -8 to -7 at 2am wall time on March 8th 2009,
-        /// so 2am became 3am. This means that 2.30am doesn't exist on that day.
-        /// We'll return 3am, the start of the second interval.
+        /// so 2am became 3am. This means that 2:30am doesn't exist on that day.
+        /// We'll return 3:30am, the forward-shifted value.
         /// </summary>
         [Test]
-        public void AtLeniently_ReturnsStartOfSecondInterval()
+        public void AtLeniently_ReturnsForwardShiftedValue()
         {
             var local = new LocalDateTime(2009, 3, 8, 2, 30, 0);
             var zoned = Pacific.AtLeniently(local);
-            Assert.AreEqual(new LocalDateTime(2009, 3, 8, 3, 0, 0), zoned.LocalDateTime);
+            Assert.AreEqual(new LocalDateTime(2009, 3, 8, 3, 30, 0), zoned.LocalDateTime);
             Assert.AreEqual(Offset.FromHours(-7), zoned.Offset);
         }
 

--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -346,28 +346,28 @@ namespace NodaTime.Test
 
         /// <summary>
         /// Pacific time changed from -7 to -8 at 2am wall time on November 2nd 2009,
-        /// so 2am became 1am. We'll return the later result, i.e. with the offset of -8
+        /// so 2am became 1am. We'll return the earlier result, i.e. with the offset of -7
         /// </summary>
         [Test]
-        public void InZoneLeniently_AmbiguousTime_ReturnsLaterMapping()
+        public void InZoneLeniently_AmbiguousTime_ReturnsEarlierMapping()
         {
             var local = new LocalDateTime(2009, 11, 1, 1, 30, 0);
             var zoned = local.InZoneLeniently(Pacific);
             Assert.AreEqual(local, zoned.LocalDateTime);
-            Assert.AreEqual(Offset.FromHours(-8), zoned.Offset);
+            Assert.AreEqual(Offset.FromHours(-7), zoned.Offset);
         }
 
         /// <summary>
         /// Pacific time changed from -8 to -7 at 2am wall time on March 8th 2009,
-        /// so 2am became 3am. This means that 2.30am doesn't exist on that day.
-        /// We'll return 3am, the start of the second interval.
+        /// so 2am became 3am. This means that 2:30am doesn't exist on that day.
+        /// We'll return 3:30am, the forward-shifted value.
         /// </summary>
         [Test]
         public void InZoneLeniently_ReturnsStartOfSecondInterval()
         {
             var local = new LocalDateTime(2009, 3, 8, 2, 30, 0);
             var zoned = local.InZoneLeniently(Pacific);
-            Assert.AreEqual(new LocalDateTime(2009, 3, 8, 3, 0, 0), zoned.LocalDateTime);
+            Assert.AreEqual(new LocalDateTime(2009, 3, 8, 3, 30, 0), zoned.LocalDateTime);
             Assert.AreEqual(Offset.FromHours(-7), zoned.Offset);
         }
 

--- a/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
@@ -160,7 +160,7 @@ namespace NodaTime.Test.Text
             new Data(new LocalDateTime(2005, 1, 1, 1, 30).InZoneStrictly(TestZone1)) { Pattern = "yyyy-MM-dd o<g> HH:mm z", Text = "2005-01-01 +01 01:30 ab"},
             
             // Ambiguous value, resolver returns later value.
-            new Data(TestZone2.Transition.Plus(Duration.FromMinutes(30)).InZone(TestZone2)) { Pattern = "yyyy-MM-dd HH:mm z", Text = "2010-01-01 01:30 abc", Resolver = Resolvers.LenientResolver },
+            new Data(TestZone2.Transition.Plus(Duration.FromMinutes(30)).InZone(TestZone2)) { Pattern = "yyyy-MM-dd HH:mm z", Text = "2010-01-01 01:30 abc", Resolver = Resolvers.CreateMappingResolver(Resolvers.ReturnLater, Resolvers.ThrowWhenSkipped) },
 
             // Ambiguous value, resolver returns earlier value.
             new Data(TestZone2.Transition.Plus(Duration.FromMinutes(-30)).InZone(TestZone2)) { Pattern = "yyyy-MM-dd HH:mm z", Text = "2010-01-01 01:30 abc", Resolver = Resolvers.CreateMappingResolver(Resolvers.ReturnEarlier, Resolvers.ThrowWhenSkipped) },

--- a/src/NodaTime.Test/TimeZones/ResolversTest.cs
+++ b/src/NodaTime.Test/TimeZones/ResolversTest.cs
@@ -82,6 +82,7 @@ namespace NodaTime.Test.TimeZones
             var gap = mapping.LateInterval.WallOffset.Ticks - mapping.EarlyInterval.WallOffset.Ticks;
             var expected = TimeInTransition.ToLocalInstant().Minus(mapping.LateInterval.WallOffset).PlusTicks(gap);
             Assert.AreEqual(expected, resolved.ToInstant());
+            Assert.AreEqual(mapping.LateInterval.WallOffset, resolved.Offset);
             Assert.AreEqual(GapZone, resolved.Zone);
         }
 

--- a/src/NodaTime.Test/TimeZones/ResolversTest.cs
+++ b/src/NodaTime.Test/TimeZones/ResolversTest.cs
@@ -73,6 +73,19 @@ namespace NodaTime.Test.TimeZones
         }
 
         [Test]
+        public void ReturnForwardShifted()
+        {
+            var mapping = GapZone.MapLocal(TimeInTransition);
+            Assert.AreEqual(0, mapping.Count);
+            var resolved = Resolvers.ReturnForwardShifted(TimeInTransition, GapZone, mapping.EarlyInterval, mapping.LateInterval);
+
+            var gap = mapping.LateInterval.WallOffset.Ticks - mapping.EarlyInterval.WallOffset.Ticks;
+            var expected = TimeInTransition.ToLocalInstant().Minus(mapping.LateInterval.WallOffset).PlusTicks(gap);
+            Assert.AreEqual(expected, resolved.ToInstant());
+            Assert.AreEqual(GapZone, resolved.Zone);
+        }
+
+        [Test]
         public void ThrowWhenSkipped()
         {
             var mapping = GapZone.MapLocal(TimeInTransition);

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -262,8 +262,10 @@ namespace NodaTime.Test
 
             LocalDateTime local = new LocalDateTime(2011, 6, 13, 1, 30);
             ZonedDateTime zoned = new ZonedDateTime(local, zone, zone.LateInterval.WallOffset);
-            // Leniently will return the later instant
-            Assert.AreEqual(zoned, local.InZoneLeniently(zone));
+
+            // Map the local time to the later of the offsets in a way which is tested elsewhere.
+            var resolver = Resolvers.CreateMappingResolver(Resolvers.ReturnLater, Resolvers.ThrowWhenSkipped);
+            Assert.AreEqual(zoned, local.InZone(zone, resolver));
         }
 
         [Test]

--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -32,8 +32,8 @@ namespace NodaTime
     ///   </item>
     ///   <item>
     ///     <description><see cref="AtLeniently"/> will never throw an exception due to ambiguous or skipped times,
-    ///     resolving to the later option of ambiguous matches or the start of the zone interval after the gap for
-    ///     skipped times.</description>
+    ///     resolving to the earlier option of ambiguous matches, or to a value that's forward-shifted by the duration
+    ///     of the gap for skipped times.</description>
     ///   </item>
     ///   <item>
     ///     <description><see cref="ResolveLocal(LocalDateTime, ZoneLocalMappingResolver)"/> will apply a <see cref="ZoneLocalMappingResolver"/> to the result of

--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -398,7 +398,7 @@ namespace NodaTime
         /// <exception cref="AmbiguousTimeException">The given local date/time is ambiguous in this time zone.</exception>
         /// <returns>The unambiguous matching <see cref="ZonedDateTime"/> if it exists.</returns>
         public ZonedDateTime AtStrictly(LocalDateTime localDateTime) =>
-            ResolveLocal(localDateTime, Resolvers.ThrowWhenAmbiguous, Resolvers.ThrowWhenSkipped);
+            ResolveLocal(localDateTime, Resolvers.StrictResolver);
 
         /// <summary>
         /// Maps the given <see cref="LocalDateTime"/> to the corresponding <see cref="ZonedDateTime"/> in a lenient
@@ -413,7 +413,7 @@ namespace NodaTime
         /// <returns>The unambiguous mapping if there is one, the later result if the mapping is ambiguous,
         /// or the start of the later zone interval if the given local date/time is skipped.</returns>
         public ZonedDateTime AtLeniently(LocalDateTime localDateTime) =>
-            ResolveLocal(localDateTime, Resolvers.ReturnLater, Resolvers.ReturnStartOfIntervalAfter);
+            ResolveLocal(localDateTime, Resolvers.LenientResolver);
         #endregion
 
         /// <summary>

--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -402,16 +402,21 @@ namespace NodaTime
 
         /// <summary>
         /// Maps the given <see cref="LocalDateTime"/> to the corresponding <see cref="ZonedDateTime"/> in a lenient
-        /// manner: ambiguous values map to the later of the alternatives, and "skipped" values map to the start of the
-        /// zone interval after the "gap".
+        /// manner: ambiguous values map to the earlier of the alternatives, and "skipped" values are shifted forward
+        /// by the duration of the "gap".
         /// </summary>
         /// <remarks>
         /// See <see cref="AtStrictly"/> and <see cref="ResolveLocal(LocalDateTime, ZoneLocalMappingResolver)"/> for alternative ways to map a local time to a
         /// specific instant.
+        /// <para>Note: The behavior of this method was changed in version 2.0 to fit the most commonly seen real-world
+        /// usage pattern.  Previous versions returned the later instance of ambiguous values, and returned the start of
+        /// the zone interval after the gap for skipped value.  The previous functionality can still be used if desired,
+        /// by using <see cref="ResolveLocal(LocalDateTime, AmbiguousTimeResolver, SkippedTimeResolver)"/> and passing the
+        /// <see cref="ReturnLater"/> and <see cref="ReturnStartOfIntervalAfter"/> resolvers.</para>
         /// </remarks>
         /// <param name="localDateTime">The local date/time to map.</param>
-        /// <returns>The unambiguous mapping if there is one, the later result if the mapping is ambiguous,
-        /// or the start of the later zone interval if the given local date/time is skipped.</returns>
+        /// <returns>The unambiguous mapping if there is one, the earlier result if the mapping is ambiguous,
+        /// or the forward-shifted value if the given local date/time is skipped.</returns>
         public ZonedDateTime AtLeniently(LocalDateTime localDateTime) =>
             ResolveLocal(localDateTime, Resolvers.LenientResolver);
         #endregion

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -896,14 +896,18 @@ namespace NodaTime
 
         /// <summary>
         /// Returns the mapping of this local date/time within the given <see cref="DateTimeZone" />,
-        /// with "lenient" rules applied such that ambiguous values map to the
-        /// later of the alternatives, and "skipped" values map to the start of the zone interval
-        /// after the "gap".
+        /// with "lenient" rules applied such that ambiguous values map to the earlier of the alternatives, and
+        /// "skipped" values are shifted forward by the duration of the "gap".
         /// </summary>
         /// <remarks>
         /// See <see cref="InZoneStrictly"/> and <see cref="InZone"/> for alternative ways to map a local time to a
         /// specific instant.
         /// This is solely a convenience method for calling <see cref="DateTimeZone.AtLeniently" />.
+        /// <para>Note: The behavior of this method was changed in version 2.0 to fit the most commonly seen real-world
+        /// usage pattern.  Previous versions returned the later instance of ambiguous values, and returned the start of
+        /// the zone interval after the gap for skipped value.  The previous functionality can still be used if desired,
+        /// by using <see cref="InZone(DateTimeZone, ZoneLocalMappingResolver)"/> and passing a resolver that combines the
+        /// <see cref="Resolvers.ReturnLater"/> and <see cref="Resolvers.ReturnStartOfIntervalAfter"/> resolvers.</para>
         /// </remarks>
         /// <param name="zone">The time zone in which to map this local date/time.</param>
         /// <returns>The result of mapping this local date/time in the given time zone.</returns>

--- a/src/NodaTime/TimeZones/Resolvers.cs
+++ b/src/NodaTime/TimeZones/Resolvers.cs
@@ -67,6 +67,19 @@ namespace NodaTime.TimeZones
         };
 
         /// <summary>
+        /// A <see cref="SkippedTimeResolver"/> which shifts values in the "gap" forward by the duration
+        /// of the gap (which is usually 1 hour).
+        /// </summary>
+        public static readonly SkippedTimeResolver ReturnForwardShifted = (local, zone, before, after) =>
+        {
+            Preconditions.CheckNotNull(zone, nameof(zone));
+            Preconditions.CheckNotNull(before, nameof(before));
+            Preconditions.CheckNotNull(after, nameof(after));
+            long gap = after.WallOffset.Ticks - before.WallOffset.Ticks;
+            return new ZonedDateTime(local.PlusTicks(gap), zone, after.WallOffset);
+        };
+
+        /// <summary>
         /// A <see cref="SkippedTimeResolver"/> which simply throws a <see cref="SkippedTimeException"/>.
         /// </summary>
         public static readonly SkippedTimeResolver ThrowWhenSkipped = (local, zone, before, after) =>

--- a/src/NodaTime/TimeZones/Resolvers.cs
+++ b/src/NodaTime/TimeZones/Resolvers.cs
@@ -68,7 +68,8 @@ namespace NodaTime.TimeZones
 
         /// <summary>
         /// A <see cref="SkippedTimeResolver"/> which shifts values in the "gap" forward by the duration
-        /// of the gap (which is usually 1 hour).
+        /// of the gap (which is usually 1 hour).  This corresponds to the instant that would have occured,
+        /// had there not been a transition.
         /// </summary>
         public static SkippedTimeResolver ReturnForwardShifted { get; } = (local, zone, before, after) =>
         {

--- a/src/NodaTime/TimeZones/Resolvers.cs
+++ b/src/NodaTime/TimeZones/Resolvers.cs
@@ -107,12 +107,15 @@ namespace NodaTime.TimeZones
         /// A <see cref="ZoneLocalMappingResolver"/> which never throws an exception due to ambiguity or skipped time.
         /// </summary>
         /// <remarks>
-        /// Ambiguity is handled by returning the later occurrence, and skipped times are mapped to the start of the zone interval
-        /// after the gap. This resolver combines <see cref="ReturnLater"/> and <see cref="ReturnStartOfIntervalAfter"/>.
+        /// Ambiguity is handled by returning the earlier occurrence, and skipped times are shifted forward by the duration
+        /// of the gap. This resolver combines <see cref="ReturnEarlier"/> and <see cref="ReturnForwardShifted"/>.
+        /// <para>Note: The behavior of this resolver was changed in version 2.0 to fit the most commonly seen real-world
+        /// usage pattern.  Previous versions combined the <see cref="ReturnLater"/> and <see cref="ReturnStartOfIntervalAfter"/>
+        /// resolvers, which can still be used separately if desired.</para>
         /// </remarks>
         /// <seealso cref="DateTimeZone.AtLeniently"/>
         public static ZoneLocalMappingResolver LenientResolver { get; } =
-            CreateMappingResolver(ReturnLater, ReturnStartOfIntervalAfter);
+            CreateMappingResolver(ReturnEarlier, ReturnForwardShifted);
 
         /// <summary>
         /// Combines an <see cref="AmbiguousTimeResolver"/> and a <see cref="SkippedTimeResolver"/> to create a

--- a/src/NodaTime/TimeZones/Resolvers.cs
+++ b/src/NodaTime/TimeZones/Resolvers.cs
@@ -75,8 +75,7 @@ namespace NodaTime.TimeZones
             Preconditions.CheckNotNull(zone, nameof(zone));
             Preconditions.CheckNotNull(before, nameof(before));
             Preconditions.CheckNotNull(after, nameof(after));
-            long gap = after.WallOffset.Ticks - before.WallOffset.Ticks;
-            return new ZonedDateTime(local.PlusTicks(gap), zone, after.WallOffset);
+            return new ZonedDateTime(new OffsetDateTime(local, before.WallOffset).WithOffset(after.WallOffset), zone);
         };
 
         /// <summary>

--- a/src/NodaTime/TimeZones/Resolvers.cs
+++ b/src/NodaTime/TimeZones/Resolvers.cs
@@ -45,7 +45,7 @@ namespace NodaTime.TimeZones
         /// A <see cref="SkippedTimeResolver"/> which returns the final tick of the time zone interval
         /// before the "gap".
         /// </summary>
-        public static readonly SkippedTimeResolver ReturnEndOfIntervalBefore = (local, zone, before, after) =>
+        public static SkippedTimeResolver ReturnEndOfIntervalBefore { get; } = (local, zone, before, after) =>
         {
             Preconditions.CheckNotNull(zone, nameof(zone));
             Preconditions.CheckNotNull(before, nameof(before));
@@ -58,7 +58,7 @@ namespace NodaTime.TimeZones
         /// A <see cref="SkippedTimeResolver"/> which returns the first tick of the time zone interval
         /// after the "gap".
         /// </summary>
-        public static readonly SkippedTimeResolver ReturnStartOfIntervalAfter = (local, zone, before, after) =>
+        public static SkippedTimeResolver ReturnStartOfIntervalAfter { get; } = (local, zone, before, after) =>
         {
             Preconditions.CheckNotNull(zone, nameof(zone));
             Preconditions.CheckNotNull(before, nameof(before));
@@ -70,7 +70,7 @@ namespace NodaTime.TimeZones
         /// A <see cref="SkippedTimeResolver"/> which shifts values in the "gap" forward by the duration
         /// of the gap (which is usually 1 hour).
         /// </summary>
-        public static readonly SkippedTimeResolver ReturnForwardShifted = (local, zone, before, after) =>
+        public static SkippedTimeResolver ReturnForwardShifted { get; } = (local, zone, before, after) =>
         {
             Preconditions.CheckNotNull(zone, nameof(zone));
             Preconditions.CheckNotNull(before, nameof(before));
@@ -82,7 +82,7 @@ namespace NodaTime.TimeZones
         /// <summary>
         /// A <see cref="SkippedTimeResolver"/> which simply throws a <see cref="SkippedTimeException"/>.
         /// </summary>
-        public static readonly SkippedTimeResolver ThrowWhenSkipped = (local, zone, before, after) =>
+        public static SkippedTimeResolver ThrowWhenSkipped { get; } = (local, zone, before, after) =>
         {
             Preconditions.CheckNotNull(zone, nameof(zone));
             Preconditions.CheckNotNull(before, nameof(before));

--- a/www/unstable/userguide/versions.md
+++ b/www/unstable/userguide/versions.md
@@ -19,6 +19,15 @@ See the [Noda Time 1.x to 2.0 migration guide](migration-to-2.html) for full det
   support for the legacy resource-based time zone data format.
 - Removed `Instant(long)` constructor from the public API.
 - Removed `LocalTime.LocalDateTime` property.
+- Changed the behavior of the `LenientResolver` to more closely match real-world usage.
+  This also affects `DateTimeZone.AtLeniently` and `LocalDateTime.InZoneLeniently`.
+   - For ambiguous values, the lenient resolver used to return the later of the two possible instants.
+    It now returns the *earlier* of the two possible instants.  For example, if 01:00 is ambiguous, it used to return
+    1:00 standard time and it now will return 01:00 *daylight* time.
+  - For skipped values, the lenient resolver used to return the instant corresponding to the first possible local time
+    following the "gap".  It now returns the instant that would have occurred if the gap had not existed.  This
+    corresponds to a local time that is shifted forward by the duration of the gap.  For example, if values from
+    02:00 to 02:59 were skipped, a value of 02:30 used to return 03:00 and it will now return 03:30.
 - `Period` and `PeriodBuilder` properties for date-based values (years, months, weeks, days) are now of type `int` rather than `long`.
 - Default values for local date-based structs (`LocalDate` etc) now return 0001-01-01
   instead of the Unix epoch.
@@ -42,6 +51,12 @@ Bug fixes:
 - `BclDateTimeZone` has been reimplemented from scratch. This may result in a very few differences
   in the interpretation of when an adjustment rule starts and ends. It is now known to be incompatible
   with the BCL in well-understood ways which we don't intend to change.
+
+Other:
+
+- Added a `ReturnForwardShifted` resolver, which shifts values in the daylight saving time "gap" forward by the duration of the gap,
+  effectively returning the instant that would have occurred had the gap not existed.  This was added to support the new behavior of
+  the "lenient" resolver (see above), but can also be used separately.
 
 ## 1.3.1, released 2015-03-06 with tzdb 2015a
 


### PR DESCRIPTION
Discussed in #295, this PR does the following:

- Adds a `ReturnForwardShifted` resolver

- Changes the behavior of the `LenientResolver` and associated methods:
  - Ambiguous values are now resolved with `ReturnEarlier` instead of `ReturnLater`
  - Skipped values are now resolved with `ReturnForwardShifted` instead of `ReturnStartOfInterval`

- Updates associated xml docs and unit tests.

Note that this is a breaking change, which should be described and highlighted in the documentation and release notes when 2.0 is released.  I'm convinced that this is a better default behavior than the existing lenient behavior, based on numerous real-world examples.

My thinking goes like this:
- If you have an ambiguous value, it's probably because you are scheduling a job to run at the same time every day.  In the vast majority of cases, it would be considered a bug if a job did not run at the first time the local time was encountered on the clock.

- If you have a skipped value, you probably have it due to either some external clock source not advancing for DST, or because you are scheduling a job to run at the same time every day, and that time falls into the gap.  Thus, the value should shift forward, applying the DST gap to the value.  The current behavior of advancing to the first instant after the gap doesn't really make sense, because a clock would never tick forward in that manner.


The only exception case that comes to mind is when scheduling the close of business when the business elects to stay open the extra hour of the DST overlap.  For example, a bar might have to stop serving alcohol at 1:00AM, but once a year they get the option to serve until the *second* 1:00AM.  I think this should be thought of as an edge case rather than the default, and can thus be handled explicitly with the `ReturnLater` resolver.