### PR TITLE
Use expression-bodied members in benchmarks

### DIFF
--- a/src/NodaTime.Benchmarks/BclTests/DateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/BclTests/DateTimeBenchmarks.cs
@@ -16,89 +16,47 @@ namespace NodaTime.Benchmarks.BclTests
         private static readonly DateTime Sample = new DateTime(2009, 12, 26, 10, 8, 30, 234, DateTimeKind.Local);
 
         [Benchmark]
-        public DateTime ConstructionToDay()
-        {
-            return new DateTime(2009, 12, 26);
-        }
+        public DateTime ConstructionToDay() => new DateTime(2009, 12, 26);
 
         [Benchmark]
-        public DateTime ConstructionToSecond()
-        {
-            return new DateTime(2009, 12, 26, 10, 8, 30, DateTimeKind.Local);
-        }
+        public DateTime ConstructionToSecond() => new DateTime(2009, 12, 26, 10, 8, 30, DateTimeKind.Local);
 
         [Benchmark]
-        public DateTime ConstructionToMillisecond()
-        {
-            return new DateTime(2009, 12, 26, 10, 8, 30, 234, DateTimeKind.Local);
-        }
+        public DateTime ConstructionToMillisecond() => new DateTime(2009, 12, 26, 10, 8, 30, 234, DateTimeKind.Local);
 
         [Benchmark]
-        public int Year()
-        {
-            return Sample.Year;
-        }
+        public int Year() => Sample.Year;
 
         [Benchmark]
-        public int Month()
-        {
-            return Sample.Month;
-        }
+        public int Month() => Sample.Month;
 
         [Benchmark]
-        public int DayOfMonth()
-        {
-            return Sample.Day;
-        }
+        public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public DayOfWeek DayOfWeek()
-        {
-            return Sample.DayOfWeek;
-        }
+        public DayOfWeek DayOfWeek() => Sample.DayOfWeek;
 
         [Benchmark]
-        public int DayOfYear()
-        {
-            return Sample.DayOfYear;
-        }
+        public int DayOfYear() => Sample.DayOfYear;
 
         [Benchmark]
-        public int Hour()
-        {
-            return Sample.Hour;
-        }
+        public int Hour() => Sample.Hour;
 
         [Benchmark]
-        public int Minute()
-        {
-            return Sample.Minute;
-        }
+        public int Minute() => Sample.Minute;
 
         [Benchmark]
-        public int Second()
-        {
-            return Sample.Second;
-        }
+        public int Second() => Sample.Second;
 
         [Benchmark]
-        public int Millisecond()
-        {
-            return Sample.Millisecond;
-        }
+        public int Millisecond() => Sample.Millisecond;
 
         [Benchmark]
-        public DateTime ToUtc()
-        {
-            return Sample.ToUniversalTime();
-        }
+        public DateTime ToUtc() => Sample.ToUniversalTime();
 
         [Benchmark]
         [Category("Text")]
