### PR TITLE
Add the ability to coalesce zone intervals

### DIFF
--- a/src/NodaTime.TzValidate.NodaDump/ZoneDumper.cs
+++ b/src/NodaTime.TzValidate.NodaDump/ZoneDumper.cs
@@ -85,16 +85,11 @@ namespace NodaTime.TzValidate.NodaDump
                 OffsetPattern.Format(initial.WallOffset),
                 initial.Savings != Offset.Zero ? "daylight" : "standard",
                 initial.Name);
-            // TODO: It would be nice to be able to pass GetZoneIntervals an option like ZoneEqualityComparer...
-            var previousWallOffset = initial.WallOffset;
-            foreach (var zoneInterval in zone.GetZoneIntervals(options.Start, options.End)
+            var equalityOptions = options.WallChangeOnly ?
+                ZoneEqualityComparer.Options.OnlyMatchWallOffset : ZoneEqualityComparer.Options.StrictestMatch;
+            foreach (var zoneInterval in zone.GetZoneIntervals(new Interval(options.Start, options.End), equalityOptions)
                 .Where(zi => zi.HasStart && zi.Start >= options.Start))
             {
-                if (options.WallChangeOnly && previousWallOffset == zoneInterval.WallOffset)
-                {
-                    continue;
-                }
-                previousWallOffset = zoneInterval.WallOffset;
                 writer.Write(lineFormat,
                     InstantPattern.Format(zoneInterval.Start),
                     OffsetPattern.Format(zoneInterval.WallOffset),

--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -630,5 +630,39 @@ namespace NodaTime
                 current = zoneInterval.RawEnd;
             }
         }
+
+        /// <summary>
+        /// Returns the zone intervals within the given interval, potentially coalescing some of the
+        /// original intervals according to options.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is equivalent to <see cref="GetZoneIntervals(Interval)"/>, but may coalesce some intervals.
+        /// For example, if the <see cref="ZoneEqualityComparer.Options.OnlyMatchWallOffset"/> is specified,
+        /// and two consecutive zone intervals have the same offset but different names, a single zone interval
+        /// will be returned instead of two separate ones. When zone intervals are coalesced, all aspects of
+        /// the first zone interval are used except its end instant, which is taken from the second zone interval.
+        /// </para>
+        /// <para>
+        /// As the options are only used to determine which intervals to coalesce, the
+        /// <see cref="ZoneEqualityComparer.Options.MatchStartAndEndTransitions"/> option does not affect
+        /// the intervals returned.
+        /// </para>
+        /// </remarks>
+        /// <param name="interval">Interval to find zone intervals for. This is allowed to be unbounded (i.e.
+        /// infinite in both directions).</param>
+        /// <param name="options"></param>
+        /// <returns></returns>
+        public IEnumerable<ZoneInterval> GetZoneIntervals(Interval interval, ZoneEqualityComparer.Options options)
+        {
+            if ((options & ~ZoneEqualityComparer.Options.StrictestMatch) != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(options),
+                    $"The value {options} is not defined within ZoneEqualityComparer.Options");
+            }
+            var zoneIntervalEqualityComparer = new ZoneEqualityComparer.ZoneIntervalEqualityComparer(options, interval);
+            var originalIntervals = GetZoneIntervals(interval);
+            return zoneIntervalEqualityComparer.CoalesceIntervals(originalIntervals);
+        }
     }
 }


### PR DESCRIPTION
...  when asking for all the zone intervals in an interval.

This is slightly odd as it reuses an existing enum and not every
option will affect the result, but I think it's okay.

(I needed this for ZoneDumper, and it feels like it's generally useful.)