### PR TITLE
Fix LocalInstant.ToString() to use a valid pattern

### DIFF
--- a/src/NodaTime.Test/LocalInstantTest.cs
+++ b/src/NodaTime.Test/LocalInstantTest.cs
@@ -31,5 +31,11 @@ namespace NodaTime.Test
             Assert.AreEqual(sampleInstant, sampleLocalInstant.Minus(Offset.Zero));
             Assert.AreEqual(sampleInstant, sampleLocalInstant.MinusZeroOffset());
         }
+
+        [Test]
+        public void ToString_Expected()
+        {
+            Assert.AreEqual("1970-01-01T00:00:00 LOC", new LocalInstant(0, 0).ToString());
+        }
     }
 }

--- a/src/NodaTime/LocalInstant.cs
+++ b/src/NodaTime/LocalInstant.cs
@@ -207,7 +207,7 @@ namespace NodaTime
         public override string ToString()
         {
             var date = new LocalDate(duration.FloorDays);
-            var pattern = LocalDateTimePattern.CreateWithInvariantCulture("uuuu-MM-ddTHH:mm:ss LOC");
+            var pattern = LocalDateTimePattern.CreateWithInvariantCulture("uuuu-MM-ddTHH:mm:ss 'LOC'");
             var utc = new LocalDateTime(date, LocalTime.FromNanosecondsSinceMidnight(duration.NanosecondOfFloorDay));
             return pattern.Format(utc);
         }


### PR DESCRIPTION
We only see LocalInstant.ToString() when tests fail - but it really helps if it doesn't throw an exception itself at that point...