-        public string Format()
-        {
-            return Sample.ToString("dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture);
-        }
+        public string Format() => Sample.ToString("dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture);
 
         [Benchmark]
         [Category("Text")]

--- a/src/NodaTime.Benchmarks/BclTests/DateTimeOffsetBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/BclTests/DateTimeOffsetBenchmarks.cs
@@ -36,19 +36,12 @@ namespace NodaTime.Benchmarks.BclTests
             defaultComparer.Compare(sample, later);
         }
 
-        [Benchmark]
-        public bool Comparison_Operators()
-        {
 #pragma warning disable 1718
-            return (sample < earlier) | (sample < sample) | (sample < later);
-#pragma warning restore 1718
-        }
+        [Benchmark]
+        public bool Comparison_Operators() => (sample < earlier) | (sample < sample) | (sample < later);
 
         [Benchmark]
         [Category("Text")]
-        public string Format()
-        {
-            return sample.ToString("dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture);
-        }
+        public string Format() => sample.ToString("dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture);
     }
 }

--- a/src/NodaTime.Benchmarks/BclTests/UtcDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/BclTests/UtcDateTimeBenchmarks.cs
@@ -15,69 +15,36 @@ namespace NodaTime.Benchmarks.BclTests
         private readonly DateTime sample = new DateTime(2009, 12, 26, 10, 8, 30, DateTimeKind.Utc);
 
         [Benchmark]
-        public DateTime Construction()
-        {
-            return new DateTime(2009, 12, 26, 10, 8, 30, DateTimeKind.Utc);
-        }
+        public DateTime Construction() => new DateTime(2009, 12, 26, 10, 8, 30, DateTimeKind.Utc);
 
         [Benchmark]
-        public int Year()
-        {
-            return sample.Year;
-        }
+        public int Year() => sample.Year;
 
         [Benchmark]
-        public int Month()
-        {
-            return sample.Month;
-        }
+        public int Month() => sample.Month;
 
         [Benchmark]
-        public int DayOfMonth()
-        {
-            return sample.Day;
-        }
+        public int DayOfMonth() => sample.Day;
 
         [Benchmark]
-        public DayOfWeek DayOfWeek()
-        {
-            return sample.DayOfWeek;
-        }
+        public DayOfWeek DayOfWeek() => sample.DayOfWeek;
 
         [Benchmark]
-        public int DayOfYear()
-        {
-            return sample.DayOfYear;
-        }
+        public int DayOfYear() => sample.DayOfYear;
 
         [Benchmark]
-        public int Hour()
-        {
-            return sample.Hour;
-        }
+        public int Hour() => sample.Hour;
 
         [Benchmark]
-        public int Minute()
-        {
-            return sample.Minute;
-        }
+        public int Minute() => sample.Minute;
 
         [Benchmark]
-        public int Second()
-        {
-            return sample.Second;
-        }
+        public int Second() => sample.Second;
 
         [Benchmark]
-        public int Millisecond()
-        {
-            return sample.Millisecond;
-        }
+        public int Millisecond() => sample.Millisecond;
 
         [Benchmark]
-        public DateTime ToLocalTime()
-        {
-            return sample.ToLocalTime();
-        }
+        public DateTime ToLocalTime() => sample.ToLocalTime();
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/Calendars/HebrewCalendarBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Calendars/HebrewCalendarBenchmarks.cs
@@ -16,16 +16,10 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Calendars
         private static readonly CalendarSystem CivilCalendar = CalendarSystem.GetHebrewCalendar(HebrewMonthNumbering.Civil);
 
         [Benchmark]
-        public LocalDate ScripturalConversion()
-        {
-            return TestLeapCycle(ScripturalCalendar);
-        }
+        public LocalDate ScripturalConversion() => TestLeapCycle(ScripturalCalendar);
 
         [Benchmark]
-        public LocalDate CivilConversion()
-        {
-            return TestLeapCycle(CivilCalendar);
-        }
+        public LocalDate CivilConversion() => TestLeapCycle(CivilCalendar);
 
         /// <summary>
         /// Converts each day in a full leap cycle (for coverage of different scenarios) to the ISO

--- a/src/NodaTime.Benchmarks/NodaTimeTests/DurationBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/DurationBenchmarks.cs
@@ -13,64 +13,38 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         private static readonly TimeSpan SampleTimeSpan = new TimeSpan(1, 2, 3);
 
         [Benchmark]
-        public Duration FromDays()
-        {
+        public Duration FromDays() =>
 #if !V1
-            return Duration.FromDays(100);
+            Duration.FromDays(100);
 #else
-            return Duration.FromStandardDays(100);
+            Duration.FromStandardDays(100);
 #endif
-        }
 
         [Benchmark]
-        public Duration FromHours()
-        {
-            return Duration.FromHours(100);
-        }
+        public Duration FromHours() => Duration.FromHours(100);
 
         [Benchmark]
-        public Duration FromMinutes()
-        {
-            return Duration.FromMinutes(100);
-        }
+        public Duration FromMinutes() => Duration.FromMinutes(100);
 
         [Benchmark]
-        public Duration FromSeconds()
-        {
-            return Duration.FromSeconds(100);
-        }
+        public Duration FromSeconds() => Duration.FromSeconds(100);
 
         [Benchmark]
-        public Duration FromMilliseconds()
-        {
-            return Duration.FromMilliseconds(100);
-        }
+        public Duration FromMilliseconds() => Duration.FromMilliseconds(100);
 
         [Benchmark]
-        public Duration FromTicks()
-        {
-            return Duration.FromTicks(100);
-        }
+        public Duration FromTicks() => Duration.FromTicks(100);
 
 #if !V1
         [Benchmark]
-        public Duration FromInt64Nanoseconds()
-        {
-            return Duration.FromNanoseconds(int.MaxValue + 1L);
-        }
+        public Duration FromInt64Nanoseconds() => Duration.FromNanoseconds(int.MaxValue + 1L);
 
         [Benchmark]
-        public Duration FromBigIntegerNanoseconds()
-        {
-            return Duration.FromNanoseconds(long.MaxValue + (BigInteger) 100);
-        }
+        public Duration FromBigIntegerNanoseconds() => Duration.FromNanoseconds(long.MaxValue + (BigInteger)100);
 #endif
 
         [Benchmark]
-        public Duration FromTimeSpan()
-        {
-            return Duration.FromTimeSpan(SampleTimeSpan);
-        }
+        public Duration FromTimeSpan() => Duration.FromTimeSpan(SampleTimeSpan);
 
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/InstantBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/InstantBenchmarks.cs
@@ -17,47 +17,26 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         private static readonly DateTimeZone London = DateTimeZoneProviders.Tzdb["Europe/London"];
 
         [Benchmark]
-        public string ToStringIso()
-        {
-            return Sample.ToString("g", CultureInfo.InvariantCulture);
-        }
+        public string ToStringIso() => Sample.ToString("g", CultureInfo.InvariantCulture);
 
         [Benchmark]
-        public Instant PlusDuration()
-        {
-            return Sample.Plus(Duration.Epsilon);
-        }
+        public Instant PlusDuration() => Sample.Plus(Duration.Epsilon);
 
         [Benchmark]
-        public ZonedDateTime InUtc()
-        {
-            return Sample.InUtc();
-        }
+        public ZonedDateTime InUtc() => Sample.InUtc();
 
         [Benchmark]
-        public ZonedDateTime InZoneLondon()
-        {
-            return Sample.InZone(London);
-        }
+        public ZonedDateTime InZoneLondon() => Sample.InZone(London);
 
 #if !V1_0 && !V1_1
         [Benchmark]
-        public OffsetDateTime WithOffset_SameUtcDay()
-        {
-            return Sample.WithOffset(SmallOffset);
-        }
+        public OffsetDateTime WithOffset_SameUtcDay() => Sample.WithOffset(SmallOffset);
 
         [Benchmark]
-        public OffsetDateTime WithOffset_NextUtcDay()
-        {
-            return Sample.WithOffset(LargePositiveOffset);
-        }
+        public OffsetDateTime WithOffset_NextUtcDay() => Sample.WithOffset(LargePositiveOffset);
 
         [Benchmark]
-        public OffsetDateTime WithOffset_PreviousUtcDay()
-        {
-            return Sample.WithOffset(LargeNegativeOffset);
-        }
+        public OffsetDateTime WithOffset_PreviousUtcDay() => Sample.WithOffset(LargeNegativeOffset);
 #endif
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateBenchmarks.cs
@@ -32,16 +32,10 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         }
 
         [Benchmark]
