### PR TITLE
Convert Duration to use BigInteger instead of decimal

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTimeTests/DurationBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/DurationBenchmarks.cs
@@ -3,6 +3,7 @@
 // as found in the LICENSE.txt file.
 using System;
 using BenchmarkDotNet.Attributes;
+using System.Numerics;
 
 namespace NodaTime.Benchmarks.NodaTimeTests
 {
@@ -59,9 +60,9 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         }
 
         [Benchmark]
-        public Duration FromDecimalNanoseconds()
+        public Duration FromBigIntegerNanoseconds()
         {
-            return Duration.FromNanoseconds(long.MaxValue + 100M);
+            return Duration.FromNanoseconds(long.MaxValue + (BigInteger) 100);
         }
 #endif
 

--- a/src/NodaTime.Test/DurationTest.Construction.cs
+++ b/src/NodaTime.Test/DurationTest.Construction.cs
@@ -4,6 +4,7 @@
 
 using System;
 using NUnit.Framework;
+using System.Numerics;
 
 namespace NodaTime.Test
 {
@@ -27,15 +28,15 @@ namespace NodaTime.Test
         private static void TestFactoryMethod(Func<long, Duration> method, long value, long nanosecondsPerUnit)
         {
             Duration duration = method(value);
-            decimal expectedNanoseconds = (decimal)value * nanosecondsPerUnit;
-            Assert.AreEqual(duration.ToDecimalNanoseconds(), expectedNanoseconds);
+            BigInteger expectedNanoseconds = (BigInteger)value * nanosecondsPerUnit;
+            Assert.AreEqual(duration.ToBigIntegerNanoseconds(), expectedNanoseconds);
         }
 
         private static void TestFactoryMethod(Func<int, Duration> method, int value, long nanosecondsPerUnit)
         {
             Duration duration = method(value);
-            decimal expectedNanoseconds = (decimal)value * nanosecondsPerUnit;
-            Assert.AreEqual(duration.ToDecimalNanoseconds(), expectedNanoseconds);
+            BigInteger expectedNanoseconds = (BigInteger) value * nanosecondsPerUnit;
+            Assert.AreEqual(duration.ToBigIntegerNanoseconds(), expectedNanoseconds);
         }
 
         [Test]
@@ -106,15 +107,15 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void FromNanoSeconds_Decimal()
+        public void FromNanoSeconds_BigInteger()
         {
-            Assert.AreEqual(Duration.OneDay - Duration.Epsilon, Duration.FromNanoseconds(NanosecondsPerDay - 1M));
-            Assert.AreEqual(Duration.OneDay, Duration.FromNanoseconds(NanosecondsPerDay + 0M));
-            Assert.AreEqual(Duration.OneDay + Duration.Epsilon, Duration.FromNanoseconds(NanosecondsPerDay + 1M));
+            Assert.AreEqual(Duration.OneDay - Duration.Epsilon, Duration.FromNanoseconds(NanosecondsPerDay - BigInteger.One));
+            Assert.AreEqual(Duration.OneDay, Duration.FromNanoseconds(NanosecondsPerDay + BigInteger.Zero));
+            Assert.AreEqual(Duration.OneDay + Duration.Epsilon, Duration.FromNanoseconds(NanosecondsPerDay + BigInteger.One));
 
-            Assert.AreEqual(-Duration.OneDay - Duration.Epsilon, Duration.FromNanoseconds(-NanosecondsPerDay - 1M));
-            Assert.AreEqual(-Duration.OneDay, Duration.FromNanoseconds(-NanosecondsPerDay + 0M));
-            Assert.AreEqual(-Duration.OneDay + Duration.Epsilon, Duration.FromNanoseconds(-NanosecondsPerDay + 1M));
+            Assert.AreEqual(-Duration.OneDay - Duration.Epsilon, Duration.FromNanoseconds(-NanosecondsPerDay - BigInteger.One));
+            Assert.AreEqual(-Duration.OneDay, Duration.FromNanoseconds(-NanosecondsPerDay + BigInteger.Zero));
+            Assert.AreEqual(-Duration.OneDay + Duration.Epsilon, Duration.FromNanoseconds(-NanosecondsPerDay + BigInteger.One));
         }
     }
 }

--- a/src/NodaTime.Test/DurationTest.cs
+++ b/src/NodaTime.Test/DurationTest.cs
@@ -5,6 +5,7 @@
 using System;
 using NodaTime.Text;
 using NUnit.Framework;
+using System.Numerics;
 
 namespace NodaTime.Test
 {
@@ -78,16 +79,16 @@ namespace NodaTime.Test
         [TestCase(NodaConstants.NanosecondsPerDay + 1)]
         [TestCase(long.MaxValue - 1)]
         [TestCase(long.MaxValue)]
-        public void DecimalConversions(long int64Nanos)
+        public void BigIntegerConversions(long int64Nanos)
         {
-            decimal decimalNanos = int64Nanos;
-            var nanoseconds = Duration.FromNanoseconds(decimalNanos);
-            Assert.AreEqual(decimalNanos, nanoseconds.ToDecimalNanoseconds());
+            BigInteger bigIntegerNanos = int64Nanos;
+            var nanoseconds = Duration.FromNanoseconds(bigIntegerNanos);
+            Assert.AreEqual(bigIntegerNanos, nanoseconds.ToBigIntegerNanoseconds());
 
             // And multiply it by 100, which proves we still work for values out of the range of Int64
-            decimalNanos *= 100;
-            nanoseconds = Duration.FromNanoseconds(decimalNanos);
-            Assert.AreEqual(decimalNanos, nanoseconds.ToDecimalNanoseconds());
+            bigIntegerNanos *= 100;
+            nanoseconds = Duration.FromNanoseconds(bigIntegerNanos);
+            Assert.AreEqual(bigIntegerNanos, nanoseconds.ToBigIntegerNanoseconds());
         }
 
         [Test]
@@ -107,7 +108,7 @@ namespace NodaTime.Test
         public void FromTicks(long ticks)
         {
             var nanoseconds = Duration.FromTicks(ticks);
-            Assert.AreEqual(ticks * (decimal) NodaConstants.NanosecondsPerTick, nanoseconds.ToDecimalNanoseconds());
+            Assert.AreEqual(ticks * (BigInteger) NodaConstants.NanosecondsPerTick, nanoseconds.ToBigIntegerNanoseconds());
 
             // Just another sanity check, although Ticks is covered in more detail later.
             Assert.AreEqual(ticks, nanoseconds.Ticks);
@@ -128,8 +129,9 @@ namespace NodaTime.Test
             Assert.Throws<ArgumentOutOfRangeException>(() => Duration.FromMilliseconds(long.MinValue));
             Assert.Throws<ArgumentOutOfRangeException>(() => Duration.FromMilliseconds(long.MaxValue));
             // FromTicks never throws.
-            Assert.Throws<ArgumentOutOfRangeException>(() => Duration.FromNanoseconds(decimal.MinValue));
-            Assert.Throws<ArgumentOutOfRangeException>(() => Duration.FromNanoseconds(decimal.MaxValue));
+            // No such concept as BigInteger.Min/MaxValue, so use the values we know to be just outside valid bounds.
+            Assert.Throws<ArgumentOutOfRangeException>(() => Duration.FromNanoseconds(Duration.MaxNanoseconds + 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Duration.FromNanoseconds(Duration.MinNanoseconds - 1));
         }
 
         [Test]
@@ -152,7 +154,7 @@ namespace NodaTime.Test
         public void ConstituentParts_Large()
         {
             // And outside the normal range of long...
-            var nanos = Duration.FromNanoseconds(NodaConstants.NanosecondsPerDay * 365000m + 500m);
+            var nanos = Duration.FromNanoseconds(NodaConstants.NanosecondsPerDay * (BigInteger) 365000 + (BigInteger) 500);
             Assert.AreEqual(365000, nanos.FloorDays);
             Assert.AreEqual(500, nanos.NanosecondOfFloorDay);
         }

--- a/src/NodaTime/project.json
+++ b/src/NodaTime/project.json
@@ -38,7 +38,8 @@
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.Xml": ""
+        "System.Xml": "",
+        "System.Numerics": ""
       }
     },
     "dotnet5.4": {
@@ -47,12 +48,13 @@
       },
       "dependencies": {
         "System.Linq": "4.0.0",
+        "System.Runtime.Numerics": "4.0.1-beta-23516",
         "System.Runtime.Serialization.Xml": "4.0.0",
-        "System.Xml.XmlSerializer": "4.0.0",
-        "System.Xml.XmlDocument": "4.0.0",
-        "System.Xml.ReaderWriter": "4.0.0",
         "System.Threading": "4.0.0",
-        "System.Threading.Thread": "4.0.0-beta-23516"
+        "System.Threading.Thread": "4.0.0-beta-23516",
+        "System.Xml.ReaderWriter": "4.0.0",
+        "System.Xml.XmlDocument": "4.0.0",
+        "System.Xml.XmlSerializer": "4.0.0"
       }
     }
   }


### PR DESCRIPTION
Fixes issue #447.
(Still need to check performance, although relatively few operations will be affected.)