### PR TITLE
Use nameof with test case sources.

### DIFF
--- a/src/NodaTime.Test/CalendarSystemTest.cs
+++ b/src/NodaTime.Test/CalendarSystemTest.cs
@@ -12,13 +12,11 @@ namespace NodaTime.Test
     [TestFixture]
     public partial class CalendarSystemTest
     {
-#pragma warning disable 0414 // Used by tests via reflection - do not remove!
         private static readonly IEnumerable<string> SupportedIds = CalendarSystem.Ids.Where(x => x != "Um Al Qura" || UmAlQuraYearMonthDayCalculator.IsSupported).ToList();
         private static readonly List<CalendarSystem> SupportedCalendars = SupportedIds.Select(CalendarSystem.ForId).ToList();
-#pragma warning restore 0414
 
         [Test]
-        [TestCaseSource("SupportedCalendars")]
+        [TestCaseSource(nameof(SupportedCalendars))]
         public void MaxDate(CalendarSystem calendar)
         {
             // Construct the largest LocalDate we can, and validate that all the properties can be fetched without
@@ -27,7 +25,7 @@ namespace NodaTime.Test
         }
 
         [Test]
-        [TestCaseSource("SupportedCalendars")]
+        [TestCaseSource(nameof(SupportedCalendars))]
         public void MinDate(CalendarSystem calendar)
         {
             // Construct the smallest LocalDate we can, and validate that all the properties can be fetched without

--- a/src/NodaTime.Test/Calendars/EraTest.cs
+++ b/src/NodaTime.Test/Calendars/EraTest.cs
@@ -15,14 +15,12 @@ namespace NodaTime.Test.Calendars
     [TestFixture]
     public class EraTest
     {
-#pragma warning disable 0414 // Used by tests via reflection - do not remove!
         private static readonly IEnumerable<Era> Eras = typeof(Era).GetProperties(BindingFlags.Public | BindingFlags.Static)
                                                                    .Where(property => property.PropertyType == typeof(Era))
                                                                    .Select(property => property.GetValue(null, null))
                                                                    .Cast<Era>();
-#pragma warning restore 0414
 
-        [TestCaseSource("Eras")]
+        [TestCaseSource(nameof(Eras))]
         [Test]
         public void ResourcePresence(Era era)
         {

--- a/src/NodaTime.Test/Calendars/HebrewCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/HebrewCalendarSystemTest.cs
@@ -128,7 +128,7 @@ namespace NodaTime.Test.Calendars
         }
 
         [Test]
-        [TestCaseSource("AddAndSubtractMonthCases")]
+        [TestCaseSource(nameof(AddAndSubtractMonthCases))]
         public void AddMonths_MonthsBetween(string startText, int months, string expectedEndText)
         {
             var civil = CalendarSystem.HebrewCivil;
@@ -141,8 +141,8 @@ namespace NodaTime.Test.Calendars
         }
 
         [Test]
-        [TestCaseSource("AddAndSubtractMonthCases")]
-        [TestCaseSource("MonthsBetweenCases")]
+        [TestCaseSource(nameof(AddAndSubtractMonthCases))]
+        [TestCaseSource(nameof(MonthsBetweenCases))]
         public void MonthsBetween(string startText, int expectedMonths, string endText)
         {
             var civil = CalendarSystem.HebrewCivil;
@@ -212,7 +212,6 @@ namespace NodaTime.Test.Calendars
             }
         }
 
-#pragma warning disable 0414 // Used by tests via reflection - do not remove!
         // Cases used for adding months and differences between months.
         // 5501 is not a leap year; 5502 is; 5503 is not; 5505 is.
         // Heshvan (civil 2) is long in 5507 and 5509; it is short in 5506 and 5508
@@ -248,6 +247,5 @@ namespace NodaTime.Test.Calendars
             new object[] {"5502-02-13", 0, "5502-01-15"},
             new object[] {"5502-02-13", -1, "5502-01-05"},
         };
-#pragma warning restore 0414
     }
 }

