### PR TITLE
Handle completely empty fractional seconds with "F" format specifier.

### DIFF
--- a/src/NodaTime.Test/Text/LocalTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalTimePatternTest.cs
@@ -49,13 +49,18 @@ namespace NodaTime.Test.Text
         internal static Data[] ParseFailureData = {
             new Data { Text = "17 6", Pattern = "HH h", Message = Messages.Parse_InconsistentValues2, Parameters = {'H', 'h', typeof(LocalTime).FullName}},
             new Data { Text = "17 AM", Pattern = "HH tt", Message = Messages.Parse_InconsistentValues2, Parameters = {'H', 't', typeof(LocalTime).FullName}},
+            new Data { Text = "04.", Pattern = "ss.FF", Message = Messages.Parse_MismatchedNumber, Parameters = { "FF" } },
+            new Data { Text = "04.", Pattern = "ss.ff", Message = Messages.Parse_MismatchedNumber, Parameters = { "ff" } },
         };
 
         internal static Data[] ParseOnlyData = {
             new Data(0, 0, 0, 400) { Text = "4", Pattern = "%f", },
             new Data(0, 0, 0, 400) { Text = "4", Pattern = "%F", },
             new Data(0, 0, 0, 400) { Text = "4", Pattern = "FF", },
+            new Data(0, 0, 0, 400) { Text = "40", Pattern = "FF", },
             new Data(0, 0, 0, 400) { Text = "4", Pattern = "FFF", },
+            new Data(0, 0, 0, 400) { Text = "40", Pattern = "FFF" },
+            new Data(0, 0, 0, 400) { Text = "400", Pattern = "FFF" },
             new Data(0, 0, 0, 400) { Text = "40", Pattern = "ff", },
             new Data(0, 0, 0, 400) { Text = "400", Pattern = "fff", },
             new Data(0, 0, 0, 400) { Text = "4000", Pattern = "ffff", },
@@ -93,6 +98,12 @@ namespace NodaTime.Test.Text
             // Parsing using the semi-colon "comma dot" specifier
             new Data(16, 05, 20, 352) { Pattern = "HH:mm:ss;fff", Text = "16:05:20,352" },
             new Data(16, 05, 20, 352) { Pattern = "HH:mm:ss;FFF", Text = "16:05:20,352" },
+
+            // Empty fractional section
+            new Data(0,0,4,0) { Text = "04", Pattern = "ssFF" },
+            new Data(0,0,4,0) { Text = "040", Pattern = "ssFF" },
+            new Data(0,0,4,0) { Text = "040", Pattern = "ssFFF" },
+            new Data(0,0,4,0) { Text = "04", Pattern = "ss.FF"},
         };
 
         internal static Data[] FormatOnlyData = {
@@ -120,7 +131,7 @@ namespace NodaTime.Test.Text
             new Data(1, 1, 1, 456) { Text = "45", Pattern = "FF" },
             new Data(1, 1, 1, 456) { Text = "456", Pattern = "fff" },
             new Data(1, 1, 1, 456) { Text = "456", Pattern = "FFF" },
-
+            new Data(0,0,0,0) {Text = "", Pattern = "FF" },
 
             new Data(5, 6, 7, 8) { Culture = Cultures.EnUs, Text = "0", Pattern = "%f" },
             new Data(5, 6, 7, 8) { Culture = Cultures.EnUs, Text = "00", Pattern = "ff" },

--- a/src/NodaTime.Test/Text/ValueCursorTest.cs
+++ b/src/NodaTime.Test/Text/ValueCursorTest.cs
@@ -271,7 +271,7 @@ namespace NodaTime.Test.Text
             var value = new ValueCursor("\u0660\u0661");
             Assert.True(value.MoveNext());
             int actual;
-            Assert.False(value.ParseFraction(2, 2, out actual, true));
+            Assert.False(value.ParseFraction(2, 2, out actual, 2));
         }
 
         [Test]

--- a/src/NodaTime/Text/Patterns/TimePatternHelper.cs
+++ b/src/NodaTime/Text/Patterns/TimePatternHelper.cs
@@ -45,8 +45,8 @@ namespace NodaTime.Text.Patterns
 
                         // If there *was* a decimal separator, we should definitely have a number.
                         int fractionalSeconds;
-                        // Last argument is false because we don't need *all* the digits to be present
-                        if (!valueCursor.ParseFraction(count, maxCount, out fractionalSeconds, false))
+                        // Last argument is 1 because we need at least one digit after the decimal separator
+                        if (!valueCursor.ParseFraction(count, maxCount, out fractionalSeconds, 1))
                         {
                             return ParseResult<TResult>.MismatchedNumber(valueCursor, new string('F', count));
                         }