-        public LocalDate Construction()
-        {
-            return new LocalDate(2009, 12, 26);
-        }
+        public LocalDate Construction() => new LocalDate(2009, 12, 26);
 
         [Benchmark]
-        public LocalDate ConstructionOutsidePrecomputedRange()
-        {
-            return new LocalDate(1009, 12, 26);
-        }
+        public LocalDate ConstructionOutsidePrecomputedRange() => new LocalDate(1009, 12, 26);
 
         [Benchmark]
         public LocalDate ConstructionAvoidingCache()
@@ -60,10 +54,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         private static readonly int SampleDays = Sample.DaysSinceEpoch;
 
         [Benchmark]
-        public LocalDate ConstructionFromDays_SpecifyCalendar()
-        {
-            return new LocalDate(SampleDays, CalendarSystem.Iso);
-        }
+        public LocalDate ConstructionFromDays_SpecifyCalendar() => new LocalDate(SampleDays, CalendarSystem.Iso);
 
         [Benchmark]
         public void ConstructionFromDays_DefaultCalendar()
@@ -79,117 +70,63 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         }
 
         [Benchmark]
-        public int Year()
-        {
-            return Sample.Year;
-        }
+        public int Year() => Sample.Year;
 
         [Benchmark]
-        public int Month()
-        {
-            return Sample.Month;
-        }
+        public int Month() => Sample.Month;
 
         [Benchmark]
-        public int DayOfMonth()
-        {
-            return Sample.Day;
-        }
+        public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek()
-        {
-            return Sample.IsoDayOfWeek;
-        }
+        public IsoDayOfWeek IsoDayOfWeek() => Sample.IsoDayOfWeek;
 
         [Benchmark]
         public IsoDayOfWeek IsoDayOfWeek_BeforeEpoch()
         {
             return SampleBeforeEpoch.IsoDayOfWeek;
         }
-        
-        [Benchmark]
-        public int DayOfYear()
-        {
-            return Sample.DayOfYear;
-        }
 
         [Benchmark]
-        public int WeekOfWeekYear()
-        {
-            return Sample.WeekOfWeekYear;
-        }
+        public int DayOfYear() => Sample.DayOfYear;
 
         [Benchmark]
-        public int WeekYear()
-        {
-            return Sample.WeekYear;
-        }
+        public int WeekOfWeekYear() => Sample.WeekOfWeekYear;
 
         [Benchmark]
-        public Era Era()
-        {
-            return Sample.Era;
-        }
+        public int WeekYear() => Sample.WeekYear;
 
         [Benchmark]
-        public int YearOfEra()
-        {
-            return Sample.YearOfEra;
-        }
+        public Era Era() => Sample.Era;
 
         [Benchmark]
-        public LocalDate PlusYears()
-        {
-            return Sample.PlusYears(3);
-        }
+        public int YearOfEra() => Sample.YearOfEra;
 
         [Benchmark]
-        public LocalDate PlusMonths()
-        {
-            return Sample.PlusMonths(3);
-        }
+        public LocalDate PlusYears() => Sample.PlusYears(3);
 
         [Benchmark]
-        public LocalDate PlusWeeks()
-        {
-            return Sample.PlusWeeks(3);
-        }
+        public LocalDate PlusMonths() => Sample.PlusMonths(3);
 
         [Benchmark]
-        public LocalDate PlusDays()
-        {
-            return Sample.PlusDays(3);
-        }
+        public LocalDate PlusWeeks() => Sample.PlusWeeks(3);
 
         [Benchmark]
-        public LocalDate PlusDays_MonthBoundary()
-        {
-            return Sample.PlusDays(-50);
-        }
+        public LocalDate PlusDays() => Sample.PlusDays(3);
 
         [Benchmark]
-        public LocalDate PlusDays_MonthYearBoundary()
-        {
-            return Sample.PlusDays(10);
-        }
+        public LocalDate PlusDays_MonthBoundary() => Sample.PlusDays(-50);
 
         [Benchmark]
-        public LocalDate PlusDays_LargeGap()
-        {
-            return Sample.PlusDays(1000);
-        }
+        public LocalDate PlusDays_MonthYearBoundary() => Sample.PlusDays(10);
 
         [Benchmark]
-        public LocalDate PlusPeriod()
-        {
-            return (Sample + SamplePeriod);
-        }
+        public LocalDate PlusDays_LargeGap() => Sample.PlusDays(1000);
 
         [Benchmark]
-        public LocalDate MinusPeriod()
-        {
-            return (Sample - SamplePeriod);
-        }
+        public LocalDate PlusPeriod() => (Sample + SamplePeriod);
+
+        [Benchmark]
+        public LocalDate MinusPeriod() => (Sample - SamplePeriod);
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateTimeBenchmarks.cs
@@ -20,270 +20,138 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         private static readonly Period SampleMixedPeriod = SampleDatePeriod + SampleTimePeriod;
 
         [Benchmark]
