### PR TITLE
Week year rule interface

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTimeTests/Calendars/RegularWeekYearRuleBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Calendars/RegularWeekYearRuleBenchmarks.cs
@@ -8,14 +8,14 @@ using NodaTime.Calendars;
 namespace NodaTime.Benchmarks.NodaTimeTests.Calendars
 {
     [Config(typeof(BenchmarkConfig))]
-    public class WeekYearRuleBenchmarks
+    public class RegularWeekYearRuleBenchmarks
     {
         private static readonly LocalDate Sample = new LocalDate(2009, 12, 26);
 
         [Benchmark]
-        public int IsoWeekOfWeekYear() => WeekYearRule.Iso.GetWeekOfWeekYear(Sample);
+        public int IsoWeekOfWeekYear() => RegularWeekYearRule.Iso.GetWeekOfWeekYear(Sample);
 
         [Benchmark]
-        public int IsoWeekYear() => WeekYearRule.Iso.GetWeekYear(Sample);
+        public int IsoWeekYear() => RegularWeekYearRule.Iso.GetWeekYear(Sample);
     }
 }

--- a/src/NodaTime.Test/Calendars/IsoCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/IsoCalendarSystemTest.cs
@@ -26,8 +26,8 @@ namespace NodaTime.Test.Calendars
 
             Assert.AreEqual(1970, epoch.Year);
             Assert.AreEqual(1970, epoch.YearOfEra);
-            Assert.AreEqual(1970, WeekYearRule.Iso.GetWeekYear(epoch.Date));
-            Assert.AreEqual(1, WeekYearRule.Iso.GetWeekOfWeekYear(epoch.Date));
+            Assert.AreEqual(1970, RegularWeekYearRule.Iso.GetWeekYear(epoch.Date));
+            Assert.AreEqual(1, RegularWeekYearRule.Iso.GetWeekOfWeekYear(epoch.Date));
             Assert.AreEqual(1, epoch.Month);
             Assert.AreEqual(1, epoch.Day);
             Assert.AreEqual(1, epoch.DayOfYear);
@@ -49,8 +49,8 @@ namespace NodaTime.Test.Calendars
 
             Assert.AreEqual(2009, now.Year);
             Assert.AreEqual(2009, now.YearOfEra);
-            Assert.AreEqual(2009, WeekYearRule.Iso.GetWeekYear(now.Date));
-            Assert.AreEqual(48, WeekYearRule.Iso.GetWeekOfWeekYear(now.Date));
+            Assert.AreEqual(2009, RegularWeekYearRule.Iso.GetWeekYear(now.Date));
+            Assert.AreEqual(48, RegularWeekYearRule.Iso.GetWeekOfWeekYear(now.Date));
             Assert.AreEqual(11, now.Month);
             Assert.AreEqual(27, now.Day);
             Assert.AreEqual(TimeOfGreatAchievement.DayOfYear, now.DayOfYear);

--- a/src/NodaTime.Test/Calendars/RegularWeekYearRuleTest.cs
+++ b/src/NodaTime.Test/Calendars/RegularWeekYearRuleTest.cs
@@ -18,7 +18,7 @@ namespace NodaTime.Test.Calendars
             // In the Gregorian calendar with a minimum of 7 days in the first
             // week, Tuesday January 1st -9998 is in week year -9999. We should be able to
             // round-trip.
