### PR TITLE
Implement BCL week rules.

### DIFF
--- a/src/NodaTime.Test/Calendars/BclCalendars.cs
+++ b/src/NodaTime.Test/Calendars/BclCalendars.cs
@@ -33,7 +33,13 @@ namespace NodaTime.Test.Calendars
             }
             // Try to initialize by reflection instead...
             Type type = typeof(Calendar).GetTypeInfo().Assembly.GetType($"System.Globalization.{name}");
-            return type == null ? null : (Calendar) Activator.CreateInstance(type);
+            if (type == null)
+            {
+                // We can start being defensive if/when we try to test on a platform where
+                // this becomes a problem.
+                throw new Exception($"Unable to get calendar {name}");
+            }
+            return (Calendar) Activator.CreateInstance(type);
         }
 
         public static Calendar Hebrew => GetCalendar("HebrewCalendar");
@@ -43,6 +49,14 @@ namespace NodaTime.Test.Calendars
         public static Calendar Julian => GetCalendar("JulianCalendar");
         public static Calendar Hijri => GetCalendar("HijriCalendar");
 
+        /// <summary>
+        /// Returns a sequence of all the BCL calendar systems for which we have a
+        /// mapping in Noda Time. The first entry is Gregorian so that it's easy to
+        /// comment out the rest for initial testing of a new feature (where the
+        /// Gregorian calendar is typically easy to reason about).
+        /// </summary>
+        public static IEnumerable<Calendar> MappedCalendars =>
+            new[] { Gregorian, Hebrew, UmAlQura, Persian, Julian, Hijri };
 
         /// <summary>
         /// Tries to work out a roughly-matching calendar system for the given BCL calendar.

--- a/src/NodaTime.Test/Calendars/BclWeekYearRuleTest.cs
+++ b/src/NodaTime.Test/Calendars/BclWeekYearRuleTest.cs
@@ -1,0 +1,78 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NUnit.Framework;
+using System;
+using System.Globalization;
+using static System.Globalization.CalendarWeekRule;
+using static System.DayOfWeek;
+using NodaTime.Calendars;
+
+namespace NodaTime.Test.Calendars
+{
+    public class BclWeekYearRuleTest
+    {
+        /// <summary>
+        /// For each calendar and rule combination, check everything we can about every date
+        /// from mid December to mid January around each year between 2016 and 2046.
+        /// (For non-Gregorian calendars, the rough equivalent is used...)
+        /// That should give us plenty of coverage.
+        /// </summary>
+        [Test]
+        [Combinatorial]
+        public void BclEquivalence(
+            [ValueSource(typeof(BclCalendars), nameof(BclCalendars.MappedCalendars))] Calendar calendar,
+            [Values(FirstDay, FirstFourDayWeek, FirstFullWeek)] CalendarWeekRule bclRule,
+            [Values(Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday)]  DayOfWeek firstDayOfWeek)
+        {
+            var nodaCalendar = BclCalendars.CalendarSystemForCalendar(calendar);
+            var nodaRule = BclWeekYearRule.FromCalendarWeekRule(bclRule, firstDayOfWeek);
+            var startYear = new LocalDate(2016, 1, 1).WithCalendar(nodaCalendar).Year;
+
+            for (int year = startYear; year < startYear + 30; year++)
+            {
+                var startDate = new LocalDate(year, 1, 1, nodaCalendar).PlusDays(-15);
+                for (int day = 0; day < 30; day++)
+                {
+                    var date = startDate.PlusDays(day);
+                    var bclDate = date.ToDateTimeUnspecified();
+                    var bclWeek = calendar.GetWeekOfYear(bclDate, bclRule, firstDayOfWeek);
+                    // Weird... the BCL doesn't have a way of finding out which week-year we're in.
+                    // We're starting at "start of year - 15 days", so a "small" week-of-year
+                    // value means we're in "year", whereas a "large" week-of-year value means
+                    // we're in the "year-1".
+                    var bclWeekYear = bclWeek < 10 ? year : year - 1;
+
+                    Assert.AreEqual(bclWeek, nodaRule.GetWeekOfWeekYear(date), "Date: {0}", date);
+                    Assert.AreEqual(bclWeekYear, nodaRule.GetWeekYear(date), "Date: {0}", date);
+                    Assert.AreEqual(date, nodaRule.GetLocalDate(bclWeekYear, bclWeek, date.IsoDayOfWeek, nodaCalendar),
+                        "Week-year:{0}; Week: {1}; Day: {2}", bclWeekYear, bclWeek, date.IsoDayOfWeek);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The number of weeks in the year is equal to the week-of-week-year for the last
+        /// day of the year.
+        /// </summary>
+        [Test]
+        [Combinatorial]
+        public void GetWeeksInWeekYear(
+            [ValueSource(typeof(BclCalendars), nameof(BclCalendars.MappedCalendars))] Calendar calendar,
+            [Values(FirstDay, FirstFourDayWeek, FirstFullWeek)] CalendarWeekRule bclRule,
+            [Values(Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday)]  DayOfWeek firstDayOfWeek)
+        {
+            var nodaCalendar = BclCalendars.CalendarSystemForCalendar(calendar);
+            var nodaRule = BclWeekYearRule.FromCalendarWeekRule(bclRule, firstDayOfWeek);
+            var startYear = new LocalDate(2016, 1, 1).WithCalendar(nodaCalendar).Year;
+
+            for (int year = startYear; year < startYear + 30; year++)
+            {
+                var bclDate = new LocalDate(year + 1, 1, 1, nodaCalendar).PlusDays(-1).ToDateTimeUnspecified();
+                Assert.AreEqual(calendar.GetWeekOfYear(bclDate, bclRule, firstDayOfWeek),
+                    nodaRule.GetWeeksInWeekYear(year, nodaCalendar), "Year {0}", year);
+            }
+        }
+    }
+}

--- a/src/NodaTime/Calendars/BclWeekYearRule.cs
+++ b/src/NodaTime/Calendars/BclWeekYearRule.cs
@@ -2,75 +2,65 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
-using System;
 using JetBrains.Annotations;
 using NodaTime.Annotations;
+using NodaTime.Extensions;
 using NodaTime.Utility;
+using System;
+using System.Globalization;
+using static System.Globalization.CalendarWeekRule;
 
 namespace NodaTime.Calendars
 {
-    // Possible future feature: allow the first day of the week to vary too.
-
     /// <summary>
-    /// Implements <see cref="IWeekYearRule"/> for a rule where weeks are regular:
-    /// every week has exactly 7 days, which means that some week years straddle
-    /// the calendar year boundary. (So the start of a week can occur in one calendar
-    /// year, and the end of the week in the following calendar year, but the whole
-    /// week is in the same week-year.)
+    /// Implementation of <see cref="IWeekYearRule"/> to emulate the behavior of
+    /// <see cref="Calendar.GetWeekOfYear(DateTime, CalendarWeekRule, DayOfWeek)"/>.
     /// </summary>
     [Immutable]
-    public sealed class RegularWeekYearRule : IWeekYearRule
+    public sealed class BclWeekYearRule : IWeekYearRule
     {
-        /// <summary>
-        /// Returns an <see cref="IWeekYearRule"/> consistent with ISO-8601.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// In the standard ISO-8601 week algorithm, the first week of the year
-        /// is that in which at least 4 days are in the year. As a result of this
-        /// definition, day 1 of the first week may be in the previous year. In ISO-8601,
-        /// weeks always begin on a Monday, so this rule is equivalent to the first Thursday
-        /// being in the first Monday-to-Sunday week of the year.
-        /// </para>
-        /// <para>
-        /// For example, January 1st 2011 was a Saturday, so only two days of that week
-        /// (Saturday and Sunday) were in 2011. Therefore January 1st is part of
-        /// week 52 of week-year 2010. Conversely, December 31st 2012 is a Monday,
-        /// so is part of week 1 of week-year 2013.
-        /// </para>
-        /// </remarks>
-        /// <value>A <see cref="IWeekYearRule"/> consistent with ISO-8601.</value>
-        public static IWeekYearRule Iso { get; } = new RegularWeekYearRule(4);
-
+        private readonly CalendarWeekRule rule;
+        private readonly IsoDayOfWeek firstDayOfWeek;
         private readonly int minDaysInFirstWeek;
 
-        private RegularWeekYearRule(int minDaysInFirstWeek)
+        // TODO: Expose the above as properties?
+
+        private BclWeekYearRule(CalendarWeekRule calendarWeekRule, DayOfWeek firstDayOfWeek)
         {
-            Preconditions.DebugCheckArgumentRange(nameof(minDaysInFirstWeek), minDaysInFirstWeek, 1, 7);
-            this.minDaysInFirstWeek = minDaysInFirstWeek;
+            this.rule = calendarWeekRule;
+            this.firstDayOfWeek = firstDayOfWeek.ToIsoDayOfWeek();
+            switch (calendarWeekRule)
+            {
+                case FirstDay:
+                    minDaysInFirstWeek = 1;
+                    break;
+                case FirstFourDayWeek:
+                    minDaysInFirstWeek = 4;
+                    break;
+                case FirstFullWeek:
+                    minDaysInFirstWeek = 7;
+                    break;
+                default:
+                    throw new ArgumentException($"Unsupported CalendarWeekRule: {calendarWeekRule}", nameof(calendarWeekRule));
+            }
         }
 
         /// <summary>
-        /// Creates a week year rule where the boundary between one week-year and the next
-        /// is parameterized in terms of how many days of the first week of the week
-        /// year have to be in the new calendar year. Weeks are always deemed to begin on an Monday.
+        /// Creates a rule which behaves the same way as the BCL
+        /// <see cref="Calendar.GetWeekOfYear(DateTime, CalendarWeekRule, DayOfWeek)"/>
+        /// method.
         /// </summary>
-        /// <remarks>
-        /// <paramref name="minDaysInFirstWeek"/> determines when the first week of the week-year starts.
-        /// For any given calendar year X, consider the Monday-to-Sunday week that includes the first day of the
-        /// calendar year. Usually, some days of that week are in calendar year X, and some are in calendar year 
-        /// X-1. If <paramref name="minDaysInFirstWeek"/> or more of the days are in year X, then the week is
-        /// deemed to be the first week of week-year X. Otherwise, the week is deemed to be the last week of
-        /// week-year X-1, and the first week of week-year X starts on the following Monday.
+        /// <remarks>The BCL week year rules are subtly different to the ISO rules.
+        /// In particular, the last few days of the calendar year are always part of the same
+        /// week-year in the BCL rules, whereas in the ISO rules they can fall into the next
+        /// week-year. (The first few days of the calendar year can be part of the previous
+        /// week-year in both kinds of rule.) This means that in the BCL rules, some weeks
+        /// are incomplete, whereas ISO weeks are always exactly 7 days long.
         /// </remarks>
-        /// <param name="minDaysInFirstWeek">The minimum number of days in the first Monday-to-Sunday week
-        /// which have to be in the new calendar year for that week to count as being in that week-year.
-        /// Must be in the range 1 to 7 inclusive.
-        /// </param>
-        /// <returns>A <see cref="RegularWeekYearRule"/> with the specified minimum number of days in the first
-        /// week.</returns>
-        public static RegularWeekYearRule ForMinDaysInFirstWeek(int minDaysInFirstWeek)
-            => new RegularWeekYearRule(minDaysInFirstWeek);
+        /// <param name="calendarWeekRule">The BCL rule to emulate.</param>
+        /// <param name="firstDayOfWeek">The first day of the week to use in the rule.</param>
+        public static BclWeekYearRule FromCalendarWeekRule(CalendarWeekRule calendarWeekRule, DayOfWeek firstDayOfWeek)
+            => new BclWeekYearRule(calendarWeekRule, firstDayOfWeek);
 
         /// <inheritdoc />
         public LocalDate GetLocalDate(int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek, [NotNull] CalendarSystem calendar)
@@ -87,10 +77,12 @@ namespace NodaTime.Calendars
             {
                 throw new ArgumentOutOfRangeException(nameof(weekOfWeekYear));
             }
-            
+
             unchecked
             {
-                int days = GetWeekYearDaysSinceEpoch(yearMonthDayCalculator, weekYear) + (weekOfWeekYear - 1) * 7 + ((int)dayOfWeek - 1);
+                int startOfWeekYear = GetRegularWeekYearDaysSinceEpoch(yearMonthDayCalculator, weekYear);
+                int daysIntoWeek = ((dayOfWeek - firstDayOfWeek) + 7) % 7;
+                int days = startOfWeekYear + (weekOfWeekYear - 1) * 7 + daysIntoWeek;
                 if (days < calendar.MinDays || days > calendar.MaxDays)
                 {
                     throw new ArgumentOutOfRangeException(nameof(weekYear),
@@ -108,7 +100,9 @@ namespace NodaTime.Calendars
             // This is a bit inefficient, as we'll be converting forms several times. However, it's
             // understandable... we might want to optimize in the future if it's reported as a bottleneck.
             int weekYear = GetWeekYear(date);
-            int startOfWeekYear = GetWeekYearDaysSinceEpoch(yearMonthDayCalculator, weekYear);
+            // Even if this is before the *real* start of the week year, that doesn't change the
+            // week-of-week-year, as we've definitely got the right week-year to start with.
+            int startOfWeekYear = GetRegularWeekYearDaysSinceEpoch(yearMonthDayCalculator, weekYear);
             int daysSinceEpoch = yearMonthDayCalculator.GetDaysSinceEpoch(yearMonthDay);
             int zeroBasedDayOfWeekYear = daysSinceEpoch - startOfWeekYear;
             int zeroBasedWeek = zeroBasedDayOfWeekYear / 7;
@@ -123,17 +117,20 @@ namespace NodaTime.Calendars
             ValidateWeekYear(weekYear, calendar);
             unchecked
             {
-                int startOfWeekYear = GetWeekYearDaysSinceEpoch(yearMonthDayCalculator, weekYear);
+                int startOfWeekYear = GetRegularWeekYearDaysSinceEpoch(yearMonthDayCalculator, weekYear);
                 int startOfCalendarYear = yearMonthDayCalculator.GetStartOfYearInDays(weekYear);
+
                 // The number of days gained or lost in the week year compared with the calendar year.
                 // So if the week year starts on December 31st of the previous calendar year, this will be +1.
                 // If the week year starts on January 2nd of this calendar year, this will be -1.
-
+                // If this is positive, then those aren't "real" days in the week year, as the BCL
+                // never has the end of a calendar year in the following week year. However, it doesn't
+                // matter for the purposes of this calculation.
                 int extraDays = startOfCalendarYear - startOfWeekYear;
                 int daysInThisYear = yearMonthDayCalculator.GetDaysInYear(weekYear);
 
-                // We can have up to "minDaysInFirstWeek - 1" days of the next year, too.
-                return (daysInThisYear + extraDays + (minDaysInFirstWeek - 1)) / 7;
+                // There are daysInThisYear + extraDays within this week-year, so we just need to round up.
+                return (daysInThisYear + extraDays + 6) / 7;
             }
         }
 
@@ -146,7 +143,7 @@ namespace NodaTime.Calendars
             {
                 // Let's guess that it's in the same week year as calendar year, and check that.
                 int calendarYear = yearMonthDay.Year;
-                int startOfWeekYear = GetWeekYearDaysSinceEpoch(yearMonthDayCalculator, calendarYear);
+                int startOfWeekYear = GetRegularWeekYearDaysSinceEpoch(yearMonthDayCalculator, calendarYear);
                 int daysSinceEpoch = yearMonthDayCalculator.GetDaysSinceEpoch(yearMonthDay);
                 if (daysSinceEpoch < startOfWeekYear)
                 {
@@ -156,15 +153,9 @@ namespace NodaTime.Calendars
                     return calendarYear - 1;
                 }
 
-                // By now, we know it's either calendarYear or calendarYear + 1. Check using the number of
-                // weeks in the year. Note that this will fetch the start of the calendar year and the week year
-                // again, so could be optimized by copying some logic here - but only when we find we need to.
-                int weeksInWeekYear = GetWeeksInWeekYear(calendarYear, date.Calendar);
-
-                // We assume that even for the maximum year, we've got just about enough leeway to get to the
-                // start of the week year. (If not, we should adjust the maximum.)
-                int startOfNextWeekYear = startOfWeekYear + weeksInWeekYear * 7;
-                return daysSinceEpoch < startOfNextWeekYear ? calendarYear : calendarYear + 1;
+                // In BCL rules, a day can belong to the *previous* week year, but never the *next* week year.
+                // So at this point, we're done.
+                return calendarYear;
             }
         }
 
@@ -173,15 +164,16 @@ namespace NodaTime.Calendars
         /// </summary>
         private void ValidateWeekYear(int weekYear, CalendarSystem calendar)
         {
+            // FIXME: Adjust for BCL truncation.
             if (weekYear > calendar.MinYear && weekYear < calendar.MaxYear)
             {
                 return;
             }
-            int minCalendarYearDays = GetWeekYearDaysSinceEpoch(calendar.YearMonthDayCalculator, calendar.MinYear);
+            int minCalendarYearDays = GetRegularWeekYearDaysSinceEpoch(calendar.YearMonthDayCalculator, calendar.MinYear);
             // If week year X started after calendar year X, then the first days of the calendar year are in the
             // previous week year.
             int minWeekYear = minCalendarYearDays > calendar.MinDays ? calendar.MinYear - 1 : calendar.MinYear;
-            int maxCalendarYearDays = GetWeekYearDaysSinceEpoch(calendar.YearMonthDayCalculator, calendar.MaxYear + 1);
+            int maxCalendarYearDays = GetRegularWeekYearDaysSinceEpoch(calendar.YearMonthDayCalculator, calendar.MaxYear + 1);
             // If week year X + 1 started after the last day in the calendar, then everything is within week year X.
             int maxWeekYear = maxCalendarYearDays > calendar.MaxDays ? calendar.MaxYear : calendar.MaxYear + 1;
             Preconditions.CheckArgumentRange(nameof(weekYear), weekYear, minWeekYear, maxWeekYear);
@@ -189,28 +181,35 @@ namespace NodaTime.Calendars
 
         /// <summary>
         /// Returns the days at the start of the given week-year. The week-year may be
-        /// 1 higher or lower than the max/min calendar year.
+        /// 1 higher or lower than the max/min calendar year. This returns a "regular" 
+        /// start of week, so it may be in the previous calendar year. (This isn't the same
+        /// as the start of the week year in the BCL, which is always in the same calendar year,
+        /// even if that means that the first week is short.)
         /// </summary>
-        private int GetWeekYearDaysSinceEpoch(YearMonthDayCalculator yearMonthDayCalculator, [Trusted] int weekYear)
+        private int GetRegularWeekYearDaysSinceEpoch(YearMonthDayCalculator yearMonthDayCalculator, [Trusted] int weekYear)
         {
             unchecked
             {
                 // Need to be slightly careful here, as the week-year can reasonably be (just) outside the calendar year range.
                 // However, YearMonthDayCalculator.GetStartOfYearInDays already handles min/max -/+ 1.
                 int startOfCalendarYear = yearMonthDayCalculator.GetStartOfYearInDays(weekYear);
+                // Inlined from CalendarSystem.GetDayOfWeek
                 int startOfYearDayOfWeek = unchecked(startOfCalendarYear >= -3 ? 1 + ((startOfCalendarYear + 3) % 7)
                                            : 7 + ((startOfCalendarYear + 4) % 7));
 
-                if (startOfYearDayOfWeek > (8 - minDaysInFirstWeek))
-                {
-                    // First week is end of previous year because it doesn't have enough days.
-                    return startOfCalendarYear + (8 - startOfYearDayOfWeek);
-                }
-                else
-                {
-                    // First week is start of this year because it has enough days.
-                    return startOfCalendarYear - (startOfYearDayOfWeek - 1);
-                }
+                // How many days have there been from the start of the week containing
+                // the first day of the year, until the first day of the year? To put it another
+                // way, how many days in the week *containing* the start of the calendar year were
+                // in the previous calendar year.
+                // (For example, if the start of the calendar year is Friday and the first day of the week is Monday,
+                // this will be 4.)
+                int daysIntoWeek = ((startOfYearDayOfWeek - (int) firstDayOfWeek) + 7) % 7;
+                int startOfWeekContainingStartOfCalendarYear = startOfCalendarYear - daysIntoWeek;
+
+                bool startOfYearIsInWeek1 = (7 - daysIntoWeek >= minDaysInFirstWeek);
+                return startOfYearIsInWeek1 
+                    ? startOfWeekContainingStartOfCalendarYear
+                    : startOfWeekContainingStartOfCalendarYear + 7;
             }
         }
     }


### PR DESCRIPTION
It turns out these are pretty simple:
- Either 1, 4 or 7 as the "min days in first week"
- Variable "first day of week"
- Unlike the ISO rules, the end of the calendar year is always in the same
  week-year, so the first week of the week-year may be shorter than 7 days.
  (The first days of the calendar year *may* be in the previous week-year
  though.)

There's a lot of common code between this and RegularWeekYearRule; it shouldn't
be too hard to refactor the code into a single class, providing the ability
for "regular" week year rules to have a variable first day of week too. That
can come later though, along with a whole user guide page with many, many
examples.