### PR TITLE
Feature/#385 plus mintues to zoned date time

### DIFF
--- a/src/NodaTime.Test/OffsetDateTimeTest.cs
+++ b/src/NodaTime.Test/OffsetDateTimeTest.cs
@@ -254,6 +254,13 @@ namespace NodaTime.Test
         [Test]
         public void Addition_Duration()
         {
+            const int minutes = 23;
+            const int hours = 3;
+            const int milliseconds = 40000;
+            const long seconds = 321;
+            const long nanoseconds = 12345;
+            const long ticks = 5432112345;
+
             // Test all three approaches... not bothering to check a different calendar,
             // but we'll use two different offsets.
             OffsetDateTime start = new LocalDateTime(2014, 08, 14, 6, 51).WithOffset(Offset.FromHours(1));
@@ -262,6 +269,24 @@ namespace NodaTime.Test
             Assert.AreEqual(expected, start + duration);
             Assert.AreEqual(expected, start.Plus(duration));
             Assert.AreEqual(expected, OffsetDateTime.Add(start, duration));
+
+            Assert.AreEqual(start + Duration.FromHours(hours), start.PlusHours(hours));
+            Assert.AreEqual(start + Duration.FromHours(-hours), start.PlusHours(-hours));
+
+            Assert.AreEqual(start + Duration.FromMinutes(minutes), start.PlusMinutes(minutes));
+            Assert.AreEqual(start + Duration.FromMinutes(-minutes), start.PlusMinutes(-minutes));
+
+            Assert.AreEqual(start + Duration.FromSeconds(seconds), start.PlusSeconds(seconds));
+            Assert.AreEqual(start + Duration.FromSeconds(-seconds), start.PlusSeconds(-seconds));
+
+            Assert.AreEqual(start + Duration.FromMilliseconds(milliseconds), start.PlusMilliseconds(milliseconds));
+            Assert.AreEqual(start + Duration.FromMilliseconds(-milliseconds), start.PlusMilliseconds(-milliseconds));
+
+            Assert.AreEqual(start + Duration.FromNanoseconds(nanoseconds), start.PlusNanoseconds(nanoseconds));
+            Assert.AreEqual(start + Duration.FromNanoseconds(-nanoseconds), start.PlusNanoseconds(-nanoseconds));
+
+            Assert.AreEqual(start + Duration.FromNanoseconds(ticks), start.PlusNanoseconds(ticks));
+            Assert.AreEqual(start + Duration.FromNanoseconds(-ticks), start.PlusNanoseconds(-ticks));
         }
 
         [Test]

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -75,9 +75,34 @@ namespace NodaTime.Test
         [Test]
         public void Add_MethodEquivalents()
         {
+            const int minutes = 23;
+            const int hours = 3;
+            const int milliseconds = 40000;
+            const long seconds = 321;
+            const long nanoseconds = 12345;
+            const long ticks = 5432112345;
+
             ZonedDateTime before = SampleZone.AtStrictly(new LocalDateTime(2011, 6, 12, 15, 0));
             Assert.AreEqual(before + Duration.OneDay, ZonedDateTime.Add(before, Duration.OneDay));
             Assert.AreEqual(before + Duration.OneDay, before.Plus(Duration.OneDay));
+            
+            Assert.AreEqual(before + Duration.FromHours(hours), before.PlusHours(hours));
+            Assert.AreEqual(before + Duration.FromHours(-hours), before.PlusHours(-hours));
+
+            Assert.AreEqual(before + Duration.FromMinutes(minutes), before.PlusMinutes(minutes));
+            Assert.AreEqual(before + Duration.FromMinutes(-minutes), before.PlusMinutes(-minutes));
+
+            Assert.AreEqual(before + Duration.FromSeconds(seconds), before.PlusSeconds(seconds));
+            Assert.AreEqual(before + Duration.FromSeconds(-seconds), before.PlusSeconds(-seconds));
+
+            Assert.AreEqual(before + Duration.FromMilliseconds(milliseconds), before.PlusMilliseconds(milliseconds));
+            Assert.AreEqual(before + Duration.FromMilliseconds(-milliseconds), before.PlusMilliseconds(-milliseconds));
+
+            Assert.AreEqual(before + Duration.FromNanoseconds(nanoseconds), before.PlusNanoseconds(nanoseconds));
+            Assert.AreEqual(before + Duration.FromNanoseconds(-nanoseconds), before.PlusNanoseconds(-nanoseconds));
+
+            Assert.AreEqual(before + Duration.FromNanoseconds(ticks), before.PlusNanoseconds(ticks));
+            Assert.AreEqual(before + Duration.FromNanoseconds(-ticks), before.PlusNanoseconds(-ticks));
         }
 
         [Test]

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -568,6 +568,54 @@ namespace NodaTime
         public OffsetDateTime Plus(Duration duration) => this + duration;
 
         /// <summary>
+        /// Returns the result of adding a increment of hours to this zoned date and time
+        /// </summary>
+        /// <param name="hours">The number of hours to add</param>
+        /// <returns>A new <see cref="OffsetDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public OffsetDateTime PlusHours(int hours) => this + Duration.FromHours(hours);
+
+        /// <summary>
+        /// Returns the result of adding an increment of minutes to this zoned date and time
+        /// </summary>
+        /// <param name="minutes">The number of minutes to add</param>
+        /// <returns>A new <see cref="OffsetDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public OffsetDateTime PlusMinutes(int minutes) => this + Duration.FromMinutes(minutes);
+
+        /// <summary>
+        /// Returns the result of adding an increment of seconds to this zoned date and time
+        /// </summary>
+        /// <param name="seconds">The number of seconds to add</param>#
+        /// <returns>A new <see cref="OffsetDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public OffsetDateTime PlusSeconds(long seconds) => this + Duration.FromSeconds(seconds);
+
+        /// <summary>
+        /// Returns the result of adding an increment of milliseconds to this zoned date and time
+        /// </summary>
+        /// <param name="milliseconds">The number of milliseconds to add</param>
+        /// <returns>A new <see cref="OffsetDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public OffsetDateTime PlusMilliseconds(long milliseconds) => this + Duration.FromMilliseconds(milliseconds);
+
+        /// <summary>
+        /// Returns the result of adding an increment of nanoseconds to this zoned date and time
+        /// </summary>
+        /// <param name="nanoseconds">The number of nanoseconds to add</param>
+        /// <returns>A new <see cref="OffsetDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public OffsetDateTime PlusNanoseconds(long nanoseconds) => this + Duration.FromNanoseconds(nanoseconds);
+
+        /// <summary>
+        /// Returns the result of adding an increment of ticks to this zoned date and time
+        /// </summary>
+        /// <param name="ticks">The number of ticks to add</param>
+        /// <returns>A new <see cref="OffsetDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public OffsetDateTime PlusTicks(long ticks) => this + Duration.FromTicks(ticks);
+
+        /// <summary>
         /// Returns a new <see cref="OffsetDateTime"/> with the time advanced by the given duration.
         /// </summary>
         /// <remarks>

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -380,6 +380,54 @@ namespace NodaTime
         public ZonedDateTime Plus(Duration duration) => this + duration;
 
         /// <summary>
+        /// Returns the result of adding a increment of hours to this zoned date and time
+        /// </summary>
+        /// <param name="hours">The number of hours to add</param>
+        /// <returns>A new <see cref="ZonedDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public ZonedDateTime PlusHours(int hours) => this + Duration.FromHours(hours);
+
+        /// <summary>
+        /// Returns the result of adding an increment of minutes to this zoned date and time
+        /// </summary>
+        /// <param name="minutes">The number of minutes to add</param>
+        /// <returns>A new <see cref="ZonedDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public ZonedDateTime PlusMinutes(int minutes) => this + Duration.FromMinutes(minutes);
+
+        /// <summary>
+        /// Returns the result of adding an increment of seconds to this zoned date and time
+        /// </summary>
+        /// <param name="seconds">The number of seconds to add</param>
+        /// <returns>A new <see cref="ZonedDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public ZonedDateTime PlusSeconds(long seconds) => this + Duration.FromSeconds(seconds);
+
+        /// <summary>
+        /// Returns the result of adding an increment of milliseconds to this zoned date and time
+        /// </summary>
+        /// <param name="milliseconds">The number of milliseconds to add</param>
+        /// <returns>A new <see cref="ZonedDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public ZonedDateTime PlusMilliseconds(long milliseconds) => this + Duration.FromMilliseconds(milliseconds);
+
+        /// <summary>
+        /// Returns the result of adding an increment of nanoseconds to this zoned date and time
+        /// </summary>
+        /// <param name="nanoseconds">The number of nanoseconds to add</param>
+        /// <returns>A new <see cref="ZonedDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public ZonedDateTime PlusNanoseconds(long nanoseconds) => this + Duration.FromNanoseconds(nanoseconds);
+
+        /// <summary>
+        /// Returns the result of adding an increment of ticks to this zoned date and time
+        /// </summary>
+        /// <param name="ticks">The number of ticks to add</param>
+        /// <returns>A new <see cref="ZonedDateTime" /> representing the result of the addition.</returns>
+        [Pure]
+        public ZonedDateTime PlusTicks(long ticks) => this + Duration.FromTicks(ticks);
+
+        /// <summary>
         /// Returns a new <see cref="ZonedDateTime"/> with the time advanced by the given duration. Note that
         /// due to daylight saving time changes this may not advance the local time by the same amount.
         /// </summary>


### PR DESCRIPTION
In relation to [Feature 385](https://github.com/nodatime/nodatime/issues/385). 

No breaking change to current functionality, purely additive. Please inform me if there are any test cases missing or additional modifications.

Thanks.