### PR TITLE
Added CalendarSystem.GetWeeksInWeekYear

### DIFF
--- a/src/NodaTime.Test/CalendarSystemTest.Validation.cs
+++ b/src/NodaTime.Test/CalendarSystemTest.Validation.cs
@@ -115,5 +115,22 @@ namespace NodaTime.Test
         {
             TestHelper.AssertInvalid(Iso.GetMaxYearOfEra, Era.AnnoPersico);
         }
+
+        [Test]
+        [TestCase(2009, 53)]
+        [TestCase(2010, 52)]
+        [TestCase(2011, 52)]
+        [TestCase(2012, 52)]
+        [TestCase(2013, 52)]
+        [TestCase(2014, 52)]
+        [TestCase(2015, 53)]
+        [TestCase(2016, 52)]
+        [TestCase(2017, 52)]
+        [TestCase(2018, 52)]
+        [TestCase(2019, 52)]
+        public void GetWeeksInWeekYear(int weekYear, int expectedResult)
+        {
+            Assert.AreEqual(expectedResult, CalendarSystem.Iso.GetWeeksInWeekYear(weekYear));
+        }
     }
 }

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -615,7 +615,7 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// The maximum valid month (inclusive) within this calendar in the given year.
+        /// Returns the maximum valid month (inclusive) within this calendar in the given year.
         /// </summary>
         /// <remarks>
         /// It is assumed that in all calendars, every month between 1 and this month
@@ -632,6 +632,21 @@ namespace NodaTime
         {
             Preconditions.CheckArgumentRange(nameof(year), year, MinYear, MaxYear);
             return YearMonthDayCalculator.GetMonthsInYear(year);
+        }
+
+        /// <summary>
+        /// Returns the number of weeks in the given week-year.
+        /// </summary>
+        /// <param name="weekYear">The week-year to determine the number of weeks for.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="weekYear"/> is outside
+        /// the range of this calendar.</exception>
+        /// <returns>The number of weeks in the given week-year.</returns>
+        public int GetWeeksInWeekYear(int weekYear)
+        {
+            // TODO: Is this really valid? It means we can't necessarily round-trip. Maybe be more lenient, but then check the resulting days-since-epoch.
+            Preconditions.CheckArgumentRange(nameof(weekYear), weekYear,
+                YearMonthDayCalculator.MinYear, YearMonthDayCalculator.MaxYear);
+            return weekYearCalculator.GetWeeksInWeekYear(weekYear);
         }
 
         internal void ValidateYearMonthDay(int year, int month, int day)

--- a/src/NodaTime/Calendars/WeekYearCalculator.cs
+++ b/src/NodaTime/Calendars/WeekYearCalculator.cs
@@ -88,7 +88,7 @@ namespace NodaTime.Calendars
             unchecked(daysSinceEpoch >= -3 ? 1 + ((daysSinceEpoch + 3) % 7)
                                            : 7 + ((daysSinceEpoch + 4) % 7));
 
-        private int GetWeeksInWeekYear([Trusted] int weekYear)
+        internal int GetWeeksInWeekYear([Trusted] int weekYear)
         {
             unchecked
             {


### PR DESCRIPTION
This suffers the problem we have elsewhere of not really having a min/max week-year... will file an issue.

This fixes issue #437.