### PR TITLE
Serve .nzd extensions as application/octet-stream

### DIFF
--- a/src/NodaTime-Web.sln
+++ b/src/NodaTime-Web.sln
@@ -7,6 +7,10 @@ Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NodaTime.Web", "NodaTime.We
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NodaTime", "NodaTime\NodaTime.xproj", "{29F470FA-C1CB-408B-A0B6-C1A9216C4B7B}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NodaTime.TzdbCompiler", "NodaTime.TzdbCompiler\NodaTime.TzdbCompiler.xproj", "{30E9D024-1A36-415B-96A8-B7A3A393FBB0}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NodaTime.TzValidate.NodaDump", "NodaTime.TzValidate.NodaDump\NodaTime.TzValidate.NodaDump.xproj", "{F546EDA0-6B44-4B32-A8BE-18B1FE664BFF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +25,14 @@ Global
 		{29F470FA-C1CB-408B-A0B6-C1A9216C4B7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29F470FA-C1CB-408B-A0B6-C1A9216C4B7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{29F470FA-C1CB-408B-A0B6-C1A9216C4B7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30E9D024-1A36-415B-96A8-B7A3A393FBB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30E9D024-1A36-415B-96A8-B7A3A393FBB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30E9D024-1A36-415B-96A8-B7A3A393FBB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30E9D024-1A36-415B-96A8-B7A3A393FBB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F546EDA0-6B44-4B32-A8BE-18B1FE664BFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F546EDA0-6B44-4B32-A8BE-18B1FE664BFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F546EDA0-6B44-4B32-A8BE-18B1FE664BFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F546EDA0-6B44-4B32-A8BE-18B1FE664BFF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NodaTime.Web/Controllers/TzValidateController.cs
+++ b/src/NodaTime.Web/Controllers/TzValidateController.cs
@@ -2,6 +2,9 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 using Microsoft.AspNetCore.Mvc;
+using NodaTime.TimeZones;
+using NodaTime.TzValidate.NodaDump;
+using System.IO;
 using System.Net;
 
 namespace NodaTime.Web.Controllers
@@ -9,11 +12,17 @@ namespace NodaTime.Web.Controllers
     public class TzValidateController : Controller
     {
         // This will do something soon :)
-        public IActionResult Index(int startYear = 1, int endYear = 2035)
+        public IActionResult Generate(int startYear = 1, int endYear = 2035)
         {
+            var source = TzdbDateTimeZoneSource.Default;
+            var writer = new StringWriter();
+            var options = new Options { FromYear = startYear, ToYear = endYear };
+            var dumper = new ZoneDumper(source, options);
+            dumper.Dump(writer);
+
             return new ContentResult
             {
-                Content = $"Foo; start={startYear} end = {endYear}",
+                Content = writer.ToString(),
                 ContentType = "text/plain",
                 StatusCode = (int) HttpStatusCode.OK
             };

--- a/src/NodaTime.Web/Startup.cs
+++ b/src/NodaTime.Web/Startup.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -46,7 +47,12 @@ namespace NodaTime.Web
             }
 
             app.UseDefaultFiles();
-            app.UseStaticFiles();
+            var contentTypeProvider = new FileExtensionContentTypeProvider();
+            contentTypeProvider.Mappings[".nzd"] = "application/octet-stream";
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                ContentTypeProvider = contentTypeProvider
+            });
 
             // At some stage we may want an MVC view for the home page, but at the moment
             // we're just serving static files, so we don't need much.

--- a/src/NodaTime.Web/project.json
+++ b/src/NodaTime.Web/project.json
@@ -20,7 +20,8 @@
     "Microsoft.Extensions.Logging.Debug": "1.0.0",
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
     "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0",
-    "NodaTime": { "target": "project" }
+    "NodaTime": { "target": "project" },
+    "NodaTime.TzValidate.NodaDump": { "target": "project" }
   },
 
   "tools": {


### PR DESCRIPTION
This will fix issue #548 when the web site is rebuilt.

(There are other accidental changes in here too, but they're not problematic.)