--- a/src/NodaTime.Test/Calendars/UmAlQuraYearMonthDayCalculatorTest.cs
+++ b/src/NodaTime.Test/Calendars/UmAlQuraYearMonthDayCalculatorTest.cs
@@ -16,11 +16,9 @@ namespace NodaTime.Test.Calendars
 
         private static readonly UmAlQuraYearMonthDayCalculator Calculator = UmAlQuraYearMonthDayCalculator.IsSupported ? new UmAlQuraYearMonthDayCalculator() : null;
 
-#pragma warning disable 0414 // Used by tests via reflection - do not remove!
         // Horrible way to conditionalize tests at execution time...
         private static readonly IEnumerable<string> Supported =
             UmAlQuraYearMonthDayCalculator.IsSupported ? new[] { "(Supported)" } : new string[0];
-#pragma warning restore 0414
 
         private static Calendar GetBclCalendar()
         {
@@ -61,7 +59,7 @@ namespace NodaTime.Test.Calendars
             }
         }
 
-        [Test, TestCaseSource("Supported")]
+        [Test, TestCaseSource(nameof(Supported))]
         public void GetDaysInYear(string ignored)
         {
             for (int year = Calculator.MinYear; year <= Calculator.MaxYear; year++)
@@ -70,7 +68,7 @@ namespace NodaTime.Test.Calendars
             }
         }
 
-        [Test, TestCaseSource("Supported")]
+        [Test, TestCaseSource(nameof(Supported))]
         public void IsLeapYear(string ignored)
         {
             for (int year = Calculator.MinYear; year <= Calculator.MaxYear; year++)
@@ -79,7 +77,7 @@ namespace NodaTime.Test.Calendars
             }
         }
 
-        [Test, TestCaseSource("Supported")]
+        [Test, TestCaseSource(nameof(Supported))]
         public void GetStartOfYearInDays(string ignored)
         {
             // This exercises CalculateStartOfYearInDays too.
@@ -91,7 +89,7 @@ namespace NodaTime.Test.Calendars
             }
         }
 
-        [Test, TestCaseSource("Supported")]
+        [Test, TestCaseSource(nameof(Supported))]
         public void GetYearMonthDay_DaysSinceEpoch(string ignored)
         {
             int daysSinceEpoch = Calculator.GetStartOfYearInDays(Calculator.MinYear);
@@ -110,7 +108,7 @@ namespace NodaTime.Test.Calendars
             }
         }
 
-        [Test, TestCaseSource("Supported")]
+        [Test, TestCaseSource(nameof(Supported))]
         public void GetYearMonthDay_YearAndDayOfYear(string ignored)
         {
             for (int year = Calculator.MinYear; year <= Calculator.MaxYear; year++)
@@ -129,7 +127,7 @@ namespace NodaTime.Test.Calendars
             }
         }
 