-            var rule = WeekYearRule.ForMinDaysInFirstWeek(7);
+            var rule = RegularWeekYearRule.ForMinDaysInFirstWeek(7);
             var date = new LocalDate(-9998, 1, 1);
             Assert.AreEqual(date, rule.GetLocalDate(
                 rule.GetWeekYear(date),
@@ -32,7 +32,7 @@ namespace NodaTime.Test.Calendars
             // In the Gregorian calendar with a minimum of 1 day in the first
             // week, Friday December 31st 9999 is in week year 10000. We should be able to
             // round-trip.
-            var rule = WeekYearRule.ForMinDaysInFirstWeek(1);
+            var rule = RegularWeekYearRule.ForMinDaysInFirstWeek(1);
             var date = new LocalDate(9999, 12, 31);
             Assert.AreEqual(date, rule.GetLocalDate(
                 rule.GetWeekYear(date),
@@ -47,10 +47,10 @@ namespace NodaTime.Test.Calendars
             // and is therefore out of range, even though the week-year
             // and week-of-week-year are valid.
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => WeekYearRule.Iso.GetLocalDate(-9998, 1, Monday));
+                () => RegularWeekYearRule.Iso.GetLocalDate(-9998, 1, Monday));
 
             // Sanity check: no exception for January 1st
-            WeekYearRule.Iso.GetLocalDate(-9998, 1, Tuesday);
+            RegularWeekYearRule.Iso.GetLocalDate(-9998, 1, Tuesday);
         }
 
         [Test]
@@ -60,10 +60,10 @@ namespace NodaTime.Test.Calendars
             // same week is therefore out of range, even though the week-year
             // and week-of-week-year are valid.
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => WeekYearRule.Iso.GetLocalDate(9999, 52, Saturday));
+                () => RegularWeekYearRule.Iso.GetLocalDate(9999, 52, Saturday));
 
             // Sanity check: no exception for December 31st
-            WeekYearRule.Iso.GetLocalDate(9999, 52, Friday);
+            RegularWeekYearRule.Iso.GetLocalDate(9999, 52, Friday);
         }
 
         // Tests ported from IsoCalendarSystemTest and LocalDateTest.Construction
@@ -78,10 +78,10 @@ namespace NodaTime.Test.Calendars
         public void WeekYearDifferentToYear(int year, int month, int day, int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek)
         {
             var date = new LocalDate(year, month, day);
-            Assert.AreEqual(weekYear, WeekYearRule.Iso.GetWeekYear(date));
-            Assert.AreEqual(weekOfWeekYear, WeekYearRule.Iso.GetWeekOfWeekYear(date));
+            Assert.AreEqual(weekYear, RegularWeekYearRule.Iso.GetWeekYear(date));
+            Assert.AreEqual(weekOfWeekYear, RegularWeekYearRule.Iso.GetWeekOfWeekYear(date));
             Assert.AreEqual(dayOfWeek, date.IsoDayOfWeek);
-            Assert.AreEqual(date, WeekYearRule.Iso.GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek));
+            Assert.AreEqual(date, RegularWeekYearRule.Iso.GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek));
         }
 
         // Ported from CalendarSystemTest.Validation
@@ -99,7 +99,7 @@ namespace NodaTime.Test.Calendars
         [TestCase(2019, 52)]
         public void GetWeeksInWeekYear(int weekYear, int expectedResult)
         {
-            Assert.AreEqual(expectedResult, WeekYearRule.Iso.GetWeeksInWeekYear(weekYear));
+            Assert.AreEqual(expectedResult, RegularWeekYearRule.Iso.GetWeeksInWeekYear(weekYear));
         }
 
         // Ported from LocalDateTest.BasicProperties
@@ -119,7 +119,7 @@ namespace NodaTime.Test.Calendars
         public void WeekOfWeekYear_ComparisonWithOracle(int year, int month, int day, int weekOfWeekYear)
         {
             var date = new LocalDate(year, month, day);
-            Assert.AreEqual(weekOfWeekYear, WeekYearRule.Iso.GetWeekOfWeekYear(date));
+            Assert.AreEqual(weekOfWeekYear, RegularWeekYearRule.Iso.GetWeekOfWeekYear(date));
         }
 
         [Test]
