### PR TITLE
Added functions to convert Instant to and from Julian Day Numbers

### DIFF
--- a/src/NodaTime.Test/InstantTest.cs
+++ b/src/NodaTime.Test/InstantTest.cs
@@ -17,6 +17,22 @@ namespace NodaTime.Test
         private static readonly Instant negativeFiftyMillion = Instant.FromUntrustedDuration(Duration.FromNanoseconds(-50000000L));
 
         [Test]
+        public void FromJDN()
+        {
+            Instant viaJDN = Instant.FromJulianDayNumber(2436116.31);
+            Instant expected = Instant.FromUtc(1957, 10, 4, 19, 26, 24);
+            Assert.AreEqual(viaJDN, expected);
+        }
+
+        [Test]
+        public void ToJDN()
+        {
+            Instant toJDN = new NodaTime.LocalDateTime(333, 1, 27, 12, 0, CalendarSystem.Julian).InUtc().ToInstant();
+            double expected = 1842713.0;
+            Assert.AreEqual(expected, toJDN.ToJulianDayNumber());
+        }
+
+        [Test]
         public void FromUtcNoSeconds()
         {
             Instant viaUtc = DateTimeZone.Utc.AtStrictly(new LocalDateTime(2008, 4, 3, 10, 35, 0)).ToInstant();

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -502,6 +502,13 @@ namespace NodaTime
         #endregion
 
         /// <summary>
+        /// Constructs a <see cref="double"/> representing the same instant of time as this value.
+        /// </summary>
+        /// <returns>Returns a <see cref="double"/> containing the number of whole and fractional days since the Julian Epoch (Noon January 1st, 4713 BCE)</returns>
+        [Pure]
+        public double ToJulianDayNumber() => this.duration.TotalSeconds / 86400d + 2440587.5;
+
+        /// <summary>
         /// Constructs a <see cref="DateTime"/> from this Instant which has a <see cref="DateTime.Kind" />
         /// of <see cref="DateTimeKind.Utc"/> and represents the same instant of time as this value.
         /// </summary>
@@ -524,6 +531,13 @@ namespace NodaTime
         /// <param name="dateTimeOffset">Date and time value with an offset.</param>
         public static Instant FromDateTimeOffset(DateTimeOffset dateTimeOffset) =>
             BclEpoch.PlusTicks(dateTimeOffset.Ticks - dateTimeOffset.Offset.Ticks);
+
+        /// <summary>
+        /// Converts a Julian Day Number into a new Instant representing the same instant in time
+        /// </summary>
+        /// <param name="JDN">a <see cref="double"/> containing the number of whole and fractional days since the Julian Epoch (Noon January 1st, 4713 BCE)</param>
+        /// <returns>An <see cref="Instant"/> value representing the same instant in time as the given <see cref="double"/>.</returns>
+        public static Instant FromJulianDayNumber(double JDN) => UnixEpoch.PlusTicks(Convert.ToInt64((JDN - 2440587.5) * 86400) * TicksPerSecond);
 
         /// <summary>
         /// Converts a <see cref="DateTime"/> into a new Instant representing the same instant in time.


### PR DESCRIPTION
Julian Day Numbers are widely used in Astronomical calculations. I added two functions to convert the NodaTime.Instant classes back and forth to and from their JDN.