-        [Test, TestCaseSource("Supported")]
+        [Test, TestCaseSource(nameof(Supported))]
         public void GetDaysFromStartOfYearToStartOfMonth(string ignored)
         {
             for (int year = Calculator.MinYear; year <= Calculator.MaxYear; year++)

--- a/src/NodaTime.Test/Globalization/NodaFormatInfoTest.cs
+++ b/src/NodaTime.Test/Globalization/NodaFormatInfoTest.cs
@@ -32,7 +32,7 @@ namespace NodaTime.Test.Globalization
         // Just check we can actually build a NodaFormatInfo for every culture, outside
         // text-specific tests.
         [Test]
-        [TestCaseSource(typeof(Cultures), "AllCultures")]
+        [TestCaseSource(typeof(Cultures), nameof(Cultures.AllCultures))]
         public void ConvertCulture(CultureInfo culture)
         {
             NodaFormatInfo.GetFormatInfo(culture);

--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -25,9 +25,7 @@ namespace NodaTime.Test
 
         private const PeriodUnits HoursMinutesPeriodType = PeriodUnits.Hours | PeriodUnits.Minutes;
 
-#pragma warning disable 0414 // Used by tests via reflection - do not remove!
         private static readonly PeriodUnits[] AllPeriodUnits = (PeriodUnits[])Enum.GetValues(typeof(PeriodUnits));
-#pragma warning restore 0414
 
         [Test]
         public void BetweenLocalDateTimes_WithoutSpecifyingUnits_OmitsWeeks()
@@ -782,7 +780,7 @@ namespace NodaTime.Test
         }
 
         [Test]
-        [TestCaseSource("AllPeriodUnits")]
+        [TestCaseSource(nameof(AllPeriodUnits))]
         public void Between_ExtremeValues(PeriodUnits units)
         {
             // We can't use None, and Ticks/Nanoseconds will *correctly* overflow.

--- a/src/NodaTime.Test/Text/Cultures.cs
+++ b/src/NodaTime.Test/Text/Cultures.cs
@@ -15,7 +15,6 @@ namespace NodaTime.Test.Text
     /// </summary>
     internal static class Cultures
     {
-#pragma warning disable 0414 // Used by tests via reflection - do not remove!
         // Force the cultures to be read-only for tests, to take advantage of caching. Our Continuous Integration system
         // is very slow at reading resources (in the NodaFormatInfo constructor).
         // Note: R# suggests using a method group conversion for the Select call here, which is fine with the C# 4 compiler,
@@ -30,7 +29,6 @@ namespace NodaTime.Test.Text
         // Pretend we have no cultures, for the sake of these tests.
         // TODO: Make the tests pass instead?
         internal static readonly IEnumerable<CultureInfo> AllCulturesOrEmptyOnMono = TestHelper.IsRunningOnMono ? new CultureInfo[0] : Cultures.AllCultures;
-#pragma warning restore 0414
 
         internal static readonly CultureInfo Invariant = CultureInfo.InvariantCulture;
         internal static readonly CultureInfo EnUs = CultureInfo.ReadOnly(new CultureInfo("en-US"));

--- a/src/NodaTime.Test/Text/LocalDatePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalDatePatternTest.cs
@@ -193,7 +193,7 @@ namespace NodaTime.Test.Text
         internal static IEnumerable<Data> FormatData = FormatOnlyData.Concat(FormatAndParseData);
         
         [Test]
-        [TestCaseSource(typeof(Cultures), "AllCultures")]
+        [TestCaseSource(typeof(Cultures), nameof(Cultures.AllCultures))]
         public void BclLongDatePatternGivesSameResultsInNoda(CultureInfo culture)
         {
             // See https://bugzilla.xamarin.com/show_bug.cgi?id=11363
@@ -205,7 +205,7 @@ namespace NodaTime.Test.Text
         }
 
         [Test]
-        [TestCaseSource(typeof(Cultures), "AllCultures")]
+        [TestCaseSource(typeof(Cultures), nameof(Cultures.AllCultures))]
         public void BclShortDatePatternGivesSameResultsInNoda(CultureInfo culture)
         {
             AssertBclNodaEquality(culture, culture.DateTimeFormat.ShortDatePattern);

--- a/src/NodaTime.Test/Text/LocalTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalTimePatternTest.cs
@@ -303,28 +303,28 @@ namespace NodaTime.Test.Text
 
         // Fails on Mono: https://github.com/nodatime/nodatime/issues/98
         [Test]
-        [TestCaseSource(typeof(Cultures), "AllCulturesOrEmptyOnMono")]
+        [TestCaseSource(typeof(Cultures), nameof(Cultures.AllCulturesOrEmptyOnMono))]
         public void BclLongTimePatternIsValidNodaPattern(CultureInfo culture)
         {
             AssertValidNodaPattern(culture, culture.DateTimeFormat.LongTimePattern);
         }
 
         [Test]
-        [TestCaseSource(typeof(Cultures), "AllCultures")]
+        [TestCaseSource(typeof(Cultures), nameof(Cultures.AllCultures))]
         public void BclShortTimePatternIsValidNodaPattern(CultureInfo culture)
         {
             AssertValidNodaPattern(culture, culture.DateTimeFormat.ShortTimePattern);
         }
 
         [Test]
-        [TestCaseSource(typeof(Cultures), "AllCultures")]
+        [TestCaseSource(typeof(Cultures), nameof(Cultures.AllCultures))]
         public void BclLongTimePatternGivesSameResultsInNoda(CultureInfo culture)
         {
             AssertBclNodaEquality(culture, culture.DateTimeFormat.LongTimePattern);
         }
 
         [Test]
-        [TestCaseSource(typeof(Cultures), "AllCultures")]
+        [TestCaseSource(typeof(Cultures), nameof(Cultures.AllCultures))]
         public void BclShortTimePatternGivesSameResultsInNoda(CultureInfo culture)
         {
             AssertBclNodaEquality(culture, culture.DateTimeFormat.ShortTimePattern);

--- a/src/NodaTime.Test/Text/OffsetPatternTest.cs
+++ b/src/NodaTime.Test/Text/OffsetPatternTest.cs
@@ -208,14 +208,14 @@ namespace NodaTime.Test.Text
         internal static IEnumerable<Data> FormatData = FormatOnlyData.Concat(FormatAndParseData);
 
         [Test]
-        [TestCaseSource("ParseData")]
+        [TestCaseSource(nameof(ParseData))]
         public void ParsePartial(PatternTestData<Offset> data)
         {
             data.TestParsePartial();
         }
 
         [Test]
-        [TestCaseSource("FormatData")]
+        [TestCaseSource(nameof(FormatData))]
         public void AppendFormat(PatternTestData<Offset> data)
         {
             data.TestAppendFormat();

--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.cs
@@ -15,15 +15,13 @@ namespace NodaTime.Test.TimeZones
     [TestFixture]
     public class BclDateTimeZoneTest
     {
-#pragma warning disable 0414 // Used by tests via reflection - do not remove!
         // This test is effectively disabled on Mono as its time zone support is broken in the current
         // stable release - see https://github.com/nodatime/nodatime/issues/97
         private static readonly ReadOnlyCollection<TimeZoneInfo> BclZonesOrEmptyOnMono = TestHelper.IsRunningOnMono
             ? new List<TimeZoneInfo>().AsReadOnly() : TimeZoneInfo.GetSystemTimeZones();
-#pragma warning restore 0414
 
         [Test]
-        [TestCaseSource("BclZonesOrEmptyOnMono")]
+        [TestCaseSource(nameof(BclZonesOrEmptyOnMono))]
         public void AllZoneTransitions(TimeZoneInfo windowsZone)
         {
             var nodaZone = BclDateTimeZone.FromTimeZoneInfo(windowsZone);
@@ -48,7 +46,7 @@ namespace NodaTime.Test.TimeZones
         /// slow test, mostly because TimeZoneInfo is slow.
         /// </summary>
         [Test]
-        [TestCaseSource("BclZonesOrEmptyOnMono")]
+        [TestCaseSource(nameof(BclZonesOrEmptyOnMono))]
         public void AllZonesEveryWeek(TimeZoneInfo windowsZone)
         {
             ValidateZoneEveryWeek(windowsZone);
@@ -71,7 +69,7 @@ namespace NodaTime.Test.TimeZones
         }
 
         [Test]
-        [TestCaseSource("BclZonesOrEmptyOnMono")]
+        [TestCaseSource(nameof(BclZonesOrEmptyOnMono))]
         public void AllZonesStartAndEndOfTime(TimeZoneInfo windowsZone)
         {
             var nodaZone = BclDateTimeZone.FromTimeZoneInfo(windowsZone);

--- a/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
@@ -15,9 +15,7 @@ namespace NodaTime.Test.TimeZones
     [TestFixture]
     public class TzdbDateTimeZoneSourceTest
     {
-#pragma warning disable 0414 // Used by tests via reflection - do not remove!
         private static readonly List<TimeZoneInfo> SystemTimeZones = TimeZoneInfo.GetSystemTimeZones().ToList();
-#pragma warning restore 0414
 
         [Test]
         [TestCase("UTC", "Etc/GMT")]

--- a/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneTest.cs
@@ -14,9 +14,7 @@ namespace NodaTime.Test.TimeZones
     [TestFixture]
     public class TzdbDateTimeZoneTest
     {
-#pragma warning disable 0414 // Used by tests via reflection - do not remove!
         private static readonly IEnumerable<DateTimeZone> AllTzdbZones = DateTimeZoneProviders.Tzdb.GetAllZones();
-#pragma warning restore 0414
 
         [Test]
         [TestCaseSource(nameof(AllTzdbZones))]


### PR DESCRIPTION
Aside from generally being nicer, it means we can get rid of a bunch of #pragma warning disable directives.