-        public LocalDateTime ConstructionToMinute()
-        {
-            return new LocalDateTime(2009, 12, 26, 10, 8);
-        }
+        public LocalDateTime ConstructionToMinute() => new LocalDateTime(2009, 12, 26, 10, 8);
 
         [Benchmark]
-        public LocalDateTime ConstructionToSecond()
-        {
-            return new LocalDateTime(2009, 12, 26, 10, 8, 30);
-        }
+        public LocalDateTime ConstructionToSecond() => new LocalDateTime(2009, 12, 26, 10, 8, 30);
 
         [Benchmark]
-        public LocalDateTime ConstructionToTick()
-        {
-            return new LocalDateTime(2009, 12, 26, 10, 8, 30, 0, 0);
-        }
+        public LocalDateTime ConstructionToTick() => new LocalDateTime(2009, 12, 26, 10, 8, 30, 0, 0);
 
         [Benchmark]
-        public LocalDateTime FromDateTime()
-        {
-            return LocalDateTime.FromDateTime(SampleDateTime);
-        }
+        public LocalDateTime FromDateTime() => LocalDateTime.FromDateTime(SampleDateTime);
 
         [Benchmark]
-        public DateTime ToDateTimeUnspecified()
-        {
-            return Sample.ToDateTimeUnspecified();
-        }
+        public DateTime ToDateTimeUnspecified() => Sample.ToDateTimeUnspecified();
 
         [Benchmark]
-        public int Year()
-        {
-            return Sample.Year;
-        }
+        public int Year() => Sample.Year;
 
         [Benchmark]
-        public int Month()
-        {
-            return Sample.Month;
-        }
+        public int Month() => Sample.Month;
 
         [Benchmark]
-        public int DayOfMonth()
-        {
-            return Sample.Day;
-        }
+        public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek()
-        {
-            return Sample.IsoDayOfWeek;
-        }
+        public IsoDayOfWeek IsoDayOfWeek() => Sample.IsoDayOfWeek;
 
         [Benchmark]
-        public int DayOfYear()
-        {
-            return Sample.DayOfYear;
-        }
+        public int DayOfYear() => Sample.DayOfYear;
 
         [Benchmark]
-        public int Hour()
-        {
-            return Sample.Hour;
-        }
+        public int Hour() => Sample.Hour;
 
         [Benchmark]
-        public int Minute()
-        {
-            return Sample.Minute;
-        }
+        public int Minute() => Sample.Minute;
 
         [Benchmark]
-        public int Second()
-        {
-            return Sample.Second;
-        }
+        public int Second() => Sample.Second;
 
         [Benchmark]
-        public int Millisecond()
-        {
-            return Sample.Millisecond;
-        }
+        public int Millisecond() => Sample.Millisecond;
 
         [Benchmark]
-        public LocalDate Date()
-        {
-            return Sample.Date;
-        }
+        public LocalDate Date() => Sample.Date;
 
         [Benchmark]
-        public LocalTime TimeOfDay()
-        {
-            return Sample.TimeOfDay;
-        }
+        public LocalTime TimeOfDay() => Sample.TimeOfDay;
 
         [Benchmark]
-        public long TickOfDay()
-        {
-            return Sample.TickOfDay;
-        }
+        public long TickOfDay() => Sample.TickOfDay;
 
         [Benchmark]
-        public int TickOfSecond()
-        {
-            return Sample.TickOfSecond;
-        }
+        public int TickOfSecond() => Sample.TickOfSecond;
 
         [Benchmark]
-        public int WeekOfWeekYear()
-        {
-            return Sample.WeekOfWeekYear;
-        }
+        public int WeekOfWeekYear() => Sample.WeekOfWeekYear;
 
         [Benchmark]
-        public int WeekYear()
-        {
-            return Sample.WeekYear;
-        }
+        public int WeekYear() => Sample.WeekYear;
 
         [Benchmark]
-        public int ClockHourOfHalfDay()
-        {
-            return Sample.ClockHourOfHalfDay;
-        }
+        public int ClockHourOfHalfDay() => Sample.ClockHourOfHalfDay;
 
         [Benchmark]
-        public Era Era()
-        {
-            return Sample.Era;
-        }
+        public Era Era() => Sample.Era;
 
         [Benchmark]
-        public int YearOfEra()
-        {
-            return Sample.YearOfEra;
-        }
+        public int YearOfEra() => Sample.YearOfEra;
 
         [Benchmark]
-        public string ToString_Parameterless()
-        {
-            return Sample.ToString();
-        }
+        public string ToString_Parameterless() => Sample.ToString();
 
         [Benchmark]