@@ -138,14 +138,14 @@ namespace NodaTime.Test.Calendars
             // Rules which put the first day of the calendar year into the same week year
             for (int i = 1; i <= maxMinDaysInFirstWeekForSameWeekYear; i++)
             {
-                var rule = WeekYearRule.ForMinDaysInFirstWeek(i);
+                var rule = RegularWeekYearRule.ForMinDaysInFirstWeek(i);
                 Assert.AreEqual(year, rule.GetWeekYear(startOfCalendarYear));
                 Assert.AreEqual(1, rule.GetWeekOfWeekYear(startOfCalendarYear));
             }
             // Rules which put the first day of the calendar year into the previous week year
             for (int i = maxMinDaysInFirstWeekForSameWeekYear + 1; i <= 7; i++)
             {
-                var rule = WeekYearRule.ForMinDaysInFirstWeek(i);
+                var rule = RegularWeekYearRule.ForMinDaysInFirstWeek(i);
                 Assert.AreEqual(year - 1, rule.GetWeekYear(startOfCalendarYear));
                 Assert.AreEqual(rule.GetWeeksInWeekYear(year - 1), rule.GetWeekOfWeekYear(startOfCalendarYear));
             }
@@ -162,7 +162,7 @@ namespace NodaTime.Test.Calendars
         public void Iso(int year, int month, int day, int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek)
         {
             var viaCalendar = new LocalDate(year, month, day);
-            var rule = WeekYearRule.Iso;
+            var rule = RegularWeekYearRule.Iso;
             Assert.AreEqual(weekYear, rule.GetWeekYear(viaCalendar));
             Assert.AreEqual(weekOfWeekYear, rule.GetWeekOfWeekYear(viaCalendar));
             Assert.AreEqual(dayOfWeek, viaCalendar.IsoDayOfWeek);
@@ -190,7 +190,7 @@ namespace NodaTime.Test.Calendars
             int expectedWeeks, int expectedWeekYearOfFirstDay, int expectedWeekOfWeekYearOfFirstDay)
         {
             var civilDate = new LocalDate(year, 1, 1, HebrewCivil);
-            var rule = WeekYearRule.Iso;
+            var rule = RegularWeekYearRule.Iso;
             Assert.AreEqual(expectedFirstDay, civilDate.IsoDayOfWeek);
             Assert.AreEqual(civilDate.WithCalendar(CalendarSystem.Iso), new LocalDate(isoYear, isoMonth, isoDay));
             Assert.AreEqual(expectedWeeks, rule.GetWeeksInWeekYear(year, HebrewCivil));

--- a/src/NodaTime.Test/Calendars/RegularWeekYearRuleTest.cs
+++ b/src/NodaTime.Test/Calendars/RegularWeekYearRuleTest.cs
@@ -10,7 +10,7 @@ using static NodaTime.CalendarSystem;
 
 namespace NodaTime.Test.Calendars
 {
-    public class WeekYearRuleTest
+    public class RegularWeekYearRuleTest
     {
         [Test]
         public void RoundtripFirstDay_Iso7()

--- a/src/NodaTime/Calendars/IWeekYearRule.cs
+++ b/src/NodaTime/Calendars/IWeekYearRule.cs
@@ -1,11 +1,9 @@
-﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
-// Use of this source code is governed by the Apache License 2.0,
-// as found in the LICENSE.txt file.
-
-using JetBrains.Annotations;
-using NodaTime.Annotations;
+﻿using JetBrains.Annotations;
 using NodaTime.Utility;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace NodaTime.Calendars
 {
@@ -50,63 +48,8 @@ namespace NodaTime.Calendars
     /// should be immutable too.
     /// </para>
     /// </remarks>
-    [Immutable]
-    public abstract class WeekYearRule
+    public interface IWeekYearRule
     {
-        private static readonly WeekYearRule[] isoBasedRules = Enumerable.Range(1, 7).Select(x => new RegularWeekYearRule(x)).ToArray();
-
-        /// <summary>
-        /// Returns a <see cref="WeekYearRule"/> similar to ISO-8601, but allowing the minimum number of
-        /// days in the first week to vary from the value of 4 specified by ISO-8601. Weeks are always
-        /// deemed to begin on an Monday.
-        /// </summary>
-        /// <remarks>
-        /// <paramref name="minDaysInFirstWeek"/> determines when the first week of the week-year starts.
-        /// For any given calendar year X, consider the Monday-to-Sunday week that includes the first day of the
-        /// calendar year. Usually, some days of that week are in calendar year X, and some are in calendar year 
-        /// X-1. If <paramref name="minDaysInFirstWeek"/> or more of the days are in year X, then the week is
-        /// deemed to be the first week of week-year X. Otherwise, the week is deemed to be the last week of
-        /// week-year X-1, and the first week of week-year X starts on the following Monday.
-        /// </remarks>
-        /// <param name="minDaysInFirstWeek">The minimum number of days in the first Monday-to-Sunday week
-        /// which have to be in the new calendar year for that week to count as being in that week-year.
-        /// Must be in the range 1 to 7 inclusive.
-        /// </param>
-        /// <returns>A <see cref="WeekYearRule"/> with the specified minimum number of days in the first
-        /// week.</returns>
-        public static WeekYearRule ForMinDaysInFirstWeek(int minDaysInFirstWeek)
-        {
-            Preconditions.CheckArgumentRange(nameof(minDaysInFirstWeek), minDaysInFirstWeek, 1, 7);
-            return isoBasedRules[minDaysInFirstWeek - 1];
-        }
-
-        /// <summary>
-        /// Returns a <see cref="WeekYearRule"/> consistent with ISO-8601.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// In the standard ISO-8601 week algorithm, the first week of the year
-        /// is that in which at least 4 days are in the year. As a result of this
-        /// definition, day 1 of the first week may be in the previous year. In ISO-8601,
-        /// weeks always begin on a Monday, so this rule is equivalent to the first Thursday
-        /// being in the first Monday-to-Sunday week of the year.
-        /// </para>
-        /// <para>
-        /// For example, January 1st 2011 was a Saturday, so only two days of that week
-        /// (Saturday and Sunday) were in 2011. Therefore January 1st is part of
-        /// week 52 of week-year 2010. Conversely, December 31st 2012 is a Monday,
-        /// so is part of week 1 of week-year 2013.
-        /// </para>
-        /// </remarks>
-        /// <value>A <see cref="WeekYearRule"/> consistent with ISO-8601.</value>
-        public static WeekYearRule Iso { get; } = isoBasedRules[3];
-
-        // TODO: public static WeekYearRule FromBclRule(CalendarWeekRule rule, IsoDayOfWeek firstDayOfWeek) => null;
-        // TODO: public static WeekYearRule FromBclRule(CalendarWeekRule rule, DayOfWeek firstDayOfWeek)
-        //    => FromBclRule(rule, BclConversions.ToIsoDayOfWeek(firstDayOfWeek));
-
-        // TODO: Make IsoBasedWeekYearRule more flexible, allowing non-Monday-to-Sunday weeks?
-
         /// <summary>
         /// Creates a <see cref="LocalDate" /> from a given week-year, week within that week-year,
         /// and day-of-week, for the specified calendar system.
@@ -136,13 +79,41 @@ namespace NodaTime.Calendars
         /// <param name="calendar">The calendar system for the date.</param>
         /// <exception cref="ArgumentOutOfRangeException">The parameters do not combine to form a valid date.</exception>
         /// <returns>A <see cref="LocalDate"/> corresponding to the specified values.</returns>
-        public abstract LocalDate GetLocalDate(
-            int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek, [NotNull] CalendarSystem calendar);
+        LocalDate GetLocalDate(int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek, [NotNull] CalendarSystem calendar);
 
         /// <summary>
-        /// Convenience overload to call <see cref="GetLocalDate(int, int, IsoDayOfWeek, CalendarSystem)"/>
+        /// Calculates the week-year in which the given date occurs, according to this rule.
+        /// </summary>
+        /// <param name="date">The date to compute the week-year of.</param>
+        /// <returns>The week-year of <paramref name="date"/>, according to this rule.</returns>
+        int GetWeekYear(LocalDate date);
+
+        /// <summary>
+        /// Calculates the week of the week-year in which the given date occurs, according to this rule.
+        /// </summary>
+        /// <param name="date">The date to compute the week of.</param>
+        /// <returns>The week of the week-year of <paramref name="date"/>, according to this rule.</returns>
+        int GetWeekOfWeekYear(LocalDate date);
+
+        /// <summary>
+        /// Returns the number of weeks in the given week-year, within the specified calendar system.
+        /// </summary>
+        /// <param name="weekYear">The week-year to find the range of.</param>
+        /// <param name="calendar">The calendar system the calculation is relative to.</param>
+        /// <returns>The number of weeks in the given week-year within the given calendar.</returns>
+        int GetWeeksInWeekYear(int weekYear, [NotNull] CalendarSystem calendar);
+    }
+
+    /// <summary>
+    /// Extension methods on <see cref="IWeekYearRule"/>.
+    /// </summary>
+    public static class WeekYearRuleExtensions
+    {
+        /// <summary>
+        /// Convenience method to call <see cref="IWeekYearRule.GetLocalDate(int, int, IsoDayOfWeek, CalendarSystem)"/>
         /// passing in the ISO calendar system.
         /// </summary>
+        /// <param name="rule">The rule to delegate the call to.</param>
         /// <param name="weekYear">The week-year of the new date. Implementations provided by Noda Time allow any
         /// year which is a valid calendar year, and sometimes one less than the minimum calendar year
         /// and/or one more than the maximum calendar year, to allow for dates near the start of a calendar
@@ -153,37 +124,17 @@ namespace NodaTime.Calendars
         /// depending on <paramref name="weekYear"/> and <paramref name="weekOfWeekYear"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException">The parameters do not combine to form a valid date.</exception>
         /// <returns>A <see cref="LocalDate"/> corresponding to the specified values.</returns>
-        public LocalDate GetLocalDate(int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek)
-            => GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek, CalendarSystem.Iso);
-
-        /// <summary>
-        /// Calculates the week-year in which the given date occurs, according to this rule.
-        /// </summary>
-        /// <param name="date">The date to compute the week-year of.</param>
-        /// <returns>The week-year of <paramref name="date"/>, according to this rule.</returns>
-        public abstract int GetWeekYear(LocalDate date);
-
-        /// <summary>
-        /// Calculates the week of the week-year in which the given date occurs, according to this rule.
-        /// </summary>
-        /// <param name="date">The date to compute the week of.</param>
-        /// <returns>The week of the week-year of <paramref name="date"/>, according to this rule.</returns>
-        public abstract int GetWeekOfWeekYear(LocalDate date);
-
-        /// <summary>
-        /// Returns the number of weeks in the given week-year, within the specified calendar system.
-        /// </summary>
-        /// <param name="weekYear">The week-year to find the range of.</param>
-        /// <param name="calendar">The calendar system the calculation is relative to.</param>
-        /// <returns>The number of weeks in the given week-year within the given calendar.</returns>
-        public abstract int GetWeeksInWeekYear(int weekYear, [NotNull] CalendarSystem calendar);
+        public static LocalDate GetLocalDate([NotNull] this IWeekYearRule rule, int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek) =>
+            Preconditions.CheckNotNull(rule, nameof(rule)).GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek, CalendarSystem.Iso);
 
         /// <summary>
         /// Convenience overload to call <see cref="GetWeeksInWeekYear(int, CalendarSystem)"/> with
         /// the ISO calendar system.
         /// </summary>
+        /// <param name="rule">The rule to delegate the call to.</param>
         /// <param name="weekYear">The week year to calculate the number of contained weeks.</param>
         /// <returns>The number of weeks in the given week year.</returns>
-        public int GetWeeksInWeekYear(int weekYear) => GetWeeksInWeekYear(weekYear, CalendarSystem.Iso);
+        public static int GetWeeksInWeekYear([NotNull] this IWeekYearRule rule, int weekYear) =>
+            Preconditions.CheckNotNull(rule, nameof(rule)).GetWeeksInWeekYear(weekYear, CalendarSystem.Iso);
     }
 }

--- a/src/NodaTime/Calendars/RegularWeekYearRule.cs
+++ b/src/NodaTime/Calendars/RegularWeekYearRule.cs
@@ -15,11 +15,11 @@ namespace NodaTime.Calendars
     /// WeekYearRule implementing the rules from Noda Time 1.x. Basically this is the ISO
     /// rules, but with a variable "minimum number of days in the first week".
     /// </summary>
-    internal sealed class IsoBasedWeekYearRule : WeekYearRule
+    internal sealed class RegularWeekYearRule : WeekYearRule
     {
         private readonly int minDaysInFirstWeek;
 
-        internal IsoBasedWeekYearRule(int minDaysInFirstWeek)
+        internal RegularWeekYearRule(int minDaysInFirstWeek)
         {
             Preconditions.DebugCheckArgumentRange(nameof(minDaysInFirstWeek), minDaysInFirstWeek, 1, 7);
             this.minDaysInFirstWeek = minDaysInFirstWeek;

--- a/src/NodaTime/Calendars/RegularWeekYearRule.cs
+++ b/src/NodaTime/Calendars/RegularWeekYearRule.cs
@@ -12,21 +12,70 @@ namespace NodaTime.Calendars
     // Possible future feature: allow the first day of the week to vary too.
 
     /// <summary>
-    /// WeekYearRule implementing the rules from Noda Time 1.x. Basically this is the ISO
-    /// rules, but with a variable "minimum number of days in the first week".
+    /// Implements <see cref="IWeekYearRule"/> for a rule where weeks are regular:
+    /// every week has exactly 7 days, which means that some week years straddle
+    /// the calendar year boundary. (So the start of a week can occur in one calendar
+    /// year, and the end of the week in the following calendar year, but the whole
+    /// week is in the same week-year.)
     /// </summary>
-    internal sealed class RegularWeekYearRule : WeekYearRule
+    [Immutable]
+    public sealed class RegularWeekYearRule : IWeekYearRule
     {
+        /// <summary>
+        /// Returns a <see cref="WeekYearRule"/> consistent with ISO-8601.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// In the standard ISO-8601 week algorithm, the first week of the year
+        /// is that in which at least 4 days are in the year. As a result of this
+        /// definition, day 1 of the first week may be in the previous year. In ISO-8601,
+        /// weeks always begin on a Monday, so this rule is equivalent to the first Thursday
+        /// being in the first Monday-to-Sunday week of the year.
+        /// </para>
+        /// <para>
+        /// For example, January 1st 2011 was a Saturday, so only two days of that week
+        /// (Saturday and Sunday) were in 2011. Therefore January 1st is part of
+        /// week 52 of week-year 2010. Conversely, December 31st 2012 is a Monday,
+        /// so is part of week 1 of week-year 2013.
+        /// </para>
+        /// </remarks>
+        /// <value>A <see cref="WeekYearRule"/> consistent with ISO-8601.</value>
+        public static IWeekYearRule Iso { get; } = new RegularWeekYearRule(4);
+
         private readonly int minDaysInFirstWeek;
 
-        internal RegularWeekYearRule(int minDaysInFirstWeek)
+        private RegularWeekYearRule(int minDaysInFirstWeek)
         {
             Preconditions.DebugCheckArgumentRange(nameof(minDaysInFirstWeek), minDaysInFirstWeek, 1, 7);
             this.minDaysInFirstWeek = minDaysInFirstWeek;
         }
 
+        /// <summary>
+        /// Creates a week year rule where the boundary between one week-year and the next
+        /// is parameterized in terms of how many days of the first week of the week
+        /// year have to be in the new calendar year. Weeks are always deemed to begin on an Monday.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="minDaysInFirstWeek"/> determines when the first week of the week-year starts.
+        /// For any given calendar year X, consider the Monday-to-Sunday week that includes the first day of the
+        /// calendar year. Usually, some days of that week are in calendar year X, and some are in calendar year 
+        /// X-1. If <paramref name="minDaysInFirstWeek"/> or more of the days are in year X, then the week is
+        /// deemed to be the first week of week-year X. Otherwise, the week is deemed to be the last week of
+        /// week-year X-1, and the first week of week-year X starts on the following Monday.
+        /// </remarks>
+        /// <param name="minDaysInFirstWeek">The minimum number of days in the first Monday-to-Sunday week
+        /// which have to be in the new calendar year for that week to count as being in that week-year.
+        /// Must be in the range 1 to 7 inclusive.
+        /// </param>
+        /// <returns>A <see cref="RegularWeekYearRule"/> with the specified minimum number of days in the first
+        /// week.</returns>
+        public static RegularWeekYearRule ForMinDaysInFirstWeek(int minDaysInFirstWeek)
+        {
+            return new RegularWeekYearRule(minDaysInFirstWeek);
+        }
+
         /// <inheritdoc />
-        public override LocalDate GetLocalDate(int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek, [NotNull] CalendarSystem calendar)
+        public LocalDate GetLocalDate(int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek, [NotNull] CalendarSystem calendar)
         {
             Preconditions.CheckNotNull(calendar, nameof(calendar));
             ValidateWeekYear(weekYear, calendar);
@@ -54,7 +103,7 @@ namespace NodaTime.Calendars
         }
 
         /// <inheritdoc />
-        public override int GetWeekOfWeekYear(LocalDate date)
+        public int GetWeekOfWeekYear(LocalDate date)
         {
             YearMonthDay yearMonthDay = date.YearMonthDay;
             YearMonthDayCalculator yearMonthDayCalculator = date.Calendar.YearMonthDayCalculator;
@@ -69,7 +118,7 @@ namespace NodaTime.Calendars
         }
 
         /// <inheritdoc />
-        public override int GetWeeksInWeekYear(int weekYear, [NotNull] CalendarSystem calendar)
+        public int GetWeeksInWeekYear(int weekYear, [NotNull] CalendarSystem calendar)
         {
             Preconditions.CheckNotNull(calendar, nameof(calendar));
             YearMonthDayCalculator yearMonthDayCalculator = calendar.YearMonthDayCalculator;
@@ -91,7 +140,7 @@ namespace NodaTime.Calendars
         }
 
         /// <inheritdoc />
-        public override int GetWeekYear(LocalDate date)
+        public int GetWeekYear(LocalDate date)
         {
             YearMonthDay yearMonthDay = date.YearMonthDay;
             YearMonthDayCalculator yearMonthDayCalculator = date.Calendar.YearMonthDayCalculator;

--- a/src/NodaTime/Calendars/WeekYearRule.cs
+++ b/src/NodaTime/Calendars/WeekYearRule.cs
@@ -53,7 +53,7 @@ namespace NodaTime.Calendars
     [Immutable]
     public abstract class WeekYearRule
     {
-        private static readonly WeekYearRule[] isoBasedRules = Enumerable.Range(1, 7).Select(x => new IsoBasedWeekYearRule(x)).ToArray();
+        private static readonly WeekYearRule[] isoBasedRules = Enumerable.Range(1, 7).Select(x => new RegularWeekYearRule(x)).ToArray();
 
         /// <summary>
         /// Returns a <see cref="WeekYearRule"/> similar to ISO-8601, but allowing the minimum number of

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -249,7 +249,7 @@ namespace NodaTime
         /// <param name="dayOfWeek">ISO-8601 day of week to return</param>
         /// <returns>The date corresponding to the given week year / week of week year / day of week.</returns>
         public static LocalDate FromWeekYearWeekAndDay(int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek)
-            => WeekYearRule.Iso.GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek, CalendarSystem.Iso);
+            => RegularWeekYearRule.Iso.GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek, CalendarSystem.Iso);
 
         /// <summary>
         /// Returns the local date corresponding to a particular occurrence of a day-of-week


### PR DESCRIPTION
Two-step change to move to WeekYearRule being an interface.

If we're happy with the code here, we can then brush up on the documentation (either as extra commits in this PR or as other PRs). I wanted to get the right shape of the API first though.

// cc @mj1856 for any feedback on abstract class vs interface, and extension methods vs optional parameters.