### PR TITLE
Implement LocalDate.InZone.

### DIFF
--- a/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
+++ b/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
@@ -57,6 +57,7 @@ namespace NodaTime.Test
                 TransitionBackwardToMidnightZone);
             var actual = TransitionBackwardToMidnightZone.AtStartOfDay(TransitionDate);
             Assert.AreEqual(expected, actual);
+            Assert.AreEqual(expected, TransitionDate.AtStartOfDayInZone(TransitionBackwardToMidnightZone));
         }
 
         [Test]
@@ -67,6 +68,7 @@ namespace NodaTime.Test
                 TransitionBackwardAfterMidnightZone);
             var actual = TransitionBackwardAfterMidnightZone.AtStartOfDay(TransitionDate);
             Assert.AreEqual(expected, actual);
+            Assert.AreEqual(expected, TransitionDate.AtStartOfDayInZone(TransitionBackwardAfterMidnightZone));
         }
 
         [Test]
@@ -77,6 +79,7 @@ namespace NodaTime.Test
                 TransitionForwardAtMidnightZone);
             var actual = TransitionForwardAtMidnightZone.AtStartOfDay(TransitionDate);
             Assert.AreEqual(expected, actual);
+            Assert.AreEqual(expected, TransitionDate.AtStartOfDayInZone(TransitionForwardAtMidnightZone));
         }
 
         [Test]
@@ -87,6 +90,7 @@ namespace NodaTime.Test
                 TransitionForwardBeforeMidnightZone);
             var actual = TransitionForwardBeforeMidnightZone.AtStartOfDay(TransitionDate);
             Assert.AreEqual(expected, actual);
+            Assert.AreEqual(expected, TransitionDate.AtStartOfDayInZone(TransitionForwardBeforeMidnightZone));
         }
 
         [Test]
@@ -97,6 +101,7 @@ namespace NodaTime.Test
                 TransitionForwardAtMidnightZone);
             var actual = TransitionForwardAtMidnightZone.AtStartOfDay(new LocalDate(2000, 3, 1));
             Assert.AreEqual(expected, actual);
+            Assert.AreEqual(expected, new LocalDate(2000, 3, 1).AtStartOfDayInZone(TransitionForwardAtMidnightZone));
         }
 
         private static void AssertImpossible(LocalDateTime localTime, DateTimeZone zone)

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -581,6 +581,24 @@ namespace NodaTime
         public bool Equals(LocalDate other) => this == other;
 
         /// <summary>
+        /// Resolves this local date into a <see cref="ZonedDateTime"/> in the given time zone representing the
+        /// start of this date in the given zone.
+        /// </summary>
+        /// <remarks>
+        /// This is a convenience method for calling <see cref="DateTimeZone.AtStartOfDay(LocalDate)"/>.
+        /// </remarks>
+        /// <param name="zone">The time zone to map this local date into</param>
+        /// <exception cref="SkippedTimeException">The entire day was skipped due to a very large time zone transition.
+        /// (This is extremely rare.)</exception>
+        /// <returns>The <see cref="ZonedDateTime"/> representing the earliest time on this date, in the given time zone.</returns>
+        [Pure]
+        public ZonedDateTime AtStartOfDayInZone([NotNull] DateTimeZone zone)
+        {
+            Preconditions.CheckNotNull(zone, nameof(zone));
+            return zone.AtStartOfDay(this);
+        }
+        
+        /// <summary>
         /// Creates a new LocalDate representing the same physical date, but in a different calendar.
         /// The returned LocalDate is likely to have different field values to this one.
         /// For example, January 1st 1970 in the Gregorian calendar was December 19th 1969 in the Julian calendar.


### PR DESCRIPTION
This is a convenience method to call DateTimeZone.AtStartOfDay.

This fixes issue #399.

(I'd be open to other naming suggestions, btw.)

// cc @malcolmr 