### PR TITLE
Remove traces of code.google.com from 1.3 user guide

### DIFF
--- a/www/_plugins/userguide.rb
+++ b/www/_plugins/userguide.rb
@@ -60,8 +60,8 @@ module Jekyll
         text.gsub!(@@MethodPattern) { |match| translateurl(match, 'M') }
         text.gsub!(@@FieldPattern) { |match| translateurl(match, 'F') }
         text.gsub!(@@PropertyPattern) { |match| translateurl(match, 'P') }
-        text.gsub!(@@IssueUrlPattern, '\1(http://code.google.com/p/noda-time/issues/detail?id=\2)')
-        text.gsub!(@@IssueLinkPattern, '[issue \1](http://code.google.com/p/noda-time/issues/detail?id=\1)')
+        text.gsub!(@@IssueUrlPattern, '\1(https://github.com/nodatime/nodatime/issues/\2)')
+        text.gsub!(@@IssueLinkPattern, '[issue \1](https://github.com/nodatime/nodatime/issues/\1)')
         text
       end
 

--- a/www/index.html
+++ b/www/index.html
@@ -60,9 +60,9 @@ var before = london.AtStrictly(localDate);
 	<div class="row">
 		<div class="large-4 columns">
 			<h3><i class="foundicon-globe"></i> Community</h3>
-			<p>Find out more about Noda Time on our <a href="http://groups.google.com/group/noda-time">group mailing list</a> or our <a href="http://blog.nodatime.org/">blog</a>.</p>
+			<p>Find out more about Noda Time on our <a href="https://groups.google.com/group/noda-time">group mailing list</a> or our <a href="http://blog.nodatime.org/">blog</a>.  You can also <a href="https://gitter.im/nodatime/nodatime">chat with us on Gitter</a>.</p>
 			<p>For more specific "How do I solve problem X?" questions, please ask on Stack Overflow using the <a href="http://stackoverflow.com/questions/tagged/nodatime">nodatime</a> tag.</p>
-            <p>The <a href="https://code.google.com/p/noda-time/issues/list">issue tracker</a> is hosted on the <a href="http://noda-time.googlecode.com">project's Google Code site</a>.
+            <p>The <a href="https://github.com/nodatime/nodatime/issues">issue tracker</a> is hosted on the <a href="https://github.com/nodatime/nodatime">project's GitHub site</a>.
 		</div>
 		<div class="large-4 columns">
 			<h3><i class="foundicon-page"></i> Documentation</h3>
@@ -72,9 +72,8 @@ var before = london.AtStrictly(localDate);
 		</div>
 		<div class="large-4 columns">
 			<h3><i class="foundicon-add-doc"></i> Contributing</h3>
-			<p>Developers interested in contributing to Noda Time itself should also check out the <a href="{{relative}}developer">Developer Guide</a> and <a href="{{relative}}unstable/userguide/roadmap.html">current roadmap</a>.</p>
-            <p>If you just want the code, you can <a href="https://code.google.com/p/noda-time/source/checkout">check it out from the Mercurial repository</a>.
-			<p><a href="http://teamcity.codebetter.com/project.html?projectId=project54">Our continuous build</a> is hosted by <a href="http://jetbrains.com/">JetBrains</a> on <a href="http://codebetter.com/">CodeBetter</a></p>
+			<p>Developers interested in contributing to Noda Time itself should also check out the <a href="{{relative}}developer">Developer Guide</a> and <a href="{{relative}}developer/roadmap.html">current roadmap</a>.</p>
+            <p>If you just want the code, you can <a href="https://github.com/nodatime/nodatime">check it out from the repository</a>.
 		</div>
 	</div>
 	<div class="row">

--- a/www/unstable/userguide/calendars.md
+++ b/www/unstable/userguide/calendars.md
@@ -19,7 +19,7 @@ are currently out of scope for Noda Time.
 
 Noda Time supports the calendars listed below. If you would like us to consider adding support for
 another calendar system, please contact [the mailing list](http://groups.google.com/group/noda-time) or
-[file a bug](https://code.google.com/p/noda-time/issues/list).
+[file a bug](https://github.com/nodatime/nodatime/issues).
 
 ISO
 ===

--- a/www/unstable/userguide/installation.md
+++ b/www/unstable/userguide/installation.md
@@ -77,4 +77,4 @@ already using SymbolSource as one of your symbol servers, you just need to make 
 modules to fetch.)
 
 If you believe you've found a bug in Noda Time, using the SymbolSource version is likely to prove painful after a while - it's
-much better to just fetch the [source code](https://code.google.com/p/noda-time/source/checkout) and build your own copy locally.
+much better to just fetch the [source code](https://github.com/nodatime/nodatime) and build your own copy locally.

--- a/www/unstable/userguide/limitations.md
+++ b/www/unstable/userguide/limitations.md
@@ -8,7 +8,7 @@ weight: 4040
 Noda Time is a work in progress. It has various limitations, some of
 which we'd obviously like to remove over time. Here's a list of some
 aspects we'd like to improve; see the 
-[issues list](http://code.google.com/p/noda-time/issues/list) for
+[issues list](https://github.com/nodatime/nodatime/issues) for
 others.
 
 We also have a [roadmap](roadmap.html) of intended releases. This is

--- a/www/unstable/userguide/mono.md
+++ b/www/unstable/userguide/mono.md
@@ -14,7 +14,7 @@ Noda Time runs on Mono, but with some limitations:
 - Noda Time is not *developed* on Mono, so while releases will be tested
   against it (running all the unit tests), code which isn't part
   of a release may not work. Please raise an issue on the
-  [tracker page](http://code.google.com/p/noda-time/issues/list) if
+  [tracker page](https://github.com/nodatime/nodatime/issues) if
   you come across a breakage like this, and we'll fix it as soon
   as possible.
 - `TimeZoneInfo` in Mono has some critical flaws in the latest stable

--- a/www/unstable/userguide/versions.md
+++ b/www/unstable/userguide/versions.md
@@ -6,7 +6,7 @@ weight: 4060
 ---
 
 User-visible changes from 1.0.0-beta1 onwards. See the
-[project repository](http://code.google.com/p/noda-time/source/list) for more
+[project repository](https://github.com/nodatime/nodatime) for more
 details.
 
 ## 1.3.1, released 2015-03-06 with tzdb 2015a


### PR DESCRIPTION
(We won't be updating the online user guide, but we ship an offline copy.)
These are all I could find easily, but I'll have another look when I build the package.

(Anything else you can think of that I might have forgotten?)