### PR TITLE
Improve LocalInstant.ToString behaviour

### DIFF
--- a/src/NodaTime.Test/LocalInstantTest.cs
+++ b/src/NodaTime.Test/LocalInstantTest.cs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using NodaTime.Text;
 using NUnit.Framework;
 
 namespace NodaTime.Test
@@ -33,9 +34,21 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void ToString_Expected()
+        [TestCase(0, 0, "1970-01-01T00:00:00 LOC")]
+        [TestCase(0, 1, "1970-01-01T00:00:00.000000001 LOC")]
+        [TestCase(0, 1000, "1970-01-01T00:00:00.000001 LOC")]
+        [TestCase(0, 1000000, "1970-01-01T00:00:00.001 LOC")]
+        [TestCase(-1, NodaConstants.NanosecondsPerDay - 1, "1969-12-31T23:59:59.999999999 LOC")]
+        public void ToString_Valid(int day, long nanoOfDay, string expectedText)
         {
-            Assert.AreEqual("1970-01-01T00:00:00 LOC", new LocalInstant(0, 0).ToString());
+            Assert.AreEqual(expectedText, new LocalInstant(day, nanoOfDay).ToString());
+        }
+
+        [Test]
+        public void ToString_Extremes()
+        {
+            Assert.AreEqual(InstantPatternParser.BeforeMinValueText, LocalInstant.BeforeMinValue.ToString());
+            Assert.AreEqual(InstantPatternParser.AfterMaxValueText, LocalInstant.AfterMaxValue.ToString());
         }
     }
 }

--- a/src/NodaTime/LocalInstant.cs
+++ b/src/NodaTime/LocalInstant.cs
@@ -206,8 +206,16 @@ namespace NodaTime
         /// </returns>
         public override string ToString()
         {
+            if (this == BeforeMinValue)
+            {
+                return InstantPatternParser.BeforeMinValueText;
+            }
+            if (this == AfterMaxValue)
+            {
+                return InstantPatternParser.AfterMaxValueText;
+            }
             var date = new LocalDate(duration.FloorDays);
-            var pattern = LocalDateTimePattern.CreateWithInvariantCulture("uuuu-MM-ddTHH:mm:ss 'LOC'");
+            var pattern = LocalDateTimePattern.CreateWithInvariantCulture("uuuu-MM-ddTHH:mm:ss.FFFFFFFFF 'LOC'");
             var utc = new LocalDateTime(date, LocalTime.FromNanosecondsSinceMidnight(duration.NanosecondOfFloorDay));
             return pattern.Format(utc);
         }

--- a/src/NodaTime/Text/InstantPatternParser.cs
+++ b/src/NodaTime/Text/InstantPatternParser.cs
@@ -25,6 +25,8 @@ namespace NodaTime.Text
     internal sealed class InstantPatternParser : IPatternParser<Instant>
     {
         private const string GeneralPatternText = "uuuu'-'MM'-'dd'T'HH':'mm':'ss'Z'";
+        internal const string BeforeMinValueText = "StartOfTime";
+        internal const string AfterMaxValueText = "EndOfTime";
 
         public IPattern<Instant> ParsePattern([NotNull] string patternText, NodaFormatInfo formatInfo)
         {
@@ -63,8 +65,8 @@ namespace NodaTime.Text
                 // We don't need to be able to parse before-min/after-max values, but it's convenient to be
                 // able to format them - mostly for the sake of testing (but also for ZoneInterval).
                 value.IsValid ? pattern.Format(value.InUtc().LocalDateTime)
-                    : value == Instant.BeforeMinValue ? "StartOfTime"
-                    : "EndOfTime";
+                    : value == Instant.BeforeMinValue ? BeforeMinValueText
+                    : AfterMaxValueText;
 
             public StringBuilder AppendFormat(Instant value, [NotNull] StringBuilder builder) =>
                 pattern.AppendFormat(value.InUtc().LocalDateTime, builder);


### PR DESCRIPTION
- Make the value roundtrip by including subsecond information
- Handle BeforeMinValue/AfterMaxValue