### PR TITLE
Remove System.Runtime.Numerics dependency from NodaTime.Testing.

### DIFF
--- a/src/NodaTime.Testing/project.json
+++ b/src/NodaTime.Testing/project.json
@@ -42,9 +42,6 @@
     "netstandard1.1": {
       "buildOptions": {
         "define": [ "PCL" ]
-      },
-      "dependencies": {
-        "System.Runtime.Numerics": "4.0.1"
       }
     }
   }


### PR DESCRIPTION
This looks like it's okay now.

Closes #510.