### PR TITLE
Add the ability to provide an "override" file for Windows zone mappings

### DIFF
--- a/src/NodaTime.Test/Tests.nunit
+++ b/src/NodaTime.Test/Tests.nunit
@@ -1,9 +1,0 @@
-﻿<NUnitProject>
-  <Settings activeconfig="Debug" />
-  <Config name="Debug" binpathtype="Auto">
-    <assembly path="bin\Debug\NodaTime.Test.dll" />
-  </Config>
-  <Config name="Release" binpathtype="Auto">
-    <assembly path="bin\Release\NodaTime.Test.dll" />
-  </Config>
-</NUnitProject>

--- a/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.xproj
+++ b/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.xproj
@@ -14,5 +14,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/NodaTime.TzdbCompiler.Test/ProgramTest.cs
+++ b/src/NodaTime.TzdbCompiler.Test/ProgramTest.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.TimeZones.Cldr;
+using NUnit.Framework;
+
+namespace NodaTime.TzdbCompiler.Test
+{
+    public class ProgramTest
+    {
+        [Test]
+        public void MergeWindowsZones()
+        {
+            var originalZones = new WindowsZones("orig-version", "orig-tzdb-version", "orig-win-version",
+                new[]
+                {
+                    new MapZone("ID1", "001", new[] { "A" }),
+                    new MapZone("ID1", "T1-1", new[] { "B", "C" }),
+                    new MapZone("ID1", "T1-2", new[] { "D" }),
+                    new MapZone("ID2", "001", new[] { "E" }),
+                    new MapZone("ID2", "T2-1", new[] { "F" })
+                });
+
+            var overrideZones = new WindowsZones("override-version", "", "",
+                new[]
+                {
+                    // Replace ID1 / 001
+                    new MapZone("ID1", "001", new[] { "A1" }),
+                    // Delete ID1 / T1-1
+                    new MapZone("ID1", "T1-1", new string[0]),
+                    // (Leave ID1 / T1-2)
+                    // Add ID1 / T1-3
+                    new MapZone("ID1", "T1-3", new[] { "B1", "C1", "G1" }),
+                    // (Leave ID2 / 001)
+                    // Replace ID2 / T2-1
+                    new MapZone("ID2", "T2-1", new[] { "H1" }),
+                    // Add ID3 / 001
+                    new MapZone("ID3", "001", new[] { "I1" })
+                });
+            var actual = Program.MergeWindowsZones(originalZones, overrideZones);
+            var expected = new WindowsZones("override-version", "orig-tzdb-version", "orig-win-version",
+                new[]
+                {
+                    new MapZone("ID1", "001", new[] { "A1" }),
+                    new MapZone("ID1", "T1-2", new[] { "D" }),
+                    new MapZone("ID1", "T1-3", new[] { "B1", "C1", "G1" }),
+                    new MapZone("ID2", "001", new[] { "E" }),
+                    new MapZone("ID2", "T2-1", new[] { "H1" }),
+                    new MapZone("ID3", "001", new[] { "I1" })
+                });
+
+            // Could implement IEquatable<WindowsZones>, but it doesn't seem worth it right now.
+            Assert.AreEqual(expected.Version, actual.Version);
+            Assert.AreEqual(expected.TzdbVersion, actual.TzdbVersion);
+            Assert.AreEqual(expected.WindowsVersion, actual.WindowsVersion);
+            Assert.AreEqual(expected.MapZones, actual.MapZones);
+        }
+    }
+}

--- a/src/NodaTime.TzdbCompiler.Test/Tests.nunit
+++ b/src/NodaTime.TzdbCompiler.Test/Tests.nunit
@@ -1,9 +1,0 @@
-﻿<NUnitProject>
-  <Settings activeconfig="Debug" />
-  <Config name="Debug" binpathtype="Auto">
-    <assembly path="bin\Debug\ZoneInfoCompiler.Test.dll" />
-  </Config>
-  <Config name="Release" binpathtype="Auto">
-    <assembly path="bin\Release\ZoneInfoCompiler.Test.dll" />
-  </Config>
-</NUnitProject>

