### PR TITLE
Enable testing with .NET Core

### DIFF
--- a/src/NodaTime.Serialization.Test/Program.cs
+++ b/src/NodaTime.Serialization.Test/Program.cs
@@ -1,4 +1,6 @@
 using NUnitLite;
+using System;
+using System.Reflection;
 
 namespace NodaTime.Serialization.Test
 {

--- a/src/NodaTime.Serialization.Test/project.json
+++ b/src/NodaTime.Serialization.Test/project.json
@@ -35,6 +35,14 @@
         "System.Threading.Tasks": "",
         "System.Xml.Linq": ""
       }
+    },
+    "dnxcore50": {
+      "compilationOptions": {
+        "define": [ "PCL" ]
+      },
+      "dependencies": {
+        "System.Console": "4.0.0-beta-23516"
+      }
     }
   }
 }

--- a/src/NodaTime.Test/Annotations/MutabilityTest.cs
+++ b/src/NodaTime.Test/Annotations/MutabilityTest.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Linq;
+using System.Reflection;
 using NodaTime.Annotations;
 using NUnit.Framework;
 
@@ -14,14 +15,14 @@ namespace NodaTime.Test.Annotations
         [Test]
         public void AllPublicClassesAreMutableOrImmutable()
         {
-            var unannotatedClasses = typeof(Instant).Assembly
-                                                    .GetTypes()
-                                                    .Concat(new[] { typeof(ZonedDateTime.Comparer) })
+            var unannotatedClasses = typeof(Instant).GetTypeInfo().Assembly
+                                                    .DefinedTypes
+                                                    .Concat(new[] { typeof(ZonedDateTime.Comparer).GetTypeInfo() })
                                                     .Where(t => t.IsClass && t.IsPublic && t.BaseType != typeof(MulticastDelegate))
                                                     .Where(t => !(t.IsAbstract && t.IsSealed)) // Ignore static classes
                                                     .OrderBy(t => t.Name)
-                                                    .Where(t => !t.IsDefined(typeof(ImmutableAttribute), false) &&
-                                                                !t.IsDefined(typeof(MutableAttribute), false))
+                                                    .Where(t => !t.IsDefined(typeof(ImmutableAttribute)) &&
+                                                                !t.IsDefined(typeof(MutableAttribute)))
                                                     .ToList();
             Assert.IsEmpty(unannotatedClasses, "Unannotated classes: " + string.Join(", ", unannotatedClasses.Select(c => c.Name)));
         }

--- a/src/NodaTime.Test/Annotations/PurityTest.cs
+++ b/src/NodaTime.Test/Annotations/PurityTest.cs
@@ -20,16 +20,17 @@ namespace NodaTime.Test.Annotations
         {
             var implicitlyPureNames = new HashSet<string> { "Equals", "GetHashCode", "CompareTo", "ToString" };
 
-            var impureMethods = typeof(Instant).Assembly
-                                               .GetTypes()
+            var impureMethods = typeof(Instant).GetTypeInfo().Assembly
+                                               .DefinedTypes
                                                .Where(t => t.IsValueType && t.IsPublic)
                                                .OrderBy(t => t.Name)
-                                               .SelectMany(m => m.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly))
+                                               .SelectMany(m => m.DeclaredMethods)
+                                               .Where(m => m.IsPublic && !m.IsStatic)
                                                .Where(m => !m.IsSpecialName) // Real methods, not properties
                                                .Where(m => !implicitlyPureNames.Contains(m.Name))
-                                               .Where(m => !m.IsDefined(typeof(PureAttribute), false))
+                                               .Where(m => !m.IsDefined(typeof(PureAttribute)))
                                                .ToList();
-            Assert.IsEmpty(impureMethods, "Impure methods: " + string.Join(", ", impureMethods.Select(m => m.ReflectedType.Name + "." + m.Name)));
+            Assert.IsEmpty(impureMethods, "Impure methods: " + string.Join(", ", impureMethods.Select(m => m.DeclaringType.Name + "." + m.Name)));
         }
     }
 }

--- a/src/NodaTime.Test/Annotations/ReadWriteForEfficiencyTest.cs
+++ b/src/NodaTime.Test/Annotations/ReadWriteForEfficiencyTest.cs
@@ -14,8 +14,8 @@ namespace NodaTime.Test.Annotations
     {
         private static IEnumerable<FieldInfo> GetFieldsWithAttribute()
         {
-            return from type in typeof(Instant).Assembly.GetTypes()
-                   from field in type.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+            return from type in typeof(Instant).GetTypeInfo().Assembly.DefinedTypes
+                   from field in type.DeclaredFields
                    where field.IsDefined(typeof(ReadWriteForEfficiencyAttribute))
                    select field;
         }
@@ -33,7 +33,7 @@ namespace NodaTime.Test.Annotations
         public void AttributeOnlyAppliedToValueTypeFields()
         {
             var badFields = GetFieldsWithAttribute()
-                .Where(field => !field.FieldType.IsValueType)
+                .Where(field => !field.FieldType.GetTypeInfo().IsValueType)
                 .ToList();
             Assert.IsEmpty(badFields);
         }

--- a/src/NodaTime.Test/Annotations/SecurityTest.cs
+++ b/src/NodaTime.Test/Annotations/SecurityTest.cs
@@ -5,6 +5,7 @@
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Security;
 
 namespace NodaTime.Test.Annotations
@@ -15,15 +16,15 @@ namespace NodaTime.Test.Annotations
         public void SecurityAttributesOnInterfaceImplementations()
         {
             var violations = new List<string>();
-            foreach (var type in typeof(Instant).Assembly.GetTypes().Where(type => !type.IsInterface))
+            foreach (var type in typeof(Instant).GetTypeInfo().Assembly.DefinedTypes.Where(type => !type.IsInterface))
             {
-                foreach (var iface in type.GetInterfaces())
+                foreach (var iface in type.ImplementedInterfaces)
                 {
-                    var map = type.GetInterfaceMap(iface);
+                    var map = type.GetRuntimeInterfaceMap(iface);
                     var methodCount = map.InterfaceMethods.Length;
                     for (int i = 0; i < methodCount; i++)
                     {
-                        if (map.TargetMethods[i].DeclaringType == type &&
+                        if (map.TargetMethods[i].DeclaringType.GetTypeInfo() == type &&
                             map.InterfaceMethods[i].IsDefined(typeof(SecurityCriticalAttribute), false) &&
                             !map.TargetMethods[i].IsDefined(typeof(SecurityCriticalAttribute), false))
                         {

--- a/src/NodaTime.Test/Annotations/TrustedTest.cs
+++ b/src/NodaTime.Test/Annotations/TrustedTest.cs
@@ -14,8 +14,8 @@ namespace NodaTime.Test.Annotations
         [Test]
         public void MembersWithTrustedParametersAreNotPublic()
         {
-            var types = typeof(Instant).Assembly.GetTypes();
-            var invalidMembers = types.SelectMany(t => t.GetMembers())
+            var types = typeof(Instant).GetTypeInfo().Assembly.DefinedTypes;
+            var invalidMembers = types.SelectMany(t => t.DeclaredMembers)
                                       .Where(m => GetParameters(m).Any(p => p.IsDefined(typeof(TrustedAttribute), false)))
                                       .Where(InvalidForTrustedParameters)
                                       .ToList();
@@ -25,7 +25,7 @@ namespace NodaTime.Test.Annotations
 
         private static string MemberDebugName(MemberInfo m)
         {
-            return string.Format("{0}.{1}({2})", m.ReflectedType.Name, m.Name,
+            return string.Format("{0}.{1}({2})", m.DeclaringType.Name, m.Name,
                 string.Join(", ", GetParameters(m).Select(p => p.ParameterType)));
         }
 

--- a/src/NodaTime.Test/CalendarSystemTest.cs
+++ b/src/NodaTime.Test/CalendarSystemTest.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using NodaTime.Calendars;
 using NUnit.Framework;
 
@@ -37,7 +38,7 @@ namespace NodaTime.Test
             var localDate = new LocalDate(daysSinceEpoch, calendar);
             Assert.AreEqual(expectedYear, localDate.Year);
 
-            foreach (var property in typeof(LocalDate).GetProperties())
+            foreach (var property in typeof(LocalDate).GetTypeInfo().DeclaredProperties)
             {
                 property.GetValue(localDate, null);
             }

--- a/src/NodaTime.Test/Calendars/BclCalendars.cs
+++ b/src/NodaTime.Test/Calendars/BclCalendars.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Test.Text;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace NodaTime.Test.Calendars
+{
+    /// <summary>
+    /// In the PCL, we can't access specific subclasses of System.Globalization.Calendar.
+    /// We can fetch them from cultures though... and maybe use reflection.
+    /// </summary>
+    public class BclCalendars
+    {
+        private static readonly Dictionary<string, Calendar> calendars
+            = Cultures.AllCultures
+                .SelectMany(culture => new[] { culture.Calendar }.Concat(culture.OptionalCalendars))
+                .GroupBy(calendar => calendar.GetType())
+                .ToDictionary(g => g.Key.GetTypeInfo().Name, g => g.First());
+
+        private static Calendar GetCalendar(string name)
+        {
+            Calendar calendar;
+            if (calendars.TryGetValue(name, out calendar))
+            {
+                return calendar;
+            }
+            // Try to initialize by reflection instead...
+            Type type = typeof(Calendar).GetTypeInfo().Assembly.GetType($"System.Globalization.{name}");
+            return type == null ? null : (Calendar) Activator.CreateInstance(type);
+        }
+
+        public static Calendar Hebrew => GetCalendar("HebrewCalendar");
+        public static Calendar Gregorian => GetCalendar("GregorianCalendar");
+        public static Calendar UmAlQura => GetCalendar("UmAlQuraCalendar");
+        public static Calendar Persian => GetCalendar("PersianCalendar");
+        public static Calendar Julian => GetCalendar("JulianCalendar");
+        public static Calendar Hijri => GetCalendar("HijriCalendar");
+
+
+        /// <summary>
+        /// Tries to work out a roughly-matching calendar system for the given BCL calendar.
+        /// This is needed where we're testing whether days of the week match - even if we can
+        /// get day/month/year values to match without getting the calendar right, the calendar
+        /// affects the day of week.
+        /// </summary>
+        internal static CalendarSystem CalendarSystemForCalendar(Calendar bcl)
+        {
+            // Yes, this is horrible... but the specific calendars aren't available to test
+            // against in the PCL
+            switch (bcl.GetType().Name)
+            {
+                case "GregorianCalendar": return CalendarSystem.Iso;
+                case "HijriCalendar": return CalendarSystem.IslamicBcl;
+                case "HebrewCalendar": return CalendarSystem.HebrewCivil;
+                case "PersianCalendar": return bcl.IsLeapYear(1) ? CalendarSystem.PersianSimple : CalendarSystem.PersianAstronomical;
+                case "UmAlQuraCalendar": return CalendarSystem.UmAlQura;
+                case "JulianCalendar":
+                    return CalendarSystem.Julian;
+                default:
+                    // No idea - we can't test with this calendar...
+                    return null;
+            }
+        }
+    }
+}

--- a/src/NodaTime.Test/Calendars/BclEquivalenceHelper.cs
+++ b/src/NodaTime.Test/Calendars/BclEquivalenceHelper.cs
@@ -2,13 +2,9 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
+using System;
+using System.Globalization;
 
 namespace NodaTime.Test.Calendars
 {
@@ -17,6 +13,11 @@ namespace NodaTime.Test.Calendars
     /// </summary>
     internal static class BclEquivalenceHelper
     {
+        internal static void AssertEquivalent(Calendar bcl, CalendarSystem noda)
+        {
+            AssertEquivalent(bcl, noda, noda.MinYear, noda.MaxYear);
+        }
+
         /// <summary>
         /// Checks that each day from the given start year to the end year (inclusive) is equal
         /// between the BCL and the Noda Time calendar. Additionally, the number of days in each month and year
@@ -27,7 +28,7 @@ namespace NodaTime.Test.Calendars
             // We avoid asking the BCL to create a DateTime on each iteration, simply
             // because the BCL implementation is so slow. Instead, we just check at the start of each month that
             // we're at the date we expect.
-            DateTime bclDate = new DateTime(fromYear, 1, 1, bcl);
+            DateTime bclDate = bcl.ToDateTime(fromYear, 1, 1, 0, 0, 0, 0);
             for (int year = fromYear; year <= toYear; year++)
             {
                 Assert.AreEqual(bcl.GetDaysInYear(year), noda.GetDaysInYear(year), "Year: {0}", year);
@@ -56,7 +57,6 @@ namespace NodaTime.Test.Calendars
                     }
                 }
             }
-
         }
     }
 }

--- a/src/NodaTime.Test/Calendars/EraTest.cs
+++ b/src/NodaTime.Test/Calendars/EraTest.cs
@@ -14,7 +14,8 @@ namespace NodaTime.Test.Calendars
 {
     public class EraTest
     {
-        private static readonly IEnumerable<Era> Eras = typeof(Era).GetProperties(BindingFlags.Public | BindingFlags.Static)
+        private static readonly IEnumerable<Era> Eras = typeof(Era).GetTypeInfo()
+                                                                   .DeclaredProperties // TODO: Only static and public ones...
                                                                    .Where(property => property.PropertyType == typeof(Era))
                                                                    .Select(property => property.GetValue(null, null))
                                                                    .Cast<Era>();

--- a/src/NodaTime.Test/Calendars/HebrewCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/HebrewCalendarSystemTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright 2014 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
+
 using NodaTime.Calendars;
 using NodaTime.Text;
 using NUnit.Framework;
@@ -20,7 +21,7 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void IsLeapYear()
         {
-            var bcl = new HebrewCalendar();
+            var bcl = BclCalendars.Hebrew;
             var minYear = bcl.GetYear(bcl.MinSupportedDateTime);
             var maxYear = bcl.GetYear(bcl.MaxSupportedDateTime);
             var noda = CalendarSystem.HebrewCivil;
@@ -35,11 +36,11 @@ namespace NodaTime.Test.Calendars
         /// This tests every day for the BCL-supported Hebrew calendar range, testing various aspects of each date,
         /// using the civil month numbering.
         /// </summary>
-        [Test, Timeout(300000)] // Can take a long time under NCrunch.
+        [Test]
         [Category("Slow")]
         public void BclThroughHistory_Civil()
         {
-            Calendar bcl = new HebrewCalendar();
+            var bcl = BclCalendars.Hebrew;
             var noda = CalendarSystem.HebrewCivil;
 
             // The min supported date/time starts part way through the year
@@ -54,10 +55,10 @@ namespace NodaTime.Test.Calendars
         /// This tests every day for the BCL-supported Hebrew calendar range, testing various aspects of each date,
         /// using the scriptural month numbering.
         /// </summary>
-        [Test, Timeout(300000)] // Can take a long time under NCrunch.
+        [Test]
         public void BclThroughHistory_Scriptural()
         {
-            Calendar bcl = new HebrewCalendar();
+            var bcl = BclCalendars.Hebrew;
             var noda = CalendarSystem.HebrewScriptural;
 
             // The min supported date/time starts part way through the year
@@ -77,7 +78,7 @@ namespace NodaTime.Test.Calendars
                         "Year: {0}; Month: {1} (civil)", year, civilMonth);
                     for (int day = 1; day < bcl.GetDaysInMonth(year, civilMonth); day++)
                     {
-                        DateTime bclDate = new DateTime(year, civilMonth, day, bcl);
+                        DateTime bclDate = bcl.ToDateTime(year, civilMonth, day, 0, 0, 0, 0);
                         LocalDate nodaDate = new LocalDate(year, scripturalMonth, day, noda);
                         Assert.AreEqual(bclDate, nodaDate.AtMidnight().ToDateTimeUnspecified(), "{0}-{1}-{2}", year, scripturalMonth, day);
                         Assert.AreEqual(nodaDate, LocalDateTime.FromDateTime(bclDate, noda).Date);

--- a/src/NodaTime.Test/Calendars/HebrewEcclesiasticalCalculatorTest.cs
+++ b/src/NodaTime.Test/Calendars/HebrewEcclesiasticalCalculatorTest.cs
@@ -13,7 +13,7 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void DaysInYear()
         {
-            var bcl = new HebrewCalendar();
+            var bcl = BclCalendars.Hebrew;
             var minYear = bcl.GetYear(bcl.MinSupportedDateTime);
             var maxYear = bcl.GetYear(bcl.MaxSupportedDateTime);
 
@@ -26,7 +26,7 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void DaysInMonth()
         {
-            var bcl = new HebrewCalendar();
+            var bcl = BclCalendars.Hebrew;
             // Not all months in the min/max years are supported
             var minYear = bcl.GetYear(bcl.MinSupportedDateTime) + 1;
             var maxYear = bcl.GetYear(bcl.MaxSupportedDateTime) - 1;

--- a/src/NodaTime.Test/Calendars/IslamicCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/IslamicCalendarSystemTest.cs
@@ -267,8 +267,8 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void BclUsesAstronomicalEpoch()
         {
-            Calendar hijri = new HijriCalendar();
-            DateTime bclDirect = new DateTime(1, 1, 1, 0, 0, 0, 0, hijri, DateTimeKind.Unspecified);
+            Calendar hijri = BclCalendars.Hijri;
+            DateTime bclDirect = hijri.ToDateTime(1, 1, 1, 0, 0, 0, 0);
 
             CalendarSystem julianCalendar = CalendarSystem.Julian;
             LocalDate julianIslamicEpoch = new LocalDate(622, 7, 15, julianCalendar);
@@ -280,8 +280,8 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void SampleDateBclCompatibility()
         {
-            Calendar hijri = new HijriCalendar();
-            DateTime bclDirect = new DateTime(1302, 10, 15, 0, 0, 0, 0, hijri, DateTimeKind.Unspecified);
+            Calendar hijri = BclCalendars.Hijri;
+            DateTime bclDirect = hijri.ToDateTime(1302, 10, 15, 0, 0, 0, 0);
 
             CalendarSystem islamicCalendar = CalendarSystem.IslamicBcl;
             LocalDate iso = new LocalDate(1302, 10, 15, islamicCalendar);
@@ -292,13 +292,13 @@ namespace NodaTime.Test.Calendars
         /// <summary>
         /// This tests every day for 9000 (ISO) years, to check that it always matches the year, month and day.
         /// </summary>
-        [Test, Timeout(180000)] // Can take a long time under NCrunch.
+        [Test]
         [Category("Slow")]
         public void BclThroughHistory()
         {
-            var bcl = new HijriCalendar();
+            var bcl = BclCalendars.Hijri;
             var noda = CalendarSystem.IslamicBcl;
-            BclEquivalenceHelper.AssertEquivalent(bcl, noda, noda.MinYear, noda.MaxYear);
+            BclEquivalenceHelper.AssertEquivalent(bcl, noda);
         }
 
         [Test]

--- a/src/NodaTime.Test/Calendars/PersianCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/PersianCalendarSystemTest.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright 2013 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
+
 using System;
 using System.Globalization;
 using NodaTime.Calendars;
+using NodaTime.Test.Text;
+
 using NUnit.Framework;
 
 namespace NodaTime.Test.Calendars
@@ -13,16 +16,15 @@ namespace NodaTime.Test.Calendars
     /// </summary>
     public class PersianCalendarSystemTest
     {
-        [Test, Timeout(300000)] // Can take a long time under NCrunch.
+        [Test]
         [Category("Slow")]
         public void BclThroughHistory()
         {
-            Calendar bcl = new PersianCalendar();
-            // The "right" BCL equivalent to use depends on the version of .NET... pick it appropriately here.
-            CalendarSystem noda = bcl.IsLeapYear(1) ? CalendarSystem.PersianSimple : CalendarSystem.PersianAstronomical;
+            Calendar bcl = BclCalendars.Persian;
+            CalendarSystem noda = BclCalendars.CalendarSystemForCalendar(bcl);
             // Note: Noda Time stops in 9377, whereas the BCL goes into the start of 9378. This is because
             // Noda Time ensures that the whole year is valid.
-            BclEquivalenceHelper.AssertEquivalent(bcl, noda, noda.MinYear, noda.MaxYear);
+            BclEquivalenceHelper.AssertEquivalent(bcl, noda);
         }
 
         /// <summary>

--- a/src/NodaTime.Test/Calendars/UmAlQuraYearMonthDayCalculatorTest.cs
+++ b/src/NodaTime.Test/Calendars/UmAlQuraYearMonthDayCalculatorTest.cs
@@ -11,59 +11,10 @@ namespace NodaTime.Test.Calendars
 {
     public class UmAlQuraYearMonthDayCalculatorTest
     {
-        // TODO: See how much of this can be done with BclEquivalenceHelper.
-        // TODO: FIXME with the new core tests stuff...
-        private static readonly Calendar BclCalendar = GetBclCalendar();
-
-        private static Calendar GetBclCalendar()
-        {
-            // Always get it with reflection in the test, just for simplicity.
-            try
-            {
-                var type = typeof(Calendar).Assembly.GetType("System.Globalization.UmAlQuraCalendar");
-                if (type == null)
-                {
-                    return null;
-                }
-                return (Calendar) Activator.CreateInstance(type);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
         [Test]
-        public void GetDaysInMonth()
+        public void BclEquivalence()
         {
-            var calculator = new UmAlQuraYearMonthDayCalculator();
-            for (int year = calculator.MinYear; year <= calculator.MaxYear; year++)
-            {
-                for (int month = 1; month <= 12; month++)
-                {
-                    Assert.AreEqual(BclCalendar.GetDaysInMonth(year, month), calculator.GetDaysInMonth(year, month), "year={0}; month={1}", year, month);
-                }
-            }
-        }
-
-        [Test]
-        public void GetDaysInYear()
-        {
-            var calculator = new UmAlQuraYearMonthDayCalculator();
-            for (int year = calculator.MinYear; year <= calculator.MaxYear; year++)
-            {
-                Assert.AreEqual(BclCalendar.GetDaysInYear(year), calculator.GetDaysInYear(year), "year={0}", year);
-            }
-        }
-
-        [Test]
-        public void IsLeapYear()
-        {
-            var calculator = new UmAlQuraYearMonthDayCalculator();
-            for (int year = calculator.MinYear; year <= calculator.MaxYear; year++)
-            {
-                Assert.AreEqual(BclCalendar.IsLeapYear(year), calculator.IsLeapYear(year), "year={0}", year);
-            }
+            BclEquivalenceHelper.AssertEquivalent(BclCalendars.UmAlQura, CalendarSystem.UmAlQura);
         }
 
         [Test]
@@ -73,7 +24,7 @@ namespace NodaTime.Test.Calendars
             var calculator = new UmAlQuraYearMonthDayCalculator();
             for (int year = calculator.MinYear; year <= calculator.MaxYear; year++)
             {
-                var bcl = new DateTime(year, 1, 1, BclCalendar);
+                var bcl = BclCalendars.UmAlQura.ToDateTime(year, 1, 1, 0, 0, 0, 0);
                 var days = (bcl - new DateTime(1970, 1, 1)).Days;
                 Assert.AreEqual(days, calculator.GetStartOfYearInDays(year), "year={0}", year);
             }

--- a/src/NodaTime.Test/CultureSaver.cs
+++ b/src/NodaTime.Test/CultureSaver.cs
@@ -9,8 +9,8 @@ using System.Threading;
 namespace NodaTime.Test
 {
     /// <summary>
-    ///   Provides a simple method for setting the culture of a thread so it can be reset
-    ///   to what it was. Designed to be used in a <c>using</c> statement.
+    /// Provides a simple method for setting the culture of a thread so it can be reset
+    /// to what it was. Designed to be used in a <c>using</c> statement.
     /// </summary>
     /// <example>
     ///   using (CultureSaver.SetUiCulture(new CultureInfo("en-US"))) {
@@ -24,82 +24,94 @@ namespace NodaTime.Test
     /// </remarks>
     public static class CultureSaver
     {
+        // Abstractions over Thread.CurrentThread.CurrentCulture / CultureInfo.CurrentCulture etc.
+
+#if PCL
+        private static CultureInfo CurrentCulture
+        {
+            get { return CultureInfo.DefaultThreadCurrentCulture; }
+            set { CultureInfo.DefaultThreadCurrentCulture = value; }
+        }
+
+        private static CultureInfo CurrentUICulture
+        {
+            get { return CultureInfo.DefaultThreadCurrentUICulture; }
+            set { CultureInfo.DefaultThreadCurrentUICulture = value; }
+        }
+#else
+        private static CultureInfo CurrentCulture
+        {
+            get { return Thread.CurrentThread.CurrentCulture; }
+            set { Thread.CurrentThread.CurrentCulture  = value; }
+        }
+
+        private static CultureInfo CurrentUICulture
+        {
+            get { return Thread.CurrentThread.CurrentUICulture; }
+            set { Thread.CurrentThread.CurrentUICulture = value; }
+        }
+#endif
+
         /// <summary>
-        ///   Sets the basic culture.
+        /// Sets the basic culture.
         /// </summary>
         /// <param name="newCultureInfo">The new culture info.</param>
         /// <returns>An <see cref="IDisposable" /> so the culture can be reset.</returns>
-        public static IDisposable SetBasicCulture(CultureInfo newCultureInfo)
-        {
-            return new BasicSaver(newCultureInfo);
-        }
+        public static IDisposable SetBasicCulture(CultureInfo newCultureInfo) => new BasicSaver(newCultureInfo);
 
         /// <summary>
-        ///   Sets the UI culture of the current thread.
+        /// Sets the UI culture of the current thread.
         /// </summary>
         /// <param name="newCultureInfo">The new culture info.</param>
         /// <returns>An <see cref="IDisposable" /> so the culture can be reset.</returns>
-        public static IDisposable SetUiCulture(CultureInfo newCultureInfo)
-        {
-            return new UiSaver(newCultureInfo);
-        }
+        public static IDisposable SetUiCulture(CultureInfo newCultureInfo) => new UiSaver(newCultureInfo);
 
         /// <summary>
-        ///   Sets both the UI and basic cultures of the current thread.
+        /// Sets both the UI and basic cultures of the current thread.
         /// </summary>
         /// <param name="newCultureInfo">The new culture info.</param>
         /// <returns>An <see cref="IDisposable" /> so the culture can be reset.</returns>
-        public static IDisposable SetCultures(CultureInfo newCultureInfo)
-        {
-            return new BothSaver(newCultureInfo, newCultureInfo);
-        }
+        public static IDisposable SetCultures(CultureInfo newCultureInfo) => new BothSaver(newCultureInfo, newCultureInfo);
 
         /// <summary>
-        ///   Sets both the UI and basic cultures of the current thread.
+        /// Sets both the UI and basic cultures of the current thread.
         /// </summary>
         /// <param name="newCultureInfo">The new culture info.</param>
         /// <param name="newUiCultureInfo">The new UI culture info.</param>
         /// <returns>An <see cref="IDisposable" /> so the culture can be reset.</returns>
         public static IDisposable SetCultures(CultureInfo newCultureInfo, CultureInfo newUiCultureInfo)
-        {
-            return new BothSaver(newCultureInfo, newUiCultureInfo);
-        }
+            => new BothSaver(newCultureInfo, newUiCultureInfo);
 
-        #region Nested type: BasicSaver
         /// <summary>
-        ///   Provides the <see cref="IDisposable" /> for saving the original basic culture and resetting
-        ///   it back.
+        /// Provides the <see cref="IDisposable" /> for saving the original basic culture and resetting
+        /// it back.
         /// </summary>
         private sealed class BasicSaver : IDisposable
         {
             private readonly CultureInfo oldCulture;
 
             /// <summary>
-            ///   Initializes a new instance of the <see cref="BasicSaver" /> class.
+            /// Initializes a new instance of the <see cref="BasicSaver" /> class.
             /// </summary>
             /// <param name="newCulture">The new basic culture to set.</param>
             public BasicSaver(CultureInfo newCulture)
             {
-                oldCulture = Thread.CurrentThread.CurrentCulture;
-                Thread.CurrentThread.CurrentCulture = newCulture;
+                oldCulture = CurrentCulture;
+                CurrentCulture = newCulture;
             }
 
-            #region IDisposable Members
             /// <summary>
-            ///   Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+            /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
             /// </summary>
             public void Dispose()
             {
-                Thread.CurrentThread.CurrentCulture = oldCulture;
+                CurrentCulture = oldCulture;
             }
-            #endregion
         }
-        #endregion
 
-        #region Nested type: BothSaver
         /// <summary>
-        ///   Provides the <see cref="IDisposable" /> for saving the original cultures and resetting
-        ///   them back.
+        /// Provides the <see cref="IDisposable" /> for saving the original cultures and resetting
+        /// them back.
         /// </summary>
         private sealed class BothSaver : IDisposable
         {
@@ -107,61 +119,53 @@ namespace NodaTime.Test
             private readonly CultureInfo oldUiCulture;
 
             /// <summary>
-            ///   Initializes a new instance of the <see cref="UiSaver" /> class.
+            /// Initializes a new instance of the <see cref="UiSaver" /> class.
             /// </summary>
             /// <param name="newCulture">The new basic culture to set.</param>
             /// <param name="newUiCulture">The new UI culture to set.</param>
             public BothSaver(CultureInfo newCulture, CultureInfo newUiCulture)
             {
-                oldCulture = Thread.CurrentThread.CurrentCulture;
-                oldUiCulture = Thread.CurrentThread.CurrentUICulture;
+                oldCulture = CurrentCulture;
+                oldUiCulture = CurrentUICulture;
 
-                Thread.CurrentThread.CurrentCulture = newCulture;
-                Thread.CurrentThread.CurrentUICulture = newUiCulture;
+                CurrentCulture = newCulture;
+                CurrentUICulture = newUiCulture;
             }
 
-            #region IDisposable Members
             /// <summary>
-            ///   Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+            /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
             /// </summary>
             public void Dispose()
             {
-                Thread.CurrentThread.CurrentCulture = oldCulture;
-                Thread.CurrentThread.CurrentUICulture = oldUiCulture;
+                CurrentCulture = oldCulture;
+                CurrentUICulture = oldUiCulture;
             }
-            #endregion
         }
-        #endregion
-
-        #region Nested type: UiSaver
         /// <summary>
-        ///   Provides the <see cref="IDisposable" /> for saving the original UI culture and resetting
-        ///   it back.
+        /// Provides the <see cref="IDisposable" /> for saving the original UI culture and resetting
+        /// it back.
         /// </summary>
         private sealed class UiSaver : IDisposable
         {
             private readonly CultureInfo oldCulture;
 
             /// <summary>
-            ///   Initializes a new instance of the <see cref="UiSaver" /> class.
+            /// Initializes a new instance of the <see cref="UiSaver" /> class.
             /// </summary>
             /// <param name="newCulture">The new UI culture to set.</param>
             public UiSaver(CultureInfo newCulture)
             {
-                oldCulture = Thread.CurrentThread.CurrentUICulture;
-                Thread.CurrentThread.CurrentUICulture = newCulture;
+                oldCulture = CurrentUICulture;
+                CurrentUICulture = newCulture;
             }
 
-            #region IDisposable Members
             /// <summary>
             ///   Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
             /// </summary>
             public void Dispose()
             {
-                Thread.CurrentThread.CurrentUICulture = oldCulture;
+                CurrentUICulture = oldCulture;
             }
-            #endregion
         }
-        #endregion
     }
 }

--- a/src/NodaTime.Test/Globalization/FailingCultureInfo.cs
+++ b/src/NodaTime.Test/Globalization/FailingCultureInfo.cs
@@ -8,7 +8,7 @@ using System.Globalization;
 namespace NodaTime.Test.Globalization
 {
     /// <summary>
-    /// Throws an exception if called. This forces the testing code set or pass a valid culture in all
+    /// Throws an exception if called. This forces the testing code to set or pass a valid culture in all
     /// tests. The tests cannot be guaranteed to work if the culture is not set as formatting and parsing
     /// are culture dependent.
     /// </summary>
@@ -47,13 +47,7 @@ namespace NodaTime.Test.Globalization
             }
         }
 
-        public override string Name
-        {
-            get
-            {
-                return "Failing";
-            }
-        }
+        public override string Name => "Failing";
 
         public override object GetFormat(Type formatType)
         {

--- a/src/NodaTime.Test/Globalization/NodaFormatInfoTest.cs
+++ b/src/NodaTime.Test/Globalization/NodaFormatInfoTest.cs
@@ -15,8 +15,8 @@ namespace NodaTime.Test.Globalization
 {
     public class NodaFormatInfoTest
     {
-        private readonly CultureInfo enUs = CultureInfo.GetCultureInfo("en-US");
-        private readonly CultureInfo enGb = CultureInfo.GetCultureInfo("en-GB");
+        private static readonly CultureInfo enUs = Cultures.GetCultureInfo("en-US");
+        private static readonly CultureInfo enGb = Cultures.GetCultureInfo("en-GB");
 
         private sealed class EmptyFormatProvider : IFormatProvider
         {
@@ -55,7 +55,9 @@ namespace NodaTime.Test.Globalization
             var original = new CultureInfo("en-US");
             var clone = (CultureInfo) original.Clone();
             Assert.AreEqual(original.Name, clone.Name);
-            clone.DateTimeFormat.DateSeparator = "@@@";
+            var dayNames = clone.DateTimeFormat.DayNames;
+            dayNames[1] = "@@@";
+            clone.DateTimeFormat.DayNames = dayNames;
 
             // Fool Noda Time into believing both are read-only, so it can use a cache...
             original = CultureInfo.ReadOnly(original);
@@ -63,8 +65,10 @@ namespace NodaTime.Test.Globalization
 
             var nodaOriginal = NodaFormatInfo.GetFormatInfo(original);
             var nodaClone = NodaFormatInfo.GetFormatInfo(clone);
-            Assert.AreEqual(original.DateTimeFormat.DateSeparator, nodaOriginal.DateSeparator);
-            Assert.AreEqual(clone.DateTimeFormat.DateSeparator, nodaClone.DateSeparator);
+            Assert.AreEqual(original.DateTimeFormat.DayNames[1], nodaOriginal.LongDayNames[1]);
+            Assert.AreEqual(clone.DateTimeFormat.DayNames[1], nodaClone.LongDayNames[1]);
+            // Just check we made a difference...
+            Assert.AreNotEqual(nodaOriginal.LongDayNames[1], nodaClone.LongDayNames[1]);
         }
 
         [Test]
@@ -146,12 +150,12 @@ namespace NodaTime.Test.Globalization
             using (CultureSaver.SetCultures(enUs, FailingCultureInfo.Instance))
             {
                 var info = NodaFormatInfo.GetInstance(null);
-                Assert.AreEqual(Thread.CurrentThread.CurrentCulture, info.CultureInfo);
+                Assert.AreEqual(CultureInfo.CurrentCulture, info.CultureInfo);
             }
             using (CultureSaver.SetCultures(enGb, FailingCultureInfo.Instance))
             {
                 var info = NodaFormatInfo.GetInstance(null);
-                Assert.AreEqual(Thread.CurrentThread.CurrentCulture, info.CultureInfo);
+                Assert.AreEqual(CultureInfo.CurrentCulture, info.CultureInfo);
             }
         }
 

--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -10,6 +10,7 @@ using NodaTime.Text;
 using NodaTime.TimeZones;
 using NodaTime.Utility;
 using NUnit.Framework;
+using NodaTime.Test.Calendars;
 
 namespace NodaTime.Test
 {
@@ -93,7 +94,8 @@ namespace NodaTime.Test
         [Test]
         public void DateTime_Roundtrip_OtherCalendarInBcl()
         {
-            DateTime original = new DateTime(1376, 6, 19, new HijriCalendar());
+            var bcl = BclCalendars.Hijri;
+            DateTime original = bcl.ToDateTime(1376, 6, 19, 0, 0, 0, 0);
             LocalDateTime noda = LocalDateTime.FromDateTime(original);
             // The DateTime only knows about the ISO version...
             Assert.AreNotEqual(1376, noda.Year);

--- a/src/NodaTime.Test/OffsetDateTimeTest.cs
+++ b/src/NodaTime.Test/OffsetDateTimeTest.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Linq;
 using NodaTime.Text;
 using NUnit.Framework;
+using System.Reflection;
 
 namespace NodaTime.Test
 {
@@ -24,10 +25,12 @@ namespace NodaTime.Test
 
             OffsetDateTime odt = new OffsetDateTime(local, offset);
 
-            var localDateTimePropertyNames = typeof(LocalDateTime).GetProperties()
+            var localDateTimePropertyNames = typeof(LocalDateTime).GetTypeInfo()
+                                                                  .DeclaredProperties
                                                                   .Select(p => p.Name)
                                                                   .ToList();
-            var commonProperties = typeof(OffsetDateTime).GetProperties()
+            var commonProperties = typeof(OffsetDateTime).GetTypeInfo()
+                                                         .DeclaredProperties
                                                          .Where(p => localDateTimePropertyNames.Contains(p.Name));
             foreach (var property in commonProperties)
             {

--- a/src/NodaTime.Test/OffsetTest.cs
+++ b/src/NodaTime.Test/OffsetTest.cs
@@ -3,10 +3,13 @@
 // as found in the LICENSE.txt file.
 
 using System;
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using NodaTime.Text;
 using NUnit.Framework;
+
+#if !PCL
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+#endif
 
 namespace NodaTime.Test
 {

--- a/src/NodaTime.Test/Program.cs
+++ b/src/NodaTime.Test/Program.cs
@@ -1,4 +1,6 @@
 using NUnitLite;
+using System;
+using System.Reflection;
 
 namespace NodaTime.Test
 {

--- a/src/NodaTime.Test/TestHelper.cs
+++ b/src/NodaTime.Test/TestHelper.cs
@@ -5,12 +5,16 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Serialization;
 using NUnit.Framework;
 using System.Linq;
+using System.Reflection;
+
+#if !PCL
+using System.Runtime.Serialization.Formatters.Binary;
+#endif
 
 namespace NodaTime.Test
 {
@@ -311,7 +315,7 @@ namespace NodaTime.Test
             // Comparisons only involving equal values
             if (greaterThan != null)
             {
-                if (!type.IsValueType)
+                if (!type.GetTypeInfo().IsValueType)
                 {
                     Assert.True((bool) greaterThan.Invoke(null, new object[] { value, null }), "value > null");
                     Assert.False((bool) greaterThan.Invoke(null, new object[] { null, value }), "null > value");
@@ -322,7 +326,7 @@ namespace NodaTime.Test
             }
             if (lessThan != null)
             {
-                if (!type.IsValueType)
+                if (!type.GetTypeInfo().IsValueType)
                 {
                     Assert.False((bool) lessThan.Invoke(null, new object[] { value, null }), "value < null");
                     Assert.True((bool) lessThan.Invoke(null, new object[] { null, value }), "null < value");
@@ -372,7 +376,7 @@ namespace NodaTime.Test
             // First the comparisons with equal values
             if (greaterThanOrEqual != null)
             {
-                if (!type.IsValueType)
+                if (!type.GetTypeInfo().IsValueType)
                 {
                     Assert.True((bool) greaterThanOrEqual.Invoke(null, new object[] { value, null }), "value >= null");
                     Assert.False((bool) greaterThanOrEqual.Invoke(null, new object[] { null, value }), "null >= value");
@@ -383,7 +387,7 @@ namespace NodaTime.Test
             }
             if (lessThanOrEqual != null)
             {
-                if (!type.IsValueType)
+                if (!type.GetTypeInfo().IsValueType)
                 {
                     Assert.False((bool) lessThanOrEqual.Invoke(null, new object[] { value, null }), "value <= null");
                     Assert.True((bool) lessThanOrEqual.Invoke(null, new object[] { null, value }), "null <= value");
@@ -425,7 +429,7 @@ namespace NodaTime.Test
             var equality = type.GetMethod("op_Equality", new[] { type, type });
             if (equality != null)
             {
-                if (!type.IsValueType)
+                if (!type.GetTypeInfo().IsValueType)
                 {
                     Assert.True((bool)equality.Invoke(null, new object[] { null, null }), "null == null");
                     Assert.False((bool)equality.Invoke(null, new object[] { value, null }), "value == null");
@@ -439,7 +443,7 @@ namespace NodaTime.Test
             var inequality = type.GetMethod("op_Inequality", new[] { type, type });
             if (inequality != null)
             {
-                if (!type.IsValueType)
+                if (!type.GetTypeInfo().IsValueType)
                 {
                     Assert.False((bool)inequality.Invoke(null, new object[] { null, null }), "null != null");
                     Assert.True((bool)inequality.Invoke(null, new object[] { value, null }), "value != null");

--- a/src/NodaTime.Test/Text/Cultures.cs
+++ b/src/NodaTime.Test/Text/Cultures.cs
@@ -15,15 +15,85 @@ namespace NodaTime.Test.Text
     /// </summary>
     internal static class Cultures
     {
-        // Force the cultures to be read-only for tests, to take advantage of caching. Our Continuous Integration system
-        // is very slow at reading resources (in the NodaFormatInfo constructor).
-        // Note: R# suggests using a method group conversion for the Select call here, which is fine with the C# 4 compiler,
-        // but doesn't work with the C# 3 compiler (which doesn't have quite as good type inference).
-        internal static readonly IEnumerable<CultureInfo> AllCultures = CultureInfo.GetCultures(CultureTypes.SpecificCultures)
+        // Force the cultures to be read-only for tests, to take advantage of caching. Note that on .NET Core,
+        // CultureInfo.GetCultures doesn't exist, so we have a big long list of cultures, generated against
+        // .NET 4.6.
+        internal static readonly IEnumerable<CultureInfo> AllCultures =
+#if PCL
+            new[] {
+                "aa-DJ", "aa-ER", "aa-ET", "af-NA", "af-ZA", "agq-CM", "ak-GH", "am-ET",
+                "ar-001", "ar-AE", "ar-BH", "ar-DJ", "ar-DZ", "ar-EG", "ar-ER", "ar-IL",
+                "ar-IQ", "ar-JO", "ar-KM", "ar-KW", "ar-LB", "ar-LY", "ar-MA", "ar-MR",
+                "ar-OM", "ar-PS", "ar-QA", "ar-SA", "ar-SD", "ar-SO", "ar-SS", "ar-SY",
+                "ar-TD", "ar-TN", "ar-YE", "arn-CL", "as-IN", "asa-TZ", "ast-ES", "az-Cyrl-AZ",
+                "az-Latn-AZ", "ba-RU", "bas-CM", "be-BY", "bem-ZM", "bez-TZ", "bg-BG", "bin-NG",
+                "bm-Latn-ML", "bn-BD", "bn-IN", "bo-CN", "bo-IN", "br-FR", "brx-IN", "bs-Cyrl-BA",
+                "bs-Latn-BA", "byn-ER", "ca-AD", "ca-ES", "ca-ES-valencia", "ca-FR", "ca-IT", "cgg-UG",
+                "chr-Cher-US", "co-FR", "cs-CZ", "cy-GB", "da-DK", "da-GL", "dav-KE", "de-AT",
+                "de-BE", "de-CH", "de-DE", "de-LI", "de-LU", "dje-NE", "dsb-DE", "dua-CM",
+                "dv-MV", "dyo-SN", "dz-BT", "ebu-KE", "ee-GH", "ee-TG", "el-CY", "el-GR",
+                "en-001", "en-029", "en-150", "en-AG", "en-AI", "en-AS", "en-AU", "en-BB",
+                "en-BE", "en-BM", "en-BS", "en-BW", "en-BZ", "en-CA", "en-CC", "en-CK",
+                "en-CM", "en-CX", "en-DM", "en-ER", "en-FJ", "en-FK", "en-FM", "en-GB",
+                "en-GD", "en-GG", "en-GH", "en-GI", "en-GM", "en-GU", "en-GY", "en-HK",
+                "en-ID", "en-IE", "en-IM", "en-IN", "en-IO", "en-JE", "en-JM", "en-KE",
+                "en-KI", "en-KN", "en-KY", "en-LC", "en-LR", "en-LS", "en-MG", "en-MH",
+                "en-MO", "en-MP", "en-MS", "en-MT", "en-MU", "en-MW", "en-MY", "en-NA",
+                "en-NF", "en-NG", "en-NR", "en-NU", "en-NZ", "en-PG", "en-PH", "en-PK",
+                "en-PN", "en-PR", "en-PW", "en-RW", "en-SB", "en-SC", "en-SD", "en-SG",
+                "en-SH", "en-SL", "en-SS", "en-SX", "en-SZ", "en-TC", "en-TK", "en-TO",
+                "en-TT", "en-TV", "en-TZ", "en-UG", "en-UM", "en-US", "en-VC", "en-VG",
+                "en-VI", "en-VU", "en-WS", "en-ZA", "en-ZM", "en-ZW", "eo-001", "es-419",
+                "es-AR", "es-BO", "es-CL", "es-CO", "es-CR", "es-CU", "es-DO", "es-EC",
+                "es-ES", "es-GQ", "es-GT", "es-HN", "es-MX", "es-NI", "es-PA", "es-PE",
+                "es-PH", "es-PR", "es-PY", "es-SV", "es-US", "es-UY", "es-VE", "et-EE",
+                "eu-ES", "ewo-CM", "fa-IR", "ff-CM", "ff-GN", "ff-Latn-SN", "ff-MR", "ff-NG",
+                "fi-FI", "fil-PH", "fo-FO", "fr-029", "fr-BE", "fr-BF", "fr-BI", "fr-BJ",
+                "fr-BL", "fr-CA", "fr-CD", "fr-CF", "fr-CG", "fr-CH", "fr-CI", "fr-CM",
+                "fr-DJ", "fr-DZ", "fr-FR", "fr-GA", "fr-GF", "fr-GN", "fr-GP", "fr-GQ",
+                "fr-HT", "fr-KM", "fr-LU", "fr-MA", "fr-MC", "fr-MF", "fr-MG", "fr-ML",
+                "fr-MQ", "fr-MR", "fr-MU", "fr-NC", "fr-NE", "fr-PF", "fr-PM", "fr-RE",
+                "fr-RW", "fr-SC", "fr-SN", "fr-SY", "fr-TD", "fr-TG", "fr-TN", "fr-VU",
+                "fr-WF", "fr-YT", "fur-IT", "fy-NL", "ga-IE", "gd-GB", "gl-ES", "gn-PY",
+                "gsw-CH", "gsw-FR", "gsw-LI", "gu-IN", "guz-KE", "gv-IM", "ha-Latn-GH", "ha-Latn-NE",
+                "ha-Latn-NG", "haw-US", "he-IL", "hi-IN", "hr-BA", "hr-HR", "hsb-DE", "hu-HU",
+                "hy-AM", "ia-001", "ia-FR", "ibb-NG", "id-ID", "ig-NG", "ii-CN", "is-IS",
+                "it-CH", "it-IT", "it-SM", "iu-Cans-CA", "iu-Latn-CA", "ja-JP", "jgo-CM", "jmc-TZ",
+                "jv-Java-ID", "jv-Latn-ID", "ka-GE", "kab-DZ", "kam-KE", "kde-TZ", "kea-CV", "khq-ML",
+                "ki-KE", "kk-KZ", "kkj-CM", "kl-GL", "kln-KE", "km-KH", "kn-IN", "ko-KR",
+                "kok-IN", "kr-NG", "ks-Arab-IN", "ks-Deva-IN", "ksb-TZ", "ksf-CM", "ksh-DE", "ku-Arab-IQ",
+                "kw-GB", "ky-KG", "la-001", "lag-TZ", "lb-LU", "lg-UG", "lkt-US", "ln-AO",
+                "ln-CD", "ln-CF", "ln-CG", "lo-LA", "lt-LT", "lu-CD", "luo-KE", "luy-KE",
+                "lv-LV", "mas-KE", "mas-TZ", "mer-KE", "mfe-MU", "mg-MG", "mgh-MZ", "mgo-CM",
+                "mi-NZ", "mk-MK", "ml-IN", "mn-MN", "mn-Mong-CN", "mn-Mong-MN", "mni-IN", "moh-CA",
+                "mr-IN", "ms-BN", "ms-MY", "ms-SG", "mt-MT", "mua-CM", "my-MM", "naq-NA",
+                "nb-NO", "nb-SJ", "nd-ZW", "ne-IN", "ne-NP", "nl-AW", "nl-BE", "nl-BQ",
+                "nl-CW", "nl-NL", "nl-SR", "nl-SX", "nmg-CM", "nn-NO", "nnh-CM", "nqo-GN",
+                "nr-ZA", "nso-ZA", "nus-SS", "nyn-UG", "oc-FR", "om-ET", "om-KE", "or-IN",
+                "os-GE", "os-RU", "pa-Arab-PK", "pa-IN", "pap-029", "pl-PL", "prs-AF", "ps-AF",
+                "pt-AO", "pt-BR", "pt-CV", "pt-GW", "pt-MO", "pt-MZ", "pt-PT", "pt-ST",
+                "pt-TL", "quc-Latn-GT", "quz-BO", "quz-EC", "quz-PE", "rm-CH", "rn-BI", "ro-MD",
+                "ro-RO", "rof-TZ", "ru-BY", "ru-KG", "ru-KZ", "ru-MD", "ru-RU", "ru-UA",
+                "rw-RW", "rwk-TZ", "sa-IN", "sah-RU", "saq-KE", "sbp-TZ", "sd-Arab-PK", "sd-Deva-IN",
+                "se-FI", "se-NO", "se-SE", "seh-MZ", "ses-ML", "sg-CF", "shi-Latn-MA", "shi-Tfng-MA",
+                "si-LK", "sk-SK", "sl-SI", "sma-NO", "sma-SE", "smj-NO", "smj-SE", "smn-FI",
+                "sms-FI", "sn-Latn-ZW", "so-DJ", "so-ET", "so-KE", "so-SO", "sq-AL", "sq-MK",
+                "sq-XK", "sr-Cyrl-BA", "sr-Cyrl-ME", "sr-Cyrl-RS", "sr-Cyrl-XK", "sr-Latn-BA", "sr-Latn-ME", "sr-Latn-RS",
+                "sr-Latn-XK", "ss-SZ", "ss-ZA", "ssy-ER", "st-LS", "st-ZA", "sv-AX", "sv-FI",
+                "sv-SE", "sw-CD", "sw-KE", "sw-TZ", "sw-UG", "swc-CD", "syr-SY", "ta-IN",
+                "ta-LK", "ta-MY", "ta-SG", "te-IN", "teo-KE", "teo-UG", "tg-Cyrl-TJ", "th-TH",
+                "ti-ER", "ti-ET", "tig-ER", "tk-TM", "tn-BW", "tn-ZA", "to-TO", "tr-CY",
+                "tr-TR", "ts-ZA", "tt-RU", "twq-NE", "tzm-Arab-MA", "tzm-Latn-DZ", "tzm-Latn-MA", "tzm-Tfng-MA",
+                "ug-CN", "uk-UA", "ur-IN", "ur-PK", "uz-Arab-AF", "uz-Cyrl-UZ", "uz-Latn-UZ", "vai-Latn-LR",
+                "vai-Vaii-LR", "ve-ZA", "vi-VN", "vo-001", "vun-TZ", "wae-CH", "wal-ET", "wo-SN",
+                "xh-ZA", "xog-UG", "yav-CM", "yi-001", "yo-BJ", "yo-NG", "zgh-Tfng-MA", "zh-CN"
+            }.Select(name => new CultureInfo(name))
+#else
+            CultureInfo.GetCultures(CultureTypes.SpecificCultures)
+#endif
             .Where(culture => !RuntimeFailsToLookupResourcesForCulture(culture))
-            .Select(culture => FixCultureIfDateTimeFormatBroken(culture))
             .Where(culture => !MonthNamesCompareEqual(culture))
-            .Select(culture => CultureInfo.ReadOnly(culture))
+            .Select(CultureInfo.ReadOnly)
             .ToList();
         // Some tests don't run nicely on Mono, e.g. as they have characters we don't expect in their long/short patterns.
         // Pretend we have no real cultures, for the sake of these tests. Having no entries in this test source causes
@@ -33,20 +103,57 @@ namespace NodaTime.Test.Text
 
         internal static readonly CultureInfo Invariant = CultureInfo.InvariantCulture;
         internal static readonly CultureInfo EnUs = CultureInfo.ReadOnly(new CultureInfo("en-US"));
-        internal static readonly CultureInfo FrFr = CultureInfo.ReadOnly(new CultureInfo("fr-FR"));
-        internal static readonly CultureInfo FrCa = CultureInfo.ReadOnly(new CultureInfo("fr-CA"));
+        // Specify fr-FR patterns explicitly, as DNX on Linux gives a different answer. We
+        // don't need it to be French really, just an example...
+        internal static readonly CultureInfo FrFr = CultureInfo.ReadOnly(new CultureInfo("fr-FR")
+        {
+            DateTimeFormat =
+            {
+                LongDatePattern = "dddd d MMMM yyyy",
+                LongTimePattern = "HH:mm:ss",
+                ShortDatePattern = "dd/MM/yyyy",
+                ShortTimePattern = "HH:mm"
+            }
+        });
+        internal static readonly CultureInfo FrCa = CultureInfo.ReadOnly(new CultureInfo("fr-CA")
+        {
+            DateTimeFormat =
+            {
+                LongDatePattern = "d MMMM yyyy",
+                LongTimePattern = "HH:mm:ss",
+                ShortDatePattern = "yyyy-MM-dd",
+                ShortTimePattern = "HH:mm"
+            }
+        });
 
-        // We mostly use Italy as an example of a culture with a "." as the time separator
-        // - but it doesn't have it on Mono, so force it here. (In fact, it looks like it
-        // changed to : between .NET 2 and .NET 4 anyway... another reason to force it.)
-        internal static readonly CultureInfo ItIt = CultureInfo.ReadOnly(new CultureInfo("it-IT") {
+        // We need a culture with a non-colon time separator. On .NET Core we can't specify this explicitly,
+        // so we just rely on Finland doing the right thing. On platforms where we can set this explicitly,
+        // we do so - still starting with Finland for consistency.
+#if PCL
+        internal static readonly CultureInfo DotTimeSeparator = CultureInfo.ReadOnly(new CultureInfo("fi-FI"));
+#else
+        internal static readonly CultureInfo DotTimeSeparator = CultureInfo.ReadOnly(new CultureInfo("fi-FI") {
             DateTimeFormat = { TimeSeparator = "." }
         });
-        
+#endif
+
         internal static readonly CultureInfo GenitiveNameTestCulture = CreateGenitiveTestCulture();
         internal static readonly CultureInfo GenitiveNameTestCultureWithLeadingNames = CreateGenitiveTestCultureWithLeadingNames();
         internal static readonly CultureInfo AwkwardDayOfWeekCulture = CreateAwkwardDayOfWeekCulture();
         internal static readonly CultureInfo AwkwardAmPmDesignatorCulture = CreateAwkwardAmPmCulture();
+
+        /// <summary>
+        /// Workaround for the lack of CultureInfo.GetCultureInfo(string) in the PCL.
+        /// Our PCL version doesn't cache, but does at least still return a readonly version.
+        /// </summary>
+        internal static CultureInfo GetCultureInfo(string name)
+        {
+#if PCL
+            return CultureInfo.ReadOnly(new CultureInfo(name));
+#else
+            return CultureInfo.GetCultureInfo(name);
+#endif
+        }
 
         /// <summary>
         /// .NET 3.5 doesn't contain any cultures where the abbreviated month names differ
@@ -121,26 +228,6 @@ namespace NodaTime.Test.Text
             string[] clone = (string[])input.Clone();
             clone[0] = newElement;
             return clone;
-        }
-
-        /// <summary>
-        /// Returns the passed-in culture unless culture.DateTimeFormat fails, in which case returns
-        /// CultureInfo.GetCultureInfo(culture.Name).  This is to work around a bug in pre-4.0.0 versions of Mono where
-        /// the ar-SA culture returned by CultureInfo.GetCultures(CultureTypes.SpecificCultures) is broken in this way.
-        /// See https://bugzilla.xamarin.com/show_bug.cgi?id=29039 for more info.
-        /// TODO: remove if this is fixed by the time Mono 4.0.0 is released.
-        /// </summary>
-        private static CultureInfo FixCultureIfDateTimeFormatBroken(CultureInfo culture)
-        {
-            try
-            {
-                var ignored = culture.DateTimeFormat;
-                return culture;
-            }
-            catch (NullReferenceException)
-            {
-                return CultureInfo.GetCultureInfo(culture.Name);
-            }
         }
 
         /// <summary>

--- a/src/NodaTime.Test/Text/DurationPatternTest.cs
+++ b/src/NodaTime.Test/Text/DurationPatternTest.cs
@@ -103,11 +103,11 @@ namespace NodaTime.Test.Text
 
             new Data(0, 0, 1, 2, 123400000) { Pattern = "SS.FFFF", Text = "62.1234" },
 
-            new Data(1, 2, 3, 4, 123456789) { Pattern = "D:hh:mm:ss.FFFFFFFFF", Text = "1.02.03.04.123456789", Culture = Cultures.ItIt },
+            new Data(1, 2, 3, 4, 123456789) { Pattern = "D:hh:mm:ss.FFFFFFFFF", Text = "1.02.03.04.123456789", Culture = Cultures.DotTimeSeparator },
 
             // Roundtrip pattern is invariant; redundantly specify the culture to validate that it doesn't make a difference.
-            new Data(1, 2, 3, 4, 123456789) { Pattern = "o", Text = "1:02:03:04.123456789", Culture = Cultures.ItIt },
-            new Data(-1, -2, -3, -4, -123456789) { Pattern = "o", Text = "-1:02:03:04.123456789", Culture = Cultures.ItIt },
+            new Data(1, 2, 3, 4, 123456789) { Pattern = "o", Text = "1:02:03:04.123456789", Culture = Cultures.DotTimeSeparator },
+            new Data(-1, -2, -3, -4, -123456789) { Pattern = "o", Text = "-1:02:03:04.123456789", Culture = Cultures.DotTimeSeparator },
 
             // Extremes...
             new Data(Duration.MinValue) { Pattern = "-D:hh:mm:ss.fffffffff", Text = "-16777216:00:00:00.000000000" },

--- a/src/NodaTime.Test/Text/LocalDatePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalDatePatternTest.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using NodaTime.Properties;
 using NodaTime.Text;
 using NUnit.Framework;
+using NodaTime.Test.Calendars;
 
 namespace NodaTime.Test.Text
 {
@@ -200,7 +201,7 @@ namespace NodaTime.Test.Text
         public void BclLongDatePatternGivesSameResultsInNoda(CultureInfo culture)
         {
             // See https://bugzilla.xamarin.com/show_bug.cgi?id=11363
-            if (TestHelper.IsRunningOnMono && culture.IetfLanguageTag == "mt-MT")
+            if (TestHelper.IsRunningOnMono && culture.Name == "mt-MT")
             {
                 return;
             }
@@ -234,7 +235,7 @@ namespace NodaTime.Test.Text
             }
 
             var pattern = LocalDatePattern.Create(patternText, culture);
-            var calendarSystem = CalendarSystemForCalendar(culture.Calendar);
+            var calendarSystem = BclCalendars.CalendarSystemForCalendar(culture.Calendar);
             if (calendarSystem == null)
             {
                 // We can't map this calendar system correctly yet; the test would be invalid.

--- a/src/NodaTime.Test/Text/LocalDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalDateTimePatternTest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using NodaTime.Properties;
 using NodaTime.Text;
 using NUnit.Framework;
+using NodaTime.Test.Calendars;
 
 namespace NodaTime.Test.Text
 {
@@ -221,13 +222,13 @@ namespace NodaTime.Test.Text
             // we'll skip round-trip format tests.
             // See https://bugzilla.xamarin.com/show_bug.cgi?id=11364
             bool alwaysInvariantPattern = "Oos".Contains(patternText);
-            if (alwaysInvariantPattern && TestHelper.IsRunningOnMono && !(culture.Calendar is GregorianCalendar))
+            if (alwaysInvariantPattern && TestHelper.IsRunningOnMono && !(culture.Calendar.GetType().Name == "GregorianCalendar"))
             {
                 return;
             }
             Calendar calendar = alwaysInvariantPattern ? CultureInfo.InvariantCulture.Calendar : culture.Calendar;
 
-            var calendarSystem = CalendarSystemForCalendar(calendar);
+            var calendarSystem = BclCalendars.CalendarSystemForCalendar(calendar);
             if (calendarSystem == null)
             {
                 // We can't map this calendar system correctly yet; the test would be invalid.

--- a/src/NodaTime.Test/Text/LocalTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalTimePatternTest.cs
@@ -183,8 +183,8 @@ namespace NodaTime.Test.Text
         internal static readonly Data[] FormatAndParseData = {
             new Data(LocalTime.Midnight) { Culture = Cultures.EnUs, Text = ".", Pattern = "%." },
             new Data(LocalTime.Midnight) { Culture = Cultures.EnUs, Text = ":", Pattern = "%:" },
-            new Data(LocalTime.Midnight) { Culture = Cultures.ItIt, Text = ".", Pattern = "%." },
-            new Data(LocalTime.Midnight) { Culture = Cultures.ItIt, Text = ".", Pattern = "%:" },
+            new Data(LocalTime.Midnight) { Culture = Cultures.DotTimeSeparator, Text = ".", Pattern = "%." },
+            new Data(LocalTime.Midnight) { Culture = Cultures.DotTimeSeparator, Text = ".", Pattern = "%:" },
             new Data(LocalTime.Midnight) { Culture = Cultures.EnUs, Text = "H", Pattern = "\\H" },
             new Data(LocalTime.Midnight) { Culture = Cultures.EnUs, Text = "HHss", Pattern = "'HHss'" },
             new Data(0, 0, 0, 100) { Culture = Cultures.EnUs, Text = "1", Pattern = "%f" },
@@ -236,14 +236,14 @@ namespace NodaTime.Test.Text
             new Data(14, 15, 16, 789, 1200) { Culture = Cultures.EnUs, Text = "14:15:16.78912", Pattern = "r" },
             new Data(14, 15, 16, 789, 1230) { Culture = Cultures.EnUs, Text = "14:15:16.789123", Pattern = "r" },
             new Data(14, 15, 16, 789, 1234) { Culture = Cultures.EnUs, Text = "14:15:16.7891234", Pattern = "r" },
-            new Data(14, 15, 16, 700) { Culture = Cultures.ItIt, Text = "14.15.16.7", Pattern = "r" },
-            new Data(14, 15, 16, 780) { Culture = Cultures.ItIt, Text = "14.15.16.78", Pattern = "r" },
-            new Data(14, 15, 16, 789) { Culture = Cultures.ItIt, Text = "14.15.16.789", Pattern = "r" },
-            new Data(14, 15, 16, 789, 1000) { Culture = Cultures.ItIt, Text = "14.15.16.7891", Pattern = "r" },
-            new Data(14, 15, 16, 789, 1200) { Culture = Cultures.ItIt, Text = "14.15.16.78912", Pattern = "r" },
-            new Data(14, 15, 16, 789, 1230) { Culture = Cultures.ItIt, Text = "14.15.16.789123", Pattern = "r" },
-            new Data(14, 15, 16, 789, 1234) { Culture = Cultures.ItIt, Text = "14.15.16.7891234", Pattern = "r" },
-            new Data(14, 15, 16, 789123456L) { Culture = Cultures.ItIt, Text = "14.15.16.789123456", Pattern = "r" },
+            new Data(14, 15, 16, 700) { Culture = Cultures.DotTimeSeparator, Text = "14.15.16.7", Pattern = "r" },
+            new Data(14, 15, 16, 780) { Culture = Cultures.DotTimeSeparator, Text = "14.15.16.78", Pattern = "r" },
+            new Data(14, 15, 16, 789) { Culture = Cultures.DotTimeSeparator, Text = "14.15.16.789", Pattern = "r" },
+            new Data(14, 15, 16, 789, 1000) { Culture = Cultures.DotTimeSeparator, Text = "14.15.16.7891", Pattern = "r" },
+            new Data(14, 15, 16, 789, 1200) { Culture = Cultures.DotTimeSeparator, Text = "14.15.16.78912", Pattern = "r" },
+            new Data(14, 15, 16, 789, 1230) { Culture = Cultures.DotTimeSeparator, Text = "14.15.16.789123", Pattern = "r" },
+            new Data(14, 15, 16, 789, 1234) { Culture = Cultures.DotTimeSeparator, Text = "14.15.16.7891234", Pattern = "r" },
+            new Data(14, 15, 16, 789123456L) { Culture = Cultures.DotTimeSeparator, Text = "14.15.16.789123456", Pattern = "r" },
 
             // ------------ Template value tests ----------
             // Mixtures of 12 and 24 hour times

--- a/src/NodaTime.Test/Text/OffsetPatternTest.cs
+++ b/src/NodaTime.Test/Text/OffsetPatternTest.cs
@@ -129,8 +129,8 @@ namespace NodaTime.Test.Text
         internal static readonly Data[] FormatAndParseData = {
 /*XXX*/            new Data(Offset.Zero) { Culture = Cultures.EnUs, Text = ".", Pattern = "%." }, // decimal separator
             new Data(Offset.Zero) { Culture = Cultures.EnUs, Text = ":", Pattern = "%:" }, // date separator
-/*XXX*/            new Data(Offset.Zero) { Culture = Cultures.ItIt, Text = ".", Pattern = "%." }, // decimal separator (always period)
-            new Data(Offset.Zero) { Culture = Cultures.ItIt, Text = ".", Pattern = "%:" }, // date separator
+/*XXX*/            new Data(Offset.Zero) { Culture = Cultures.DotTimeSeparator, Text = ".", Pattern = "%." }, // decimal separator (always period)
+            new Data(Offset.Zero) { Culture = Cultures.DotTimeSeparator, Text = ".", Pattern = "%:" }, // date separator
             new Data(Offset.Zero) { Culture = Cultures.EnUs, Text = "H", Pattern = "\\H" },
             new Data(Offset.Zero) { Culture = Cultures.EnUs, Text = "HHss", Pattern = "'HHss'" },
             new Data(0, 0, 12) { Culture = Cultures.EnUs, Text = "12", Pattern = "%s" },
@@ -163,11 +163,11 @@ namespace NodaTime.Test.Text
             new Data(5, 12, 34) { Culture = Cultures.FrFr, Text = "+05:12:34", Pattern = "g" },
             new Data(Offset.MaxValue) { Culture = Cultures.FrFr, Text = "+18", Pattern = "g" },
             new Data(Offset.MinValue) { Culture = Cultures.FrFr, Text = "-18", Pattern = "g" },
-            new Data(5, 0, 0) { Culture = Cultures.ItIt, Text = "+05", Pattern = "g" },
-            new Data(5, 12, 0) { Culture = Cultures.ItIt, Text = "+05.12", Pattern = "g" },
-            new Data(5, 12, 34) { Culture = Cultures.ItIt, Text = "+05.12.34", Pattern = "g" },
-            new Data(Offset.MaxValue) { Culture = Cultures.ItIt, Text = "+18", Pattern = "g" },
-            new Data(Offset.MinValue) { Culture = Cultures.ItIt, Text = "-18", Pattern = "g" },
+            new Data(5, 0, 0) { Culture = Cultures.DotTimeSeparator, Text = "+05", Pattern = "g" },
+            new Data(5, 12, 0) { Culture = Cultures.DotTimeSeparator, Text = "+05.12", Pattern = "g" },
+            new Data(5, 12, 34) { Culture = Cultures.DotTimeSeparator, Text = "+05.12.34", Pattern = "g" },
+            new Data(Offset.MaxValue) { Culture = Cultures.DotTimeSeparator, Text = "+18", Pattern = "g" },
+            new Data(Offset.MinValue) { Culture = Cultures.DotTimeSeparator, Text = "-18", Pattern = "g" },
 
             // Standard patterns without punctuation
             new Data(5, 0, 0) { Culture = Cultures.EnUs, Text = "+05", Pattern = "I"  },
@@ -187,11 +187,11 @@ namespace NodaTime.Test.Text
             new Data(5, 12, 34) { Culture = Cultures.FrFr, Text = "+051234", Pattern = "i" },
             new Data(Offset.MaxValue) { Culture = Cultures.FrFr, Text = "+18", Pattern = "i" },
             new Data(Offset.MinValue) { Culture = Cultures.FrFr, Text = "-18", Pattern = "i" },
-            new Data(5, 0, 0) { Culture = Cultures.ItIt, Text = "+05", Pattern = "i" },
-            new Data(5, 12, 0) { Culture = Cultures.ItIt, Text = "+0512", Pattern = "i" },
-            new Data(5, 12, 34) { Culture = Cultures.ItIt, Text = "+051234", Pattern = "i" },
-            new Data(Offset.MaxValue) { Culture = Cultures.ItIt, Text = "+18", Pattern = "i" },
-            new Data(Offset.MinValue) { Culture = Cultures.ItIt, Text = "-18", Pattern = "i" },
+            new Data(5, 0, 0) { Culture = Cultures.DotTimeSeparator, Text = "+05", Pattern = "i" },
+            new Data(5, 12, 0) { Culture = Cultures.DotTimeSeparator, Text = "+0512", Pattern = "i" },
+            new Data(5, 12, 34) { Culture = Cultures.DotTimeSeparator, Text = "+051234", Pattern = "i" },
+            new Data(Offset.MaxValue) { Culture = Cultures.DotTimeSeparator, Text = "+18", Pattern = "i" },
+            new Data(Offset.MinValue) { Culture = Cultures.DotTimeSeparator, Text = "-18", Pattern = "i" },
 
             // Explicit patterns
             new Data(0, 30, 0, true) { Culture = Cultures.EnUs, Text = "-00:30", Pattern = "+HH:mm" },

--- a/src/NodaTime.Test/Text/PatternTestBase.cs
+++ b/src/NodaTime.Test/Text/PatternTestBase.cs
@@ -53,43 +53,5 @@ namespace NodaTime.Test.Text
             var parseResult = pattern.Parse(text);
             Assert.AreEqual(value, parseResult.Value);            
         }
-
-        /// <summary>
-        /// Tries to work out a roughly-matching calendar system for the given BCL calendar.
-        /// This is needed where we're testing whether days of the week match - even if we can
-        /// get day/month/year values to match without getting the calendar right, the calendar
-        /// affects the day of week.
-        /// </summary>
-        internal static CalendarSystem CalendarSystemForCalendar(Calendar bcl)
-        {
-            if (bcl is GregorianCalendar)
-            {
-                return CalendarSystem.Iso;
-            }
-            if (bcl is HijriCalendar)
-            {
-                return CalendarSystem.IslamicBcl;
-            }
-            // This is *not* a general rule. Noda Time simply doesn't support this calendar, which requires
-            // table-based data. However, using the Islamic calendar with the civil epoch gives the same date for
-            // our sample, which is good enough for now...
-            if (bcl is UmAlQuraCalendar)
-            {
-                // ... On Mono, this actually might not be good enough. So let's just punt on it - the Mono
-                // implementation of UmAlQuraCalendar currently differs from the Windows one, but may get fixed
-                // at some point. Let's just abort the test.
-                if (TestHelper.IsRunningOnMono)
-                {
-                    return null;
-                }
-                return CalendarSystem.GetIslamicCalendar(IslamicLeapYearPattern.Base16, IslamicEpoch.Civil);
-            }
-            if (bcl is JulianCalendar)
-            {
-                return CalendarSystem.Julian;
-            }
-            // No idea - we can't test with this calendar...
-            return null;
-        }
     }
 }

--- a/src/NodaTime.Test/TimeZones/IO/IoStream.cs
+++ b/src/NodaTime.Test/TimeZones/IO/IoStream.cs
@@ -33,7 +33,7 @@ namespace NodaTime.Test.TimeZones.IO
         {
             if (readIndex >= writeIndex)
             {
-                throw new InternalBufferOverflowException("IoStream buffer empty in GetByte()");
+                throw new IOException("IoStream buffer empty in GetByte()");
             }
             return buffer[readIndex++];
         }
@@ -97,7 +97,7 @@ namespace NodaTime.Test.TimeZones.IO
         {
             if (writeIndex >= buffer.Length)
             {
-                throw new InternalBufferOverflowException("Exceeded the IoStream buffer size of " + buffer.Length);
+                throw new IOException("Exceeded the IoStream buffer size of " + buffer.Length);
             }
             buffer[writeIndex++] = value;
         }

--- a/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
@@ -30,7 +30,12 @@ namespace NodaTime.Test.TimeZones
                 var bclZone = TimeZoneInfo.FindSystemTimeZoneById(bclId);
                 Assert.AreEqual(tzdbId, source.MapTimeZoneId(bclZone));
             }
+#if PCL
+            // See https://github.com/dotnet/corefx/issues/7552
+            catch (Exception)
+#else
             catch (TimeZoneNotFoundException)
+#endif
             {
                 // This may occur on Mono, for example.
                 Assert.Ignore("Test assumes existence of BCL zone with ID: " + bclId);

--- a/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using NodaTime.Extensions;
 using NodaTime.TimeZones;
 using NUnit.Framework;
+using System.Reflection;
 
 namespace NodaTime.Test.TimeZones
 {
@@ -44,7 +45,7 @@ namespace NodaTime.Test.TimeZones
         [Test]
         public void CanLoadNodaTimeResourceFromOnePointOneRelease()
         {
-            var assembly = typeof(TzdbDateTimeZoneSourceTest).Assembly;
+            var assembly = typeof(TzdbDateTimeZoneSourceTest).GetTypeInfo().Assembly;
             TzdbDateTimeZoneSource source;
             using (Stream stream = assembly.GetManifestResourceStream("NodaTime.Test.TestData.Tzdb2013bFromNodaTime1.1.nzd"))
             {
@@ -226,7 +227,7 @@ namespace NodaTime.Test.TimeZones
         public void CheckDump()
         {
             List<string> expected;
-            var assembly = typeof(TzdbDateTimeZoneSourceTest).Assembly;
+            var assembly = typeof(TzdbDateTimeZoneSourceTest).GetTypeInfo().Assembly;
             using (Stream stream = assembly.GetManifestResourceStream("NodaTime.Test.TestData.tzdb-dump.txt"))
             {
                 using (var reader = new StreamReader(stream))

--- a/src/NodaTime.Test/Utility/CacheTest.cs
+++ b/src/NodaTime.Test/Utility/CacheTest.cs
@@ -21,7 +21,7 @@ namespace NodaTime.Test.Utility
         {
             factoryCallCount = 0;
             return new Cache<string, int>(3, text => { factoryCallCount++; return text.Length; }, 
-                                          StringComparer.InvariantCultureIgnoreCase);
+                                          StringComparer.OrdinalIgnoreCase);
         }
 
         [Test]

--- a/src/NodaTime.Test/project.json
+++ b/src/NodaTime.Test/project.json
@@ -30,6 +30,9 @@
     "NodaTime.Testing": "",
     "NUnit": "3.0.0",
     "NUnitLite": "3.0.0-*",
+    "Microsoft.CSharp": "4.0.0",
+    "System.Dynamic.Runtime": "4.0.0",
+    "System.Reflection.Extensions": "4.0.0",
     "System.Xml.XDocument": "4.0.0"
   },
 

--- a/src/NodaTime.Test/project.json
+++ b/src/NodaTime.Test/project.json
@@ -43,6 +43,14 @@
         "System.Threading.Tasks": "",
         "System.Xml.Linq": ""
       }
-    }
+    },
+    "dnxcore50": {
+      "compilationOptions": {
+        "define": [ "PCL" ]
+      },
+      "dependencies": {
+        "System.Console": "4.0.0-beta-23516"
+      }
+    },
   }
 }

--- a/src/NodaTime.Testing/project.json
+++ b/src/NodaTime.Testing/project.json
@@ -39,6 +39,7 @@
         "define": [ "PCL" ]
       },
       "dependencies": {
+        "System.Runtime.Numerics": "4.0.1-beta-23516",
       }
     }
   }


### PR DESCRIPTION
Some surprises in what's required here, but it's mostly been about how we support explicit BCL calendar usage, and changing to use the modern reflection API.

A few tests still fail on Linux due to https://github.com/dotnet/corefx/issues/6774 - coreclr RC2 should fix that.