### PR TITLE
Most of the way to hitting .NET Core 1.0 RTM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,15 @@ addons:
 mono:
   - latest
 
+# TODO: See whether we could use apt sources above instead.
+# But by the time I've investigated that, there'll hopefully
+# be a better solution on Travis anyway.
+
 install:
-  - export DOTNET_INSTALL_DIR="$PWD/.dotnetcli"
-  - curl -sSL https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version "$CLI_VERSION" --install-dir "$DOTNET_INSTALL_DIR"
-  - export PATH="$DOTNET_INSTALL_DIR:$PATH"
+  - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
+  - sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+  - sudo apt-get update
+  - sudo apt-get -qq install dotnet-dev-1.0.0-preview2-003121
 
 # Although TzdbCompiler is portable, the tests aren't, as they
 # check against Windows standard time zone IDs.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src" ],
   "sdk": {
-    "version": "1.0.0-preview1-002702"
+    "version": "1.0.0-preview2-003121"
   }
 }

--- a/src/.nuget/packages.config
+++ b/src/.nuget/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NuGet.CommandLine" version="2.8.2" />
-</packages>

--- a/src/NodaTime.Benchmarks/project.json
+++ b/src/NodaTime.Benchmarks/project.json
@@ -21,10 +21,13 @@
     "NodaTime": { "target": "project" },
     "NodaTime.Serialization.JsonNet": { "target": "project" },
     "NodaTime.Testing": { "target": "project" },
-    "NUnit": "3.2.1",
-    "System.Xml.XDocument": "4.0.11-rc2-24027",
-    "Newtonsoft.Json": "8.0.3"
+    "NUnit": "3.4.0",
+    "dotnet-test-nunit": "3.4.0-alpha-2",
+    "Newtonsoft.Json": "9.0.1"
   },
+
+  "testRunner": "nunit",
+
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {

--- a/src/NodaTime.Demo/packages.config
+++ b/src/NodaTime.Demo/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net35" />
-</packages>

--- a/src/NodaTime.Demo/project.json
+++ b/src/NodaTime.Demo/project.json
@@ -5,8 +5,8 @@
 
   "dependencies": {
     "NodaTime": { "target": "project" },
-    "NUnit": "3.2.1",
-    "NUnitLite": "3.2.1"
+    "NUnit": "3.4.0",
+    "NUnitLite": "3.4.0"
   },
 
   "frameworks": {
@@ -18,16 +18,12 @@
       }
     },
     "netcoreapp1.0": {
-      "imports" : [ "dnxcore50" ],
+      "imports": "dotnet",
       "buildOptions": {
         "define": [ "PCL" ]
       },
       "dependencies": {
-        "Microsoft.NETCore.App": {
-          "version": "1.0.0-*",
-          "type": "platform"
-        },
-        "System.Console": "4.0.0-rc2-24027",
+        "System.Console": "4.0.0"
       }
     }
   }

--- a/src/NodaTime.Serialization.JsonNet/packages.config
+++ b/src/NodaTime.Serialization.JsonNet/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net35-Client" />
-</packages>

--- a/src/NodaTime.Serialization.JsonNet/project.json
+++ b/src/NodaTime.Serialization.JsonNet/project.json
@@ -35,7 +35,7 @@
   },
 
   "dependencies": {
-    "Newtonsoft.Json": "8.0.3",
+    "Newtonsoft.Json": "9.0.1",
     "NodaTime": { "target": "project" }
   },
 
@@ -46,9 +46,8 @@
       "buildOptions": {
         "define": [ "PCL" ]
       },
-      "imports": ["dnxcore50"],
       "dependencies": {
-        "System.Linq": "4.1.0-rc2-24027"
+        "System.Linq": "4.1.0"
       }
     }
   }

--- a/src/NodaTime.Serialization.Test/packages.config
+++ b/src/NodaTime.Serialization.Test/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
-</packages>

--- a/src/NodaTime.Serialization.Test/project.json
+++ b/src/NodaTime.Serialization.Test/project.json
@@ -21,10 +21,9 @@
     "NodaTime": { "target": "project" },
     "NodaTime.Serialization.JsonNet": { "target": "project" },
     "NodaTime.Testing": { "target": "project" },
-    "NUnit": "3.2.1",
-    "dotnet-test-nunit": "3.4.0-alpha-1",
-    "System.Xml.XDocument": "4.0.11-rc2-24027",
-    "Newtonsoft.Json": "8.0.3"
+    "NUnit": "3.4.1",
+    "dotnet-test-nunit": "3.4.0-beta-1",
+    "Newtonsoft.Json": "9.0.1"
   },
 
   "testRunner": "nunit",
@@ -44,10 +43,11 @@
       },
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.0.0-*",
+          "version": "1.0.0",
           "type": "platform"
         },
-        "System.Console": "4.0.0-rc2-24027",
+        "System.Console": "4.0.0",
+        "System.Xml.XDocument": "4.0.11"
       }
     }
   }

--- a/src/NodaTime.Test/packages.config
+++ b/src/NodaTime.Test/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
-</packages>

--- a/src/NodaTime.Test/project.json
+++ b/src/NodaTime.Test/project.json
@@ -25,12 +25,12 @@
   "dependencies": {
     "NodaTime": { "target": "project" },
     "NodaTime.Testing": { "target": "project" },
-    "NUnit": "3.2.1",
-    "dotnet-test-nunit": "3.4.0-alpha-1",
-    "Microsoft.CSharp": "4.0.1-rc2-24027",
-    "System.Dynamic.Runtime": "4.0.11-rc2-24027",
-    "System.Reflection.Extensions": "4.0.1-rc2-24027",
-    "System.Xml.XDocument": "4.0.11-rc2-24027"
+    "NUnit": "3.4.0",
+    "dotnet-test-nunit": "3.4.0-alpha-2",
+    "Microsoft.CSharp": "4.0.1",
+    "System.Dynamic.Runtime": "4.0.11",
+    "System.Reflection.Extensions": "4.0.1",
+    "System.Xml.XDocument": "4.0.11"
   },
 
   "testRunner": "nunit",
@@ -50,10 +50,10 @@
       },
       "dependencies": {
         "Microsoft.NETCore.App": { 
-          "version": "1.0.0-*",
+          "version": "1.0.0",
           "type": "platform"
         },
-        "System.Console": "4.0.0-rc2-24027",
+        "System.Console": "4.0.0"
       }
     }
   }

--- a/src/NodaTime.Testing/project.json
+++ b/src/NodaTime.Testing/project.json
@@ -31,7 +31,7 @@
   },
 
   "dependencies": {
-    "NodaTime": "2.0.0-*"
+    "NodaTime": { "target": "project" }
   },
 
   "frameworks": {
@@ -44,7 +44,7 @@
         "define": [ "PCL" ]
       },
       "dependencies": {
-        "System.Runtime.Numerics": "4.0.1-rc2-24027"
+        "System.Runtime.Numerics": "4.0.1"
       }
     }
   }

--- a/src/NodaTime.TzValidate.NodaDump/project.json
+++ b/src/NodaTime.TzValidate.NodaDump/project.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "NodaTime": { "target": "project" },
     "NodaTime.TzdbCompiler": { "target": "project" },
-    "System.Net.Http": "4.0.1-rc2-24027"
+    "System.Net.Http": "4.1.0"
   },
 
   "frameworks": {
@@ -29,7 +29,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002702"
+          "version": "1.0.0"
         }
       }
     }

--- a/src/NodaTime.TzdbCompiler.Test/packages.config
+++ b/src/NodaTime.TzdbCompiler.Test/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net35" />
-</packages>

--- a/src/NodaTime.TzdbCompiler.Test/project.json
+++ b/src/NodaTime.TzdbCompiler.Test/project.json
@@ -20,9 +20,9 @@
   "dependencies": {
     "NodaTime": { "target": "project" },
     "NodaTime.TzdbCompiler": { "target": "project" },
-    "NUnit": "3.2.1",
-    "dotnet-test-nunit": "3.4.0-alpha-1",
-    "System.Xml.XDocument": "4.0.11-rc2-24027"
+    "NUnit": "3.4.0",
+    "dotnet-test-nunit": "3.4.0-alpha-2",
+    "System.Xml.XDocument": "4.0.11"
   },
 
   "testRunner": "nunit",
@@ -32,7 +32,7 @@
       "imports" : [ "dnxcore50", "netcoreapp1.0", "portable-net45+win8" ],
       "dependencies": {
         "Microsoft.NETCore.App": {
-          "version": "1.0.0-*",
+          "version": "1.0.0",
           "type": "platform"
         }
       }

--- a/src/NodaTime.TzdbCompiler/packages.config
+++ b/src/NodaTime.TzdbCompiler/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="sharpcompress" version="0.11.1" targetFramework="net45" />
-</packages>

--- a/src/NodaTime.TzdbCompiler/project.json
+++ b/src/NodaTime.TzdbCompiler/project.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "NodaTime": { "target": "project" },
     "SharpCompress": "0.11.6",
-    "System.Net.Http": "4.0.1-rc2-24027"
+    "System.Net.Http": "4.1.0"
   },
 
   "frameworks": {
@@ -34,7 +34,7 @@
       "dependencies": {
         "Microsoft.NETCore.App": {
           "type": "platform",
-          "version": "1.0.0-rc2-3002702"
+          "version": "1.0.0"
         }
       }
     }

--- a/src/NodaTime/project.json
+++ b/src/NodaTime/project.json
@@ -54,14 +54,18 @@
         "define": [ "PCL" ]
       },
       "dependencies": {
-        "System.Linq": "4.1.0-rc2-24027",
-        "System.Runtime.Numerics": "4.0.1-rc2-24027",
-        "System.Runtime.Serialization.Xml": "4.1.1-rc2-24027",
-        "System.Threading": "4.0.11-rc2-24027",
-        "System.Threading.Thread": "4.0.0-rc2-24027",
-        "System.Xml.ReaderWriter": "4.0.11-rc2-24027",
-        "System.Xml.XmlDocument": "4.0.1-rc2-24027",
-        "System.Xml.XmlSerializer": "4.0.11-rc2-24027"
+        "System.Diagnostics.Debug": "4.0.11",
+        "System.Globalization": "4.0.11",
+        "System.Linq": "4.1.0",
+        "System.Resources.ResourceManager": "4.0.1",
+        "System.Runtime.Extensions": "4.1.0",
+        "System.Runtime.Numerics": "4.0.1",
+        "System.Runtime.Serialization.Xml": "4.1.1",
+        "System.Threading": "4.0.11",
+        "System.Threading.Thread": "4.0.0",
+        "System.Xml.ReaderWriter": "4.0.11",
+        "System.Xml.XmlDocument": "4.0.1",
+        "System.Xml.XmlSerializer": "4.0.11"
       }
     }
   }


### PR DESCRIPTION
Two issues remain:
- Some unmapped time zones (possibly fixed by an override file); probably unrelated to .NET Core
- NodaTime.Serialization.Test fails to execute due to conflicting Json.NET versions