### PR TITLE
Pedantic - added Northern Hemisphere to "winter"

### DIFF
--- a/docs/userguide/unstable/concepts.md
+++ b/docs/userguide/unstable/concepts.md
@@ -133,7 +133,7 @@ An offset is positive if local time is later than (ahead of) UTC,
 and negative if local time is earlier than (behind) UTC. For
 example, the offset in France is +1 hour in the winter and +2 hours in
 the summer; the offset in California is -8 hours in the winter and
--7 hours in the summer. So at noon UTC in winter, it's 4am in
+-7 hours in the summer. So at noon UTC during winter in the Northern Hemisphere, it's 4am in
 California and 1pm in France.
 
 As well as mapping any particular instant to an offset,


### PR DESCRIPTION
This is a tiny change to be extra precise about the fact that the help guid talks about winter in the Northern Hemisphere. Being pedantic about time/date is good, right? ;) 