### PR TITLE
Update to BenchmarkDotNet 0.9.9

### DIFF
--- a/src/NodaTime.Benchmarks/project.json
+++ b/src/NodaTime.Benchmarks/project.json
@@ -15,7 +15,7 @@
   },
 
   "dependencies": {
-    "BenchmarkDotNet": "0.9.8",
+    "BenchmarkDotNet": "0.9.9",
     "NodaTime": { "target": "project" },
     "NodaTime.Serialization.JsonNet": { "target": "project" },
     "NodaTime.Testing": { "target": "project" },
@@ -25,7 +25,7 @@
   "testRunner": "nunit",
 
   "frameworks": {
-    "net451": {
+    "net45": {
       "frameworkAssemblies": {
         "System.Runtime": "",
         "System.Threading.Tasks": "",


### PR DESCRIPTION
This supports .NET Core, but we still have a "Category" attribute which would probably need an extra dependency; will investigate that separately.