-        public string ToString_ExplicitPattern_Invariant()
-        {
-            return Sample.ToString("dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture);
-        }
+        public string ToString_ExplicitPattern_Invariant() => Sample.ToString("dd/MM/yyyy HH:mm:ss", CultureInfo.InvariantCulture);
 
         /// <summary>
         /// This test will involve creating a new NodaFormatInfo for each iteration.
         /// </summary>
         [Benchmark]
-        public string ToString_ExplicitPattern_MutableCulture()
-        {
-            return Sample.ToString("dd/MM/yyyy HH:mm:ss", MutableCulture);
-        }
+        public string ToString_ExplicitPattern_MutableCulture() => Sample.ToString("dd/MM/yyyy HH:mm:ss", MutableCulture);
 
         [Benchmark]
-        public LocalDateTime PlusYears()
-        {
-            return Sample.PlusYears(3);
-        }
+        public LocalDateTime PlusYears() => Sample.PlusYears(3);
 
         [Benchmark]
-        public LocalDateTime PlusMonths()
-        {
-            return Sample.PlusMonths(3);
-        }
+        public LocalDateTime PlusMonths() => Sample.PlusMonths(3);
 
         [Benchmark]
-        public LocalDateTime PlusWeeks()
-        {
-            return Sample.PlusWeeks(3);
-        }
+        public LocalDateTime PlusWeeks() => Sample.PlusWeeks(3);
 
         [Benchmark]
-        public LocalDateTime PlusDays()
-        {
-            return Sample.PlusDays(3);
-        }
+        public LocalDateTime PlusDays() => Sample.PlusDays(3);
 
         [Benchmark]
-        public LocalDateTime PlusHours()
-        {
-            return Sample.PlusHours(3);
-        }
+        public LocalDateTime PlusHours() => Sample.PlusHours(3);
 
-        public LocalDateTime PlusHours_OverflowDay()
-        {
-            return Sample.PlusHours(33);
-        }
+        public LocalDateTime PlusHours_OverflowDay() => Sample.PlusHours(33);
 
         [Benchmark]
-        public LocalDateTime PlusHours_Negative()
-        {
-            return Sample.PlusHours(-3);
-        }
+        public LocalDateTime PlusHours_Negative() => Sample.PlusHours(-3);
 
         [Benchmark]
-        public LocalDateTime PlusHours_UnderflowDay()
-        {
-            return Sample.PlusHours(-33);
-        }
+        public LocalDateTime PlusHours_UnderflowDay() => Sample.PlusHours(-33);
 
         [Benchmark]
-        public LocalDateTime PlusMinutes()
-        {
-            return Sample.PlusMinutes(3);
-        }
+        public LocalDateTime PlusMinutes() => Sample.PlusMinutes(3);
 
         [Benchmark]
-        public LocalDateTime PlusSeconds()
-        {
-            return Sample.PlusSeconds(3);
-        }
+        public LocalDateTime PlusSeconds() => Sample.PlusSeconds(3);
 
         [Benchmark]
-        public LocalDateTime PlusMilliseconds()
-        {
-            return Sample.PlusMilliseconds(3);
-        }
+        public LocalDateTime PlusMilliseconds() => Sample.PlusMilliseconds(3);
 
         [Benchmark]
-        public LocalDateTime PlusTicks()
-        {
-            return Sample.PlusTicks(3);
-        }
+        public LocalDateTime PlusTicks() => Sample.PlusTicks(3);
 
         [Benchmark]
-        public LocalDateTime PlusDatePeriod()
-        {
-            return (Sample + SampleDatePeriod);
-        }
+        public LocalDateTime PlusDatePeriod() => (Sample + SampleDatePeriod);
 
         [Benchmark]
-        public LocalDateTime MinusDatePeriod()
-        {
-            return (Sample - SampleDatePeriod);
-        }
+        public LocalDateTime MinusDatePeriod() => (Sample - SampleDatePeriod);
 
         [Benchmark]
-        public LocalDateTime PlusTimePeriod()
-        {
-            return (Sample + SampleTimePeriod);
-        }
+        public LocalDateTime PlusTimePeriod() => (Sample + SampleTimePeriod);
 
         [Benchmark]
-        public LocalDateTime MinusTimePeriod()
-        {
-            return (Sample - SampleTimePeriod);
-        }
+        public LocalDateTime MinusTimePeriod() => (Sample - SampleTimePeriod);
 
         [Benchmark]
-        public LocalDateTime PlusMixedPeriod()
-        {
-            return (Sample + SampleMixedPeriod);
-        }
+        public LocalDateTime PlusMixedPeriod() => (Sample + SampleMixedPeriod);
 
         [Benchmark]
-        public LocalDateTime MinusMixedPeriod()
-        {
-            return (Sample - SampleMixedPeriod);
-        }
+        public LocalDateTime MinusMixedPeriod() => (Sample - SampleMixedPeriod);
 
 #if !NO_INTERNALS
         //        [Benchmark]

--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalTimeBenchmarks.cs
@@ -14,135 +14,69 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         private static readonly LocalDateTime LocalDateTime = new LocalDateTime(2011, 9, 14, 15, 10, 25);
 
         [Benchmark]
-        public LocalTime ConstructionToMinute()
-        {
-            return new LocalTime(15, 10);
-        }
+        public LocalTime ConstructionToMinute() => new LocalTime(15, 10);
 
         [Benchmark]
-        public LocalTime ConstructionToSecond()
-        {
-            return new LocalTime(15, 10, 25);
-        }
+        public LocalTime ConstructionToSecond() => new LocalTime(15, 10, 25);
 
         [Benchmark]
-        public LocalTime ConstructionToMillisecond()
-        {
-            return new LocalTime(15, 10, 25, 500);
-        }
+        public LocalTime ConstructionToMillisecond() => new LocalTime(15, 10, 25, 500);
 
         [Benchmark]
-        public LocalTime ConstructionToTick()
-        {
-            return new LocalTime(15, 10, 25, 500, 1234);
-        }
+        public LocalTime ConstructionToTick() => new LocalTime(15, 10, 25, 500, 1234);
 
         [Benchmark]
-        public LocalTime ConversionFromLocalDateTime()
-        {
-            return LocalDateTime.TimeOfDay;
-        }
+        public LocalTime ConversionFromLocalDateTime() => LocalDateTime.TimeOfDay;
 
         [Benchmark]
-        public int Hour()
-        {
-            return Sample.Hour;
-        }
+        public int Hour() => Sample.Hour;
 
         [Benchmark]
-        public int Minute()
-        {
-            return Sample.Minute;
-        }
+        public int Minute() => Sample.Minute;
 
         [Benchmark]
-        public int Second()
-        {
-            return Sample.Second;
-        }
+        public int Second() => Sample.Second;
 
         [Benchmark]
-        public int Millisecond()
-        {
-            return Sample.Millisecond;
-        }
+        public int Millisecond() => Sample.Millisecond;
 
         [Benchmark]
-        public int ClockHourOfHalfDay()
-        {
-            return Sample.ClockHourOfHalfDay;
-        }
+        public int ClockHourOfHalfDay() => Sample.ClockHourOfHalfDay;
 
         [Benchmark]
-        public int TickOfSecond()
-        {
-            return Sample.TickOfSecond;
-        }
+        public int TickOfSecond() => Sample.TickOfSecond;
 
         [Benchmark]
-        public long TickOfDay()
-        {
-            return Sample.TickOfDay;
-        }
+        public long TickOfDay() => Sample.TickOfDay;
 
         [Benchmark]
-        public LocalTime PlusHours()
-        {
-            return Sample.PlusHours(3);
-        }
+        public LocalTime PlusHours() => Sample.PlusHours(3);
 
         [Benchmark]
-        public LocalTime PlusHours_OverflowDay()
-        {
-            return Sample.PlusHours(33);
-        }
+        public LocalTime PlusHours_OverflowDay() => Sample.PlusHours(33);
 
         [Benchmark]
-        public LocalTime PlusHours_Negative()
-        {
-            return Sample.PlusHours(-3);
-        }
+        public LocalTime PlusHours_Negative() => Sample.PlusHours(-3);
 
         [Benchmark]
-        public LocalTime PlusHours_UnderflowDay()
-        {
-            return Sample.PlusHours(-33);
-        }
+        public LocalTime PlusHours_UnderflowDay() => Sample.PlusHours(-33);
 
         [Benchmark]
-        public LocalTime PlusMinutes()
-        {
-            return Sample.PlusMinutes(3);
-        }
+        public LocalTime PlusMinutes() => Sample.PlusMinutes(3);
 
         [Benchmark]
-        public LocalTime PlusSeconds()
-        {
-            return Sample.PlusSeconds(3);
-        }
+        public LocalTime PlusSeconds() => Sample.PlusSeconds(3);
 
         [Benchmark]
-        public LocalTime PlusMilliseconds()
-        {
-            return Sample.PlusMilliseconds(3);
-        }
+        public LocalTime PlusMilliseconds() => Sample.PlusMilliseconds(3);
 
         [Benchmark]
-        public LocalTime PlusTicks()
-        {
-            return Sample.PlusTicks(3);
-        }
+        public LocalTime PlusTicks() => Sample.PlusTicks(3);
 
         [Benchmark]
-        public LocalTime PlusPeriod()
-        {
-            return (Sample + SamplePeriod);
-        }
+        public LocalTime PlusPeriod() => (Sample + SamplePeriod);
 
         [Benchmark]
-        public LocalTime MinusPeriod()
-        {
-            return (Sample - SamplePeriod);
-        }
+        public LocalTime MinusPeriod() => (Sample - SamplePeriod);
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/OffsetDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/OffsetDateTimeBenchmarks.cs
@@ -25,120 +25,63 @@ namespace NodaTime.Benchmarks.NodaTimeTests
 #endif
 
         [Benchmark]
-        public OffsetDateTime Construction()
-        {
-            return new OffsetDateTime(SampleLocal, OneHourOffset);
-        }
+        public OffsetDateTime Construction() => new OffsetDateTime(SampleLocal, OneHourOffset);
 
         [Benchmark]
-        public int Year()
-        {
-            return Sample.Year;
-        }
+        public int Year() => Sample.Year;
 
         [Benchmark]
-        public int Month()
-        {
-            return Sample.Month;
-        }
+        public int Month() => Sample.Month;
 
         [Benchmark]
-        public int DayOfMonth()
-        {
-            return Sample.Day;
-        }
+        public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek()
-        {
-            return Sample.IsoDayOfWeek;
-        }
+        public IsoDayOfWeek IsoDayOfWeek() => Sample.IsoDayOfWeek;
 
         [Benchmark]
-        public int DayOfYear()
-        {
-            return Sample.DayOfYear;
-        }
+        public int DayOfYear() => Sample.DayOfYear;
 
         [Benchmark]
-        public int Hour()
-        {
-            return Sample.Hour;
-        }
+        public int Hour() => Sample.Hour;
 
         [Benchmark]
-        public int Minute()
-        {
-            return Sample.Minute;
-        }
+        public int Minute() => Sample.Minute;
 
         [Benchmark]
-        public int Second()
-        {
-            return Sample.Second;
-        }
+        public int Second() => Sample.Second;
 
         [Benchmark]
-        public int Millisecond()
-        {
-            return Sample.Millisecond;
-        }
+        public int Millisecond() => Sample.Millisecond;
 
 #if !V1_0
         [Benchmark]
-        public LocalDate Date()
-        {
-            return Sample.Date;
-        }
+        public LocalDate Date() => Sample.Date;
 
         [Benchmark]
-        public LocalTime TimeOfDay()
-        {
-            return Sample.TimeOfDay;
-        }
+        public LocalTime TimeOfDay() => Sample.TimeOfDay;
 #endif
 
         [Benchmark]
-        public long TickOfDay()
-        {
-            return Sample.TickOfDay;
-        }
+        public long TickOfDay() => Sample.TickOfDay;
 
         [Benchmark]
-        public int TickOfSecond()
-        {
-            return Sample.TickOfSecond;
-        }
+        public int TickOfSecond() => Sample.TickOfSecond;
 
         [Benchmark]
-        public int WeekOfWeekYear()
-        {
-            return Sample.WeekOfWeekYear;
-        }
+        public int WeekOfWeekYear() => Sample.WeekOfWeekYear;
 
         [Benchmark]
-        public int WeekYear()
-        {
-            return Sample.WeekYear;
-        }
+        public int WeekYear() => Sample.WeekYear;
 
         [Benchmark]
-        public int ClockHourOfHalfDay()
-        {
-            return Sample.ClockHourOfHalfDay;
-        }
+        public int ClockHourOfHalfDay() => Sample.ClockHourOfHalfDay;
 
         [Benchmark]
-        public Era Era()
-        {
-            return Sample.Era;
-        }
+        public Era Era() => Sample.Era;
 
         [Benchmark]
-        public int YearOfEra()
-        {
-            return Sample.YearOfEra;
-        }
+        public int YearOfEra() => Sample.YearOfEra;
 
 #if !V1_0
         [Benchmark]
@@ -161,19 +104,13 @@ namespace NodaTime.Benchmarks.NodaTimeTests
 #endif
 
 #if !V1_0 && !V1_1 && !V1_2
+        // This just about stays within the same local day
         [Benchmark]
-        public OffsetDateTime WithOffset_SameLocalDay()
-        {
-            // This just about stays within the same local day
-            return SampleEarlier.WithOffset(LargePositiveOffset);
-        }
+        public OffsetDateTime WithOffset_SameLocalDay() => SampleEarlier.WithOffset(LargePositiveOffset);
 
+        // This ends up in the day before
         [Benchmark]
-        public OffsetDateTime WithOffset_DifferentLocalDay()
-        {
-            // This ends up in the day before
-            return SampleEarlier.WithOffset(LargeNegativeOffset);
-        }
+        public OffsetDateTime WithOffset_DifferentLocalDay() => SampleEarlier.WithOffset(LargeNegativeOffset);
 #endif
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/PacificZonedDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/PacificZonedDateTimeBenchmarks.cs
@@ -14,69 +14,36 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         private static readonly ZonedDateTime SampleZoned = Pacific.AtStrictly(SampleLocal);
 
         [Benchmark]
-        public ZonedDateTime Construction()
-        {
-            return Pacific.AtStrictly(SampleLocal);
-        }
+        public ZonedDateTime Construction() => Pacific.AtStrictly(SampleLocal);
 
         [Benchmark]
-        public int Year()
-        {
-            return SampleZoned.Year;
-        }
+        public int Year() => SampleZoned.Year;
 
         [Benchmark]
-        public int Month()
-        {
-            return SampleZoned.Month;
-        }
+        public int Month() => SampleZoned.Month;
 
         [Benchmark]
-        public int DayOfMonth()
-        {
-            return SampleZoned.Day;
-        }
+        public int DayOfMonth() => SampleZoned.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek()
-        {
-            return SampleZoned.IsoDayOfWeek;
-        }
+        public IsoDayOfWeek IsoDayOfWeek() => SampleZoned.IsoDayOfWeek;
 
         [Benchmark]
-        public int DayOfYear()
-        {
-            return SampleZoned.DayOfYear;
-        }
+        public int DayOfYear() => SampleZoned.DayOfYear;
 
         [Benchmark]
-        public int Hour()
-        {
-            return SampleZoned.Hour;
-        }
+        public int Hour() => SampleZoned.Hour;
 
         [Benchmark]
-        public int Minute()
-        {
-            return SampleZoned.Minute;
-        }
+        public int Minute() => SampleZoned.Minute;
 
         [Benchmark]
-        public int Second()
-        {
-            return SampleZoned.Second;
-        }
+        public int Second() => SampleZoned.Second;
 
         [Benchmark]
-        public int Millisecond()
-        {
-            return SampleZoned.Millisecond;
-        }
+        public int Millisecond() => SampleZoned.Millisecond;
 
         [Benchmark]
-        public Instant ToInstant()
-        {
-            return SampleZoned.ToInstant();
-        }
+        public Instant ToInstant() => SampleZoned.ToInstant();
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/PeriodBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/PeriodBenchmarks.cs
@@ -19,57 +19,30 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         private static readonly LocalDateTime SampleEndDateTime = SampleEndDate + SampleEndTime;
 
         [Benchmark]
-        public Period Between_LocalDate()
-        {
-            return Period.Between(SampleStartDate, SampleEndDate);
-        }
+        public Period Between_LocalDate() => Period.Between(SampleStartDate, SampleEndDate);
 
         [Benchmark]
-        public Period Between_LocalDate_Years()
-        {
-            return Period.Between(SampleStartDate, SampleEndDate, PeriodUnits.Years);
-        }
+        public Period Between_LocalDate_Years() => Period.Between(SampleStartDate, SampleEndDate, PeriodUnits.Years);
 
         [Benchmark]
-        public Period Between_LocalDate_Months()
-        {
-            return Period.Between(SampleStartDate, SampleEndDate, PeriodUnits.Months);
-        }
+        public Period Between_LocalDate_Months() => Period.Between(SampleStartDate, SampleEndDate, PeriodUnits.Months);
 
         [Benchmark]
-        public Period Between_LocalDate_Days()
-        {
-            return Period.Between(SampleStartDate, SampleEndDate, PeriodUnits.Days);
-        }
+        public Period Between_LocalDate_Days() => Period.Between(SampleStartDate, SampleEndDate, PeriodUnits.Days);
 
         [Benchmark]
-        public Period Between_LocalDate_Days_SameMonth()
-        {
-            return Period.Between(SampleStartDate, SampleEndDateSameMonth, PeriodUnits.Days);
-        }
+        public Period Between_LocalDate_Days_SameMonth() => Period.Between(SampleStartDate, SampleEndDateSameMonth, PeriodUnits.Days);
 
         [Benchmark]
-        public Period Between_LocalDate_Days_SameYear()
-        {
-            return Period.Between(SampleStartDate, SampleEndDateSameYear, PeriodUnits.Days);
-        }
+        public Period Between_LocalDate_Days_SameYear() => Period.Between(SampleStartDate, SampleEndDateSameYear, PeriodUnits.Days);
 
         [Benchmark]
-        public Period Between_LocalTime()
-        {
-            return Period.Between(SampleStartTime, SampleEndTime);
-        }
+        public Period Between_LocalTime() => Period.Between(SampleStartTime, SampleEndTime);
 
         [Benchmark]
-        public Period Between_LocalDateTime()
-        {
-            return Period.Between(SampleStartDateTime, SampleEndDateTime);
-        }
+        public Period Between_LocalDateTime() => Period.Between(SampleStartDateTime, SampleEndDateTime);
 
         [Benchmark]
-        public Period Between_LocalDateTime_Ticks()
-        {
-            return Period.Between(SampleStartDateTime, SampleEndDateTime, PeriodUnits.Ticks);
-        }
+        public Period Between_LocalDateTime_Ticks() => Period.Between(SampleStartDateTime, SampleEndDateTime, PeriodUnits.Ticks);
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/UtcZonedDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/UtcZonedDateTimeBenchmarks.cs
@@ -20,99 +20,51 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         }
 
         [Benchmark]
