### PR TITLE
Remove uses of NumberFormatInfo and CompareInfo in NodaTimeFormatInfo

### DIFF
--- a/src/NodaTime.Test/Globalization/NodaFormatInfoTest.cs
+++ b/src/NodaTime.Test/Globalization/NodaFormatInfoTest.cs
@@ -73,10 +73,7 @@ namespace NodaTime.Test.Globalization
         {
             var info = new NodaFormatInfo(enUs);
             Assert.AreSame(enUs, info.CultureInfo);
-            Assert.NotNull(info.NumberFormat);
             Assert.NotNull(info.DateTimeFormat);
-            Assert.AreEqual("+", info.PositiveSign);
-            Assert.AreEqual("-", info.NegativeSign);
             Assert.AreEqual(":", info.TimeSeparator);
             Assert.AreEqual("/", info.DateSeparator);
             Assert.IsInstanceOf<string>(info.OffsetPatternLong);
@@ -157,14 +154,6 @@ namespace NodaTime.Test.Globalization
                 var info = NodaFormatInfo.GetInstance(null);
                 Assert.AreEqual(Thread.CurrentThread.CurrentCulture, info.CultureInfo);
             }
-        }
-
-        [Test]
-        public void TestNumberFormat()
-        {
-            var format = NumberFormatInfo.InvariantInfo;
-            var info = new NodaFormatInfo(enUs);
-            Assert.AreNotEqual(format, info.NumberFormat);
         }
 
         [Test]

--- a/src/NodaTime.Test/Text/OffsetPatternTest.cs
+++ b/src/NodaTime.Test/Text/OffsetPatternTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using NodaTime.Properties;
 using NodaTime.Text;
 using NUnit.Framework;