--- a/src/NodaTime.TzdbCompiler.Test/Tzdb/CldrWindowsZonesParserTest.cs
+++ b/src/NodaTime.TzdbCompiler.Test/Tzdb/CldrWindowsZonesParserTest.cs
@@ -1,0 +1,77 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.TimeZones.Cldr;
+using NodaTime.TzdbCompiler.Tzdb;
+using NUnit.Framework;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace NodaTime.TzdbCompiler.Test.Tzdb
+{
+    public class CldrWindowsZonesParserTest
+    {
+        [Test]
+        public void Versions_Present()
+        {
+            string xml = @"
+<supplementalData>
+  <version number='$Revision: rev-version $'/>
+  <generation date='$Date: 2012-01-14 03:54:32 -0600 (Sat, 14 Jan 2012) $' />
+  <windowsZones>
+    <mapTimezones otherVersion='win-version' typeVersion='tzdb-version'>
+    </mapTimezones>
+  </windowsZones>
+</supplementalData>
+    ";
+            var doc = XDocument.Parse(xml);
+            var parsed = CldrWindowsZonesParser.Parse(doc);
+            Assert.AreEqual("rev-version", parsed.Version);
+            Assert.AreEqual("win-version", parsed.WindowsVersion);
+            Assert.AreEqual("tzdb-version", parsed.TzdbVersion);
+        }
+
+        [Test]
+        public void Versions_Absent()
+        {
+            string xml = @"
+<supplementalData>
+  <generation date='$Date: 2012-01-14 03:54:32 -0600 (Sat, 14 Jan 2012) $' />
+  <windowsZones>
+    <mapTimezones>
+    </mapTimezones>
+  </windowsZones>
+</supplementalData>
+    ";
+            var doc = XDocument.Parse(xml);
+            var parsed = CldrWindowsZonesParser.Parse(doc);
+            Assert.AreEqual("", parsed.Version);
+            Assert.AreEqual("", parsed.WindowsVersion);
+            Assert.AreEqual("", parsed.TzdbVersion);
+        }
+
+        [Test]
+        public void MapZones()
+        {
+            string xml = @"
+<supplementalData>
+  <windowsZones>
+    <mapTimezones>
+      <mapZone other='X' territory='t0' type='' />
+      <mapZone other='X' territory='t1' type='A' />
+      <mapZone other='X' territory='t2' type='B C' />
+    </mapTimezones>
+  </windowsZones>
+</supplementalData>
+    ";
+            var doc = XDocument.Parse(xml);
+            var parsed = CldrWindowsZonesParser.Parse(doc);
+            var mapZones = parsed.MapZones;
+            Assert.AreEqual(3, mapZones.Count);
+            Assert.AreEqual(new MapZone("X", "t0", new string[0]), mapZones[0]);
+            Assert.AreEqual(new MapZone("X", "t1", new[] { "A" }), mapZones[1]);
+            Assert.AreEqual(new MapZone("X", "t2", new[] { "B", "C" }), mapZones[2]);
+        }
+    }
+}

--- a/src/NodaTime.TzdbCompiler/CompilerOptions.cs
+++ b/src/NodaTime.TzdbCompiler/CompilerOptions.cs
@@ -21,6 +21,9 @@ namespace NodaTime.TzdbCompiler
         [Option("w", "windows", Required = true, HelpText = "Windows to TZDB time zone mapping file (e.g. windowsZones.xml) or directory")]
         public string WindowsMapping { get; set; } = "";
 
