### PR TITLE
Fix TzValidate.NodaDump

### DIFF
--- a/src/NodaTime.TzdbCompiler/Program.cs
+++ b/src/NodaTime.TzdbCompiler/Program.cs
@@ -54,7 +54,7 @@ namespace NodaTime.TzdbCompiler
             var writer = new TzdbStreamWriter();
             using (var stream = CreateOutputStream(options))
             {
-                writer.Write(tzdb, windowsZones, stream);
+                writer.Write(tzdb, windowsZones, PclSupport.StandardNameToIdMap, stream);
             }
 
             if (options.OutputFileName != null)

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbDatabase.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbDatabase.cs
@@ -64,8 +64,8 @@ namespace NodaTime.TzdbCompiler.Tzdb
         public TzdbDateTimeZoneSource ToTzdbDateTimeZoneSource()
         {
             var ms = new MemoryStream();
-            var writer = new TzdbStreamWriter(ms);
-            writer.Write(this, new WindowsZones("n/a", Version, "n/a", new MapZone[0]));
+            var writer = new TzdbStreamWriter();
+            writer.Write(this, new WindowsZones("n/a", Version, "n/a", new MapZone[0]), ms);
             ms.Position = 0;
             return TzdbDateTimeZoneSource.FromStream(ms);
         }

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbDatabase.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbDatabase.cs
@@ -65,7 +65,10 @@ namespace NodaTime.TzdbCompiler.Tzdb
         {
             var ms = new MemoryStream();
             var writer = new TzdbStreamWriter();
-            writer.Write(this, new WindowsZones("n/a", Version, "n/a", new MapZone[0]), ms);
+            writer.Write(this,
+                new WindowsZones("n/a", Version, "n/a", new MapZone[0]), // No Windows mappings,
+                new Dictionary<string, string>(), // No additional name-to-id mappings
+                ms);
             ms.Position = 0;
             return TzdbDateTimeZoneSource.FromStream(ms);
         }

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbStreamWriter.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbStreamWriter.cs
@@ -31,14 +31,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
     {
         private const int Version = 0;
 
-        private readonly Stream stream;
-
-        internal TzdbStreamWriter(Stream stream)
-        {
-            this.stream = stream;
-        }
-
-        public void Write(TzdbDatabase database, WindowsZones cldrWindowsZones)
+        public void Write(TzdbDatabase database, WindowsZones cldrWindowsZones, Stream stream)
         {
             FieldCollection fields = new FieldCollection();
 
@@ -107,8 +100,6 @@ namespace NodaTime.TzdbCompiler.Tzdb
             // Now write all the fields out, in the right order.
             new BinaryWriter(stream).Write(Version);
             fields.WriteTo(stream);
-            
-            stream.Dispose();
         }
 
         private static void WriteZone(DateTimeZone zone, IDateTimeZoneWriter writer)

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbStreamWriter.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbStreamWriter.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using NodaTime.TimeZones.IO;
 using NodaTime.TimeZones.Cldr;
+using NodaTime.Utility;
 
 namespace NodaTime.TzdbCompiler.Tzdb
 {
@@ -31,7 +32,11 @@ namespace NodaTime.TzdbCompiler.Tzdb
     {
         private const int Version = 0;
 
-        public void Write(TzdbDatabase database, WindowsZones cldrWindowsZones, Stream stream)
+        public void Write(
+            TzdbDatabase database,
+            WindowsZones cldrWindowsZones,
+            IDictionary<string, string> additionalWindowsNameToIdMappings,
+            Stream stream)
         {
             FieldCollection fields = new FieldCollection();
 
@@ -64,7 +69,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
             // Windows mappings
             cldrWindowsZones.Write(fields.AddField(TzdbStreamFieldId.CldrSupplementalWindowsZones, stringPool).Writer);
             fields.AddField(TzdbStreamFieldId.WindowsAdditionalStandardNameToIdMapping, stringPool).Writer.WriteDictionary
-                (PclSupport.StandardNameToIdMap.ToDictionary(pair => pair.Key, pair => cldrWindowsZones.PrimaryMapping[pair.Value]));
+                (additionalWindowsNameToIdMappings.ToDictionary(pair => pair.Key, pair => cldrWindowsZones.PrimaryMapping[pair.Value]));
 
             // Zone locations, if any.
             var zoneLocations = database.ZoneLocations;


### PR DESCRIPTION
Two different issues prevented running the TzValidate code directly with an IANA URL.