+using System.Globalization;
 
 namespace NodaTime.Test.Text
 {
@@ -219,6 +220,18 @@ namespace NodaTime.Test.Text
         public void AppendFormat(PatternTestData<Offset> data)
         {
             data.TestAppendFormat();
+        }
+
+        [Test]
+        public void NumberFormatIgnored()
+        {
+            var culture = (CultureInfo) Cultures.EnUs.Clone();
+            culture.NumberFormat.PositiveSign = "P";
+            culture.NumberFormat.NegativeSign = "N";
+            var pattern = OffsetPattern.Create("+HH:mm", culture);
+
+            Assert.AreEqual("+05:00", pattern.Format(Offset.FromHours(5)));
+            Assert.AreEqual("-05:00", pattern.Format(Offset.FromHours(-5)));
         }
 
         /// <summary>

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -252,25 +252,10 @@ namespace NodaTime.Globalization
         public IList<string> ShortDayNames { get { EnsureDaysInitialized(); return shortDayNames; } }
 
         /// <summary>
-        /// Gets the number format associated with this formatting information.
-        /// </summary>
-        public NumberFormatInfo NumberFormat => CultureInfo.NumberFormat;
-
-        /// <summary>
         /// Gets the BCL date time format associated with this formatting information.
         /// </summary>
         public DateTimeFormatInfo DateTimeFormat => CultureInfo.DateTimeFormat;
-
-        /// <summary>
-        ///   Gets the positive sign.
-        /// </summary>
-        public string PositiveSign => NumberFormat.PositiveSign;
-
-        /// <summary>
-        /// Gets the negative sign.
-        /// </summary>
-        public string NegativeSign => NumberFormat.NegativeSign;
-
+        
 #if PCL
         /// <summary>
         /// Gets the time separator.

--- a/src/NodaTime/Text/Patterns/SteppedPatternBuilder.cs
+++ b/src/NodaTime/Text/Patterns/SteppedPatternBuilder.cs
@@ -371,23 +371,21 @@ namespace NodaTime.Text.Patterns
         /// <param name="nonNegativePredicate">Predicate to detect whether the value being formatted is non-negative</param>
         public void AddRequiredSign(Action<TBucket, bool> signSetter, Func<TResult, bool> nonNegativePredicate)
         {
-            string negativeSign = FormatInfo.NegativeSign;
-            string positiveSign = FormatInfo.PositiveSign;
             AddParseAction((str, bucket) =>
             {
-                if (str.Match(negativeSign))
+                if (str.Match("-"))
                 {
                     signSetter(bucket, false);
                     return null;
                 }
-                if (str.Match(positiveSign))
+                if (str.Match("+"))
                 {
                     signSetter(bucket, true);
                     return null;
                 }
                 return ParseResult<TResult>.MissingSign(str);
             });
-            AddFormatAction((value, sb) => sb.Append(nonNegativePredicate(value) ? positiveSign : negativeSign));
+            AddFormatAction((value, sb) => sb.Append(nonNegativePredicate(value) ? "+" : "-"));
         }
 
         /// <summary>
@@ -397,16 +395,14 @@ namespace NodaTime.Text.Patterns
         /// <param name="nonNegativePredicate">Predicate to detect whether the value being formatted is non-negative</param>
         public void AddNegativeOnlySign(Action<TBucket, bool> signSetter, Func<TResult, bool> nonNegativePredicate)
         {
-            string negativeSign = FormatInfo.NegativeSign;
-            string positiveSign = FormatInfo.PositiveSign;
             AddParseAction((str, bucket) =>
             {
-                if (str.Match(negativeSign))
+                if (str.Match("-"))
                 {
                     signSetter(bucket, false);
                     return null;
                 }
-                if (str.Match(positiveSign))
+                if (str.Match("+"))
                 {
                     return ParseResult<TResult>.PositiveSignInvalid(str);
                 }
@@ -417,7 +413,7 @@ namespace NodaTime.Text.Patterns
             {
                 if (!nonNegativePredicate(value))
                 {
-                    builder.Append(negativeSign);
+                    builder.Append("-");
                 }
             });
         }

--- a/www/unstable/userguide/migration-to-2.md
+++ b/www/unstable/userguide/migration-to-2.md
@@ -180,6 +180,13 @@ dates before 1CE should consider using custom format patterns with the `u` speci
 Noda Time's ISO-8601 pattern handling will provide the same text values as before, as the patterns have been
 updated to use `u`. This includes the patterns used in `NodaTime.Serialization.JsonNet`.
 
+Formatting changes
+---
+
+- Text formatting and parsing always uses `+` and `-` now for the positive and negative signs,
+  instead of asking the `NumberFormatInfo` from the culture. (These are the characters used by
+  all standard cultures, so this will only change behavior when using a custom culture.)
+
 Other changes
 ---
 

--- a/www/unstable/userguide/offset-patterns.md
+++ b/www/unstable/userguide/offset-patterns.md
@@ -95,9 +95,10 @@ for general notes on custom patterns, including characters used for escaping and
       <td><code>+</code></td>
       <td>
         The sign of the value, always specified whether positive or negative.
-        The character used will depend on the format provider; <code>+</code> and <code>-</code> are
-        used by the invariant culture. A positive offset is used when local time is ahead of
-		UTC (e.g. Europe) and a negative offset is used when local time is behind UTC (e.g. America).
+        <code>+</code> and <code>-</code> are always used as the symbols, regardless
+        of the culture used when constructing the pattern. A positive offset is used 
+        when local time is ahead of UTC (e.g. Europe) and a negative offset is used
+        when local time is behind UTC (e.g. America).
       </td>
       <td>
         Positive value: <code>+HH:mm</code> => <code>+07:30</code> <br />
@@ -108,8 +109,8 @@ for general notes on custom patterns, including characters used for escaping and
       <td><code>-</code></td>
       <td>
         The sign of the value, only specified when the value is negative.
-        The character used will depend on the format provider; <code>-</code> is
-        used by the invariant culture.
+        <code>+</code> and <code>-</code> are always used as the symbols, regardless
+        of the culture used when constructing the pattern.
       </td>
       <td>
         Positive value: <code>-HH:mm</code> => <code>07:30</code> <br />

--- a/www/unstable/userguide/versions.md
+++ b/www/unstable/userguide/versions.md
@@ -51,6 +51,7 @@ See the [Noda Time 1.x to 2.0 migration guide](migration-to-2.html) for full det
 - The `Instant.Ticks` property has been converted to a method, `Instant.ToUnixTimeTicks()`. (This reflects
   the fact that it would no longer reflect the complete state of the object, and aims to obscure the fact
   that the Unix epoch is the internal epoch in Noda Time.)
+- Text formatting no longer uses the `NumberFormatInfo` from a culture for positive or negative signs
 
 Bug fixes:
 


### PR DESCRIPTION
I'd like to get these two commits in before changing NodaFormatInfo.GetInstance, as the latter change is likely to require more discussion.