@@ -97,8 +97,8 @@ namespace NodaTime.Text.Patterns
 
                         // If there *was* a decimal separator, we should definitely have a number.
                         int fractionalSeconds;
-                        // Last argument is false because we don't need *all* the digits to be present
-                        if (!valueCursor.ParseFraction(count, maxCount, out fractionalSeconds, false))
+                        // Last argument is 1 because we need at least one digit to be present after a decimal separator
+                        if (!valueCursor.ParseFraction(count, maxCount, out fractionalSeconds, 1))
                         {
                             return ParseResult<TResult>.MismatchedNumber(valueCursor, new string('F', count));
                         }
@@ -137,7 +137,7 @@ namespace NodaTime.Text.Patterns
                     int fractionalSeconds;
                     // If the pattern is 'f', we need exactly "count" digits. Otherwise ('F') we need
                     // "up to count" digits.
-                    if (!str.ParseFraction(count, maxCount, out fractionalSeconds, patternCharacter == 'f'))
+                    if (!str.ParseFraction(count, maxCount, out fractionalSeconds, patternCharacter == 'f' ? count : 0))
                     {
                         return ParseResult<TResult>.MismatchedNumber(str, new string(patternCharacter, count));
                     }

--- a/src/NodaTime/Text/PeriodPattern.cs
+++ b/src/NodaTime/Text/PeriodPattern.cs
@@ -299,7 +299,7 @@ namespace NodaTime.Text
                         }
                         int totalNanoseconds;
                         // Can cope with at most 999999999 nanoseconds
-                        if (!valueCursor.ParseFraction(9, 9, out totalNanoseconds, false))
+                        if (!valueCursor.ParseFraction(9, 9, out totalNanoseconds, 1))
                         {
                             return ParseResult<Period>.MissingNumber(valueCursor);
                         }

--- a/src/NodaTime/Text/ValueCursor.cs
+++ b/src/NodaTime/Text/ValueCursor.cs
@@ -291,7 +291,7 @@ namespace NodaTime.Text
         /// <param name="allRequired">If true, <paramref name="maximumDigits"/> digits must be present in the
         /// input sequence. If false, there must be just at least one digit.</param>
         /// <returns><c>true</c> if the digits were parsed.</returns>
-        internal bool ParseFraction(int maximumDigits, int scale, out int result, bool allRequired)
+        internal bool ParseFraction(int maximumDigits, int scale, out int result, int minimumDigits)
         {
             unchecked
             {
@@ -302,16 +302,13 @@ namespace NodaTime.Text
 
                 result = 0;
                 int localIndex = Index;
-                int maxIndex = localIndex + maximumDigits;
-                if (maxIndex > Length)
+                int minIndex = localIndex + minimumDigits;
+                if (minIndex > Length)
                 {
                     // If we don't have all the digits we're meant to have, we can't possibly succeed.
-                    if (allRequired)
-                    {
-                        return false;
-                    }
-                    maxIndex = Length;
+                    return false;
                 }
+                int maxIndex = Math.Min(localIndex + maximumDigits, Length);
                 for (; localIndex < maxIndex; localIndex++)
                 {
                     // Optimized digit handling: rather than checking for the range, returning -1
@@ -324,19 +321,14 @@ namespace NodaTime.Text
                     result = result * 10 + digit;
                 }
                 int count = localIndex - Index;
-                // Couldn't parse any digits?
-                if (count == 0)
+                // Couldn't parse the minimum number of digits required?
+                if (count  < minimumDigits)
                 {
                     return false;
                 }
                 result = (int) (result * Math.Pow(10.0, scale - count));
-                bool ret = !allRequired || localIndex == maxIndex;
-                // Only move the cursor on success.
-                if (ret)
-                {
-                    Move(localIndex);
-                }
-                return ret;
+                Move(localIndex);
+                return true;
             }
         }
 


### PR DESCRIPTION
I would have expected the LocalTime pattern "HHmmssFF" to handle either of these two cases:
(1) "11223344" -> 11:22:33.44
(2) "112233" -> 11:22:33.00

Case 1 works, but case 2 does not.

Some similar cases do work:
"1122334" / "HHmmssFF" -> 11:22:33.4
"112233" / "HHmmss.FF" -> 11:22:33.0

The fix turns out to be pretty easy, as you can see by the diff. The nature of the change (removing an explicit error condition check) made me think that this would cause problems, but all the unit tests still pass, and I haven't been able to think of any cases where I would actually want the old behavior.

If somebody else can think of some cases where the check actually gives good behavior, we should at a minimum add some tests to demonstrate it. If not, you can merge in my change!