### PR TITLE
Test more calculators in YearMonthCalculatorTest... 

### DIFF
--- a/src/NodaTime.Test/Calendars/YearMonthDayCalculatorTest.cs
+++ b/src/NodaTime.Test/Calendars/YearMonthDayCalculatorTest.cs
@@ -13,37 +13,52 @@ namespace NodaTime.Test.Calendars
     [TestFixture]
     public class YearMonthDayCalculatorTest
     {
+        // Here the term "Islamic" only refers to whether the implementation is IslamicYearMonthDayCalculator,
+        // not whether the calendar itself is based on Islamic scripture.
+        // TODO(code review): Make sure I've reported a bug for the CodeRush Roslyn preview test runner - it
+        // seems to only have one test per *type* of calculator. (So only one IslamicCalculator per test...)
         private static readonly TestCaseData[] NonIslamicCalculators = {
             new TestCaseData(new GregorianYearMonthDayCalculator()).SetName("Gregorian"),
             new TestCaseData(new CopticYearMonthDayCalculator()).SetName("Coptic"),
             new TestCaseData(new JulianYearMonthDayCalculator()).SetName("Julian"),
+            new TestCaseData(new HebrewYearMonthDayCalculator(HebrewMonthNumbering.Civil)).SetName("Hebrew Civil"),
+            new TestCaseData(new HebrewYearMonthDayCalculator(HebrewMonthNumbering.Scriptural)).SetName("Hebrew Scriptural"),
+            new TestCaseData(new PersianYearMonthDayCalculator.Simple()).SetName("Persian Simple"),
+            new TestCaseData(new PersianYearMonthDayCalculator.Arithmetic()).SetName("Persian Arithmetic"),
+            new TestCaseData(new PersianYearMonthDayCalculator.Astronomical()).SetName("Persian Astronomoical"),
+            new TestCaseData(new UmAlQuraYearMonthDayCalculator()).SetName("Um Al Qura"),
         };
 
         private static readonly TestCaseData[] IslamicCalculators =
             (from epoch in Enum.GetValues(typeof(IslamicEpoch)).Cast<IslamicEpoch>()
              from leapYearPattern in Enum.GetValues(typeof(IslamicLeapYearPattern)).Cast<IslamicLeapYearPattern>()
              let calculator = new IslamicYearMonthDayCalculator(leapYearPattern, epoch)
-             select new TestCaseData(calculator).SetName(string.Format("Islamic: {0}, {1}", epoch, leapYearPattern)))
+             select new TestCaseData(calculator).SetName($"Islamic: {epoch}, {leapYearPattern}"))
              .ToArray();
 
-#pragma warning disable 0414 // Used by tests via reflection - do not remove!
-        private static IEnumerable<TestCaseData> AllCalculators = NonIslamicCalculators.Concat(IslamicCalculators);
-#pragma warning restore 0414
+        private static readonly IEnumerable<TestCaseData> AllCalculators = NonIslamicCalculators.Concat(IslamicCalculators);
 
         // Note for tests using TestCaseSource:
         // We can't make the parameter of type YearMonthDayCalculator, because that's internal.
         // We can't make the method internal, as then it isn't a test. Casting is all we've got.
 
         [Test]
-        [TestCaseSource("AllCalculators")]
-        public void ValidateYear1Ticks(object calculatorAsObject)
+        [TestCaseSource(nameof(AllCalculators))]
+        public void ValidateStartOfYear1Days(object calculatorAsObject)
         {
             var calculator = (YearMonthDayCalculator) calculatorAsObject;
+            // Some calendars (e.g. Um Al Qura) don't support year 1, so the DaysAtStartOfYear1
+            // is somewhat theoretical. (It's still used in such calendars, but only to get a guess
+            // as to a year number given a day number.)
+            if (calculator.MinYear > 1 || calculator.MaxYear < 0)
+            {
+                return;
+            }
             Assert.AreEqual(calculator.GetStartOfYearInDays(1), calculator.DaysAtStartOfYear1);
         }
 
         [Test]
-        [TestCaseSource("AllCalculators")]
+        [TestCaseSource(nameof(AllCalculators))]
         public void GetYearConsistentWithGetYearDays(object calculatorAsObject)
         {
             var calculator = (YearMonthDayCalculator)calculatorAsObject;

--- a/src/NodaTime.Test/Calendars/YearMonthDayCalculatorTest.cs
+++ b/src/NodaTime.Test/Calendars/YearMonthDayCalculatorTest.cs
@@ -15,8 +15,6 @@ namespace NodaTime.Test.Calendars
     {
         // Here the term "Islamic" only refers to whether the implementation is IslamicYearMonthDayCalculator,
         // not whether the calendar itself is based on Islamic scripture.
-        // TODO(code review): Make sure I've reported a bug for the CodeRush Roslyn preview test runner - it
-        // seems to only have one test per *type* of calculator. (So only one IslamicCalculator per test...)
         private static readonly TestCaseData[] NonIslamicCalculators = {
             new TestCaseData(new GregorianYearMonthDayCalculator()).SetName("Gregorian"),
             new TestCaseData(new CopticYearMonthDayCalculator()).SetName("Coptic"),

--- a/src/NodaTime/Calendars/HebrewScripturalCalculator.cs
+++ b/src/NodaTime/Calendars/HebrewScripturalCalculator.cs
@@ -21,6 +21,8 @@ namespace NodaTime.Calendars
         // invalid years, but still problematic in general).
         private const int IsHeshvanLongCacheBit = 1 << 0;
         private const int IsKislevShortCacheBit = 1 << 1;
+        // Number of bits to shift the elapsed days in order to get the cache value.
+        private const int ElapsedDaysCacheShift = 2;
 
         // Cache of when each year starts (in  terms of absolute days). This is the heart of
         // the algorithm, so just caching this is highly effective.
@@ -213,7 +215,7 @@ namespace NodaTime.Calendars
         internal static int ElapsedDays(int year)
         {
             int cache = GetOrPopulateCache(year);
-            return cache >> 2;
+            return cache >> ElapsedDaysCacheShift;
         }
 
         private static int ElapsedDaysNoCache(int year)
@@ -273,7 +275,7 @@ namespace NodaTime.Calendars
                 int cacheIndex = YearStartCacheEntry.GetCacheIndex(nextYear);
                 YearStartCacheEntry cacheEntry = YearCache[cacheIndex];
                 nextYearDays = cacheEntry.IsValidForYear(nextYear)
-                    ? cacheEntry.StartOfYearDays >> 2
+                    ? cacheEntry.StartOfYearDays >> ElapsedDaysCacheShift
                     : ElapsedDaysNoCache(nextYear);
             }
             else
@@ -283,7 +285,7 @@ namespace NodaTime.Calendars
             int daysInYear = nextYearDays - days;
             bool isHeshvanLong = daysInYear % 10 == 5;
             bool isKislevShort = daysInYear % 10 == 3;
-            return (days << 2)
+            return (days << ElapsedDaysCacheShift)
                 | (isHeshvanLong ? IsHeshvanLongCacheBit : 0)
                 | (isKislevShort ? IsKislevShortCacheBit : 0);
         }


### PR DESCRIPTION
… and fix them when they break.

HebrewYearMonthCalculator was broken for year 0 and earlier - which isn't a problem for
most code, but it's possible that in a few cases our internals need to be able to handle values
outside the normal range. The cache format was assuming it could tweak the two high bits
arbitrarily - which doesn't work so well when the original value is negative. We now use the
bottom two bits for the lengths of Heshvan/Kislev.