+        [Option(null, "windows-override", Required = false, HelpText = "Additional 'override' file providing extra Windows time zone mappings")]
+        public string WindowsOverride { get; set; }
+
         [Option("z", "zone",
             Required = false,
             HelpText = "Single zone ID to compile data for, for test purposes. (Incompatible with -o.)",

--- a/src/NodaTime/TimeZones/Cldr/MapZone.cs
+++ b/src/NodaTime/TimeZones/Cldr/MapZone.cs
@@ -8,6 +8,8 @@ using JetBrains.Annotations;
 using NodaTime.Annotations;
 using NodaTime.TimeZones.IO;
 using NodaTime.Utility;
+using System;
+using System.Linq;
 
 namespace NodaTime.TimeZones.Cldr
 {
@@ -16,7 +18,7 @@ namespace NodaTime.TimeZones.Cldr
     /// </summary>
     /// <threadsafety>This type is immutable reference type. See the thread safety section of the user guide for more information.</threadsafety>
     [Immutable]
-    public sealed class MapZone
+    public sealed class MapZone : IEquatable<MapZone>
     {
         /// <summary>
         /// Identifier used for the primary territory of each Windows time zone. A zone mapping with
@@ -122,5 +124,30 @@ namespace NodaTime.TimeZones.Cldr
                 writer.WriteString(id);
             }
         }
+
+        /// <inheritdoc />
+        public bool Equals(MapZone other) =>
+            other != null &&
+            WindowsId == other.WindowsId &&
+            Territory == other.Territory &&
+            TzdbIds.SequenceEqual(other.TzdbIds);
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            var hash = HashCodeHelper.Initialize().Hash(WindowsId).Hash(Territory);
+            foreach (var id in TzdbIds)
+            {
+                hash = hash.Hash(id);
+            }
+            return hash.Value;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj) => Equals(obj as MapZone);
+
+        /// <inheritdoc />
+        public override string ToString()
+            => $"Windows ID: {WindowsId}; Territory: {Territory}; TzdbIds: {string.Join(" ", TzdbIds)}";
     }
 }

--- a/src/NodaTime/TimeZones/Cldr/WindowsZones.cs
+++ b/src/NodaTime/TimeZones/Cldr/WindowsZones.cs
@@ -56,7 +56,7 @@ namespace NodaTime.TimeZones.Cldr
         /// so "7dc0101" for example.
         /// </remarks>
         /// <value>The Windows time zone database version this Windows zone mapping data was created from.</value>
-        public string WindowsVersion { get; }
+        [NotNull] public string WindowsVersion { get; }
 
         /// <summary>
         /// Gets an immutable collection of mappings from Windows system time zones to
@@ -113,26 +113,6 @@ namespace NodaTime.TimeZones.Cldr
             this.PrimaryMapping = new NodaReadOnlyDictionary<string, string>(
                 mapZones.Where(z => z.Territory == MapZone.PrimaryTerritory)
                         .ToDictionary(z => z.WindowsId, z => z.TzdbIds.Single()));
-        }
-
-        private WindowsZones(string version, NodaReadOnlyDictionary<string, string> primaryMapping)
-        {
-            this.Version = version;
-            this.WindowsVersion = "Unknown";
-            this.TzdbVersion = "Unknown";
-            this.PrimaryMapping = primaryMapping;
-            var mapZoneList = new List<MapZone>(primaryMapping.Count);
-            foreach (var entry in primaryMapping)
-            {
-                mapZoneList.Add(new MapZone(entry.Key, MapZone.PrimaryTerritory, new[] { entry.Value }));
-            }
-            MapZones = new ReadOnlyCollection<MapZone>(mapZoneList);
-        }
-
-        internal static WindowsZones FromPrimaryMapping([NotNull] string version, [NotNull] IDictionary<string, string> mappings)
-        {
-            return new WindowsZones(Preconditions.CheckNotNull(version, nameof(version)),
-                new NodaReadOnlyDictionary<string, string>(Preconditions.CheckNotNull(mappings, nameof(mappings))));
         }
 
         internal static WindowsZones Read(IDateTimeZoneReader reader)


### PR DESCRIPTION
This fixes #473 in terms of code - process still needs definition.