### PR TITLE
Refactor Julian Date arithmetic

### DIFF
--- a/src/NodaTime.Test/InstantTest.cs
+++ b/src/NodaTime.Test/InstantTest.cs
@@ -17,19 +17,20 @@ namespace NodaTime.Test
         private static readonly Instant negativeFiftyMillion = Instant.FromUntrustedDuration(Duration.FromNanoseconds(-50000000L));
 
         [Test]
-        public void FromJDN()
+        // Gregorian calendar: 1957-10-04
+        [TestCase(2436116.31, 1957, 9, 21, 19, 26, 24, Description = "Sample from Astronomical Algorithms 2nd Edition, chapter 7")]
+        // Gregorian calendar: 2013-01-01
+        [TestCase(2456293.520833, 2012, 12, 19, 0, 30, 0, Description = "Sample from Wikipedia")]
+        [TestCase(1842713.0, 333, 1, 27, 12, 0, 0, Description = "Another sample from Astronomical Algorithms 2nd Edition, chapter 7")]
+        [TestCase(0.0, -4712, 1, 1, 12, 0, 0, Description = "Julian epoch")]
+        public void JulianDateConversions(double julianDate, int year, int month, int day, int hour, int minute, int second)
         {
-            Instant viaJDN = Instant.FromJulianDayNumber(2436116.31);
-            Instant expected = Instant.FromUtc(1957, 10, 4, 19, 26, 24);
-            Assert.AreEqual(viaJDN, expected);
-        }
-
-        [Test]
-        public void ToJDN()
-        {
-            Instant toJDN = new NodaTime.LocalDateTime(333, 1, 27, 12, 0, CalendarSystem.Julian).InUtc().ToInstant();
-            double expected = 1842713.0;
-            Assert.AreEqual(expected, toJDN.ToJulianDayNumber());
+            // When dealing with floating point binary data, if we're accurate to 50 milliseconds, that's fine...
+            // (0.000001 days = ~86ms, as a guide to the scale involved...)
+            Instant actual = Instant.FromJulianDate(julianDate);
+            Instant expected = new LocalDateTime(year, month, day, hour, minute, second, CalendarSystem.Julian).InUtc().ToInstant();
+            Assert.AreEqual(expected.ToUnixTimeMilliseconds(), actual.ToUnixTimeMilliseconds(), 50, "Expected {0}, was {1}", expected, actual);
+            Assert.AreEqual(julianDate, expected.ToJulianDate(), 0.000001);
         }
 
         [Test]

--- a/src/NodaTime.Test/NodaConstantsTest.cs
+++ b/src/NodaTime.Test/NodaConstantsTest.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2015 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NUnit.Framework;
+
+namespace NodaTime.Test
+{
+    [TestFixture]
+    public class NodaConstantsTest
+    {
+        [Test]
+        public void JulianEpoch()
+        {
+            // Compute the Julian epoch using the Julian calendar, instead of the
+            // Gregorian version.
+            var localEpoch = new LocalDateTime(-4712, 1, 1, 12, 0, CalendarSystem.Julian);
+            var epoch = localEpoch.InZoneStrictly(DateTimeZone.Utc).ToInstant();
+            Assert.AreEqual(epoch, NodaConstants.JulianEpoch);
+        }
+    }
+}

--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -148,6 +148,7 @@
     </Compile>
     <Compile Include="Calendars\HebrewCalendarSystemTest.cs" />
     <Compile Include="Calendars\PersianCalendarSystemTest.cs" />
+    <Compile Include="NodaConstantsTest.cs" />
     <Compile Include="Utility\TickArithmeticTest.cs" />
     <Compile Include="Calendars\UmAlQuraYearMonthDayCalculatorTest.cs" />
     <Compile Include="Calendars\YearMonthDayCalculatorTest.cs" />

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -502,11 +502,12 @@ namespace NodaTime
         #endregion
 
         /// <summary>
-        /// Constructs a <see cref="double"/> representing the same instant of time as this value.
+        /// Returns the Julian Date of this instance - the number of days since
+        /// <see cref="NodaConstants.JulianEpoch"/> (noon on January 1st, 4713 BCE in the Julian calendar).
         /// </summary>
-        /// <returns>Returns a <see cref="double"/> containing the number of whole and fractional days since the Julian Epoch (Noon January 1st, 4713 BCE)</returns>
+        /// <returns>The number of days (including fractional days) since the Julian Epoch.</returns>
         [Pure]
-        public double ToJulianDayNumber() => this.duration.TotalSeconds / 86400d + 2440587.5;
+        public double ToJulianDate() => (this - JulianEpoch).TotalDays;
 
         /// <summary>
         /// Constructs a <see cref="DateTime"/> from this Instant which has a <see cref="DateTime.Kind" />
@@ -533,11 +534,21 @@ namespace NodaTime
             BclEpoch.PlusTicks(dateTimeOffset.Ticks - dateTimeOffset.Offset.Ticks);
 
         /// <summary>
-        /// Converts a Julian Day Number into a new Instant representing the same instant in time
+        /// Converts a Julian Date representing the given number of days
+        /// since <see cref="NodaConstants.JulianEpoch"/> (noon on January 1st, 4713 BCE in the Julian calendar)
+        /// into an <see cref="Instant"/>.
         /// </summary>
-        /// <param name="JDN">a <see cref="double"/> containing the number of whole and fractional days since the Julian Epoch (Noon January 1st, 4713 BCE)</param>
-        /// <returns>An <see cref="Instant"/> value representing the same instant in time as the given <see cref="double"/>.</returns>
-        public static Instant FromJulianDayNumber(double JDN) => UnixEpoch.PlusTicks(Convert.ToInt64((JDN - 2440587.5) * 86400) * TicksPerSecond);
+        /// <param name="julianDate">The number of days since the Julian Epoch to convert into an <see cref="Instant"/>.</param>
+        /// <returns>An <see cref="Instant"/> value which is <paramref name="julianDate"/> days after the Julian Epoch.</returns>
+        public static Instant FromJulianDate(double julianDate)
+        {
+            // TODO(2.0): Revisit this when we have more duration code that can cope with double.
+            int days = (int) julianDate;
+            double subDay = julianDate - days;
+            long nanoOfDay = (long) (subDay * NanosecondsPerDay);
+            return NodaConstants.JulianEpoch + Duration.FromDays(days) + Duration.FromNanoseconds(nanoOfDay);
+        }
+
 
         /// <summary>
         /// Converts a <see cref="DateTime"/> into a new Instant representing the same instant in time.

--- a/src/NodaTime/NodaConstants.cs
+++ b/src/NodaTime/NodaConstants.cs
@@ -159,12 +159,18 @@ namespace NodaTime
         /// <summary>
         /// The instant at the Unix epoch of midnight 1st January 1970 UTC.
         /// </summary>
-        public static readonly Instant UnixEpoch = Instant.FromUnixTimeTicks(0);
+        public static Instant UnixEpoch { get; } = Instant.FromUnixTimeTicks(0);
 
         /// <summary>
         /// The instant at the BCL epoch of midnight 1st January 0001 UTC.
         /// </summary>
-        public static readonly Instant BclEpoch = Instant.FromUtc(1, 1, 1, 0, 0);
+        public static Instant BclEpoch { get; } = Instant.FromUtc(1, 1, 1, 0, 0);
+
+        /// <summary>
+        /// The instant at the Julian epoch of noon (UTC) January 1st 4713 BCE in the proleptic
+        /// Julian calendar, or November 24th 4714 BCE in the proleptic Gregorian calendar.
+        /// </summary>
+        public static Instant JulianEpoch { get; } = Instant.FromUtc(-4713, 11, 24, 12, 0);
 
         /// <summary>
         /// The number of ticks in a BCL DateTime at the Unix epoch.


### PR DESCRIPTION
This uses Julian Date rather than Julian Day Number as terminology, following
https://en.wikipedia.org/wiki/Julian_day - a Julian Day Number is an integer instead.

Annoying that we don't have a good way of constructing a duration from a double at the moment...