-        public int Year()
-        {
-            return Sample.Year;
-        }
+        public int Year() => Sample.Year;
 
         [Benchmark]
-        public int Month()
-        {
-            return Sample.Month;
-        }
+        public int Month() => Sample.Month;
 
         [Benchmark]
-        public int DayOfMonth()
-        {
-            return Sample.Day;
-        }
+        public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek()
-        {
-            return Sample.IsoDayOfWeek;
-        }
+        public IsoDayOfWeek IsoDayOfWeek() => Sample.IsoDayOfWeek;
 
         [Benchmark]
-        public int DayOfYear()
-        {
-            return Sample.DayOfYear;
-        }
+        public int DayOfYear() => Sample.DayOfYear;
 
         [Benchmark]
-        public int Hour()
-        {
-            return Sample.Hour;
-        }
+        public int Hour() => Sample.Hour;
 
         [Benchmark]
-        public int Minute()
-        {
-            return Sample.Minute;
-        }
+        public int Minute() => Sample.Minute;
 
         [Benchmark]
-        public int Second()
-        {
-            return Sample.Second;
-        }
+        public int Second() => Sample.Second;
 
         [Benchmark]
-        public int Millisecond()
-        {
-            return Sample.Millisecond;
-        }
+        public int Millisecond() => Sample.Millisecond;
 
         [Benchmark]
-        public long TickOfDay()
-        {
-            return Sample.TickOfDay;
-        }
+        public long TickOfDay() => Sample.TickOfDay;
 
         [Benchmark]
-        public int TickOfSecond()
-        {
-            return Sample.TickOfSecond;
-        }
+        public int TickOfSecond() => Sample.TickOfSecond;
 
         [Benchmark]
-        public int WeekOfWeekYear()
-        {
-            return Sample.WeekOfWeekYear;
-        }
+        public int WeekOfWeekYear() => Sample.WeekOfWeekYear;
 
         [Benchmark]
-        public int WeekYear()
-        {
-            return Sample.WeekYear;
-        }
+        public int WeekYear() => Sample.WeekYear;
 
         [Benchmark]
-        public int ClockHourOfHalfDay()
-        {
-            return Sample.ClockHourOfHalfDay;
-        }
+        public int ClockHourOfHalfDay() => Sample.ClockHourOfHalfDay;
 
         [Benchmark]
-        public Era Era()
-        {
-            return Sample.Era;
-        }
+        public Era Era() => Sample.Era;
 
         [Benchmark]
-        public int YearOfEra()
-        {
-            return Sample.YearOfEra;
-        }
+        public int YearOfEra() => Sample.YearOfEra;
     }
 }


### PR DESCRIPTION
(Just refactoring - although I had to be careful in one case, with `#ifdef` not being handled properly.)