### PR TITLE
Rationalize Duration properties/methods

### DIFF
--- a/src/NodaTime.Test/DurationTest.Construction.cs
+++ b/src/NodaTime.Test/DurationTest.Construction.cs
@@ -15,7 +15,7 @@ namespace NodaTime.Test
         public void Zero()
         {
             Duration test = Duration.Zero;
-            Assert.AreEqual(0, test.Ticks);
+            Assert.AreEqual(0, test.BclCompatibleTicks);
         }
 
         private static void TestFactoryMethod(Func<long, Duration> method, long value, long nanosecondsPerUnit)
@@ -205,7 +205,7 @@ namespace NodaTime.Test
             Assert.AreEqual(ticks * (BigInteger) NodaConstants.NanosecondsPerTick, nanoseconds.ToBigIntegerNanoseconds());
 
             // Just another sanity check, although Ticks is covered in more detail later.
-            Assert.AreEqual(ticks, nanoseconds.Ticks);
+            Assert.AreEqual(ticks, nanoseconds.BclCompatibleTicks);
         }
 
         private static void AssertOutOfRange<T>(Func<T, Duration> factoryMethod, params T[] values)

--- a/src/NodaTime.Test/DurationTest.cs
+++ b/src/NodaTime.Test/DurationTest.cs
@@ -225,43 +225,43 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void Ticks_Zero()
+        public void BclCompatibleTick_Zero()
         {
-            Assert.AreEqual(0, Duration.FromTicks(0).Ticks);
-            Assert.AreEqual(0, Duration.FromNanoseconds(99L).Ticks);
-            Assert.AreEqual(0, Duration.FromNanoseconds(-99L).Ticks);
+            Assert.AreEqual(0, Duration.FromTicks(0).BclCompatibleTicks);
+            Assert.AreEqual(0, Duration.FromNanoseconds(99L).BclCompatibleTicks);
+            Assert.AreEqual(0, Duration.FromNanoseconds(-99L).BclCompatibleTicks);
         }
 
         [Test]
         [TestCase(5L)]
         [TestCase(NodaConstants.TicksPerDay * 2)]
         [TestCase(NodaConstants.TicksPerDay * 365000)]
-        public void Ticks_Positive(long ticks)
+        public void BclCompatibleTick_Positive(long ticks)
         {
             Assert.IsTrue(ticks > 0);
             Duration start = Duration.FromTicks(ticks);
-            Assert.AreEqual(ticks, start.Ticks);
+            Assert.AreEqual(ticks, start.BclCompatibleTicks);
 
             // We truncate towards zero... so subtracting 1 nanosecond should
             // reduce the number of ticks, and adding 99 nanoseconds should not change it
-            Assert.AreEqual(ticks - 1, start.MinusSmallNanoseconds(1L).Ticks);
-            Assert.AreEqual(ticks, start.PlusSmallNanoseconds(99L).Ticks);
+            Assert.AreEqual(ticks - 1, start.MinusSmallNanoseconds(1L).BclCompatibleTicks);
+            Assert.AreEqual(ticks, start.PlusSmallNanoseconds(99L).BclCompatibleTicks);
         }
 
         [Test]
         [TestCase(-5L)]
         [TestCase(-NodaConstants.TicksPerDay * 2)]
         [TestCase(-NodaConstants.TicksPerDay * 365000)]
-        public void Ticks_Negative(long ticks)
+        public void BclCompatibleTicks_Negative(long ticks)
         {
             Assert.IsTrue(ticks < 0);
             Duration start = Duration.FromTicks(ticks);
-            Assert.AreEqual(ticks, start.Ticks);
+            Assert.AreEqual(ticks, start.BclCompatibleTicks);
 
             // We truncate towards zero... so subtracting 99 nanoseconds should
             // have no effect, and adding 1 should increase the number of ticks
-            Assert.AreEqual(ticks, start.MinusSmallNanoseconds(99L).Ticks);
-            Assert.AreEqual(ticks + 1, start.PlusSmallNanoseconds(1L).Ticks);
+            Assert.AreEqual(ticks, start.MinusSmallNanoseconds(99L).BclCompatibleTicks);
+            Assert.AreEqual(ticks + 1, start.PlusSmallNanoseconds(1L).BclCompatibleTicks);
         }
 
         [Test]
@@ -275,10 +275,10 @@ namespace NodaTime.Test
 
         [Test]
         [Category("Overflow")]
-        public void TicksWithOverflow()
+        public void BclCompatibleTicks_Overflow()
         {
             Duration maxTicks = Duration.FromTicks(long.MaxValue) + Duration.FromTicks(1);
-            Assert.Throws<OverflowException>(() => maxTicks.Ticks.ToString());
+            Assert.Throws<OverflowException>(() => maxTicks.BclCompatibleTicks.ToString());
         }
 
         [Test]
@@ -320,6 +320,8 @@ namespace NodaTime.Test
             Assert.AreEqual(99.0336, duration.TotalHours, 0.0001);
             Assert.AreEqual(5942.0187, duration.TotalMinutes, 0.0001);
             Assert.AreEqual(356521.123456789, duration.TotalSeconds, 0.000000001);
+            Assert.AreEqual(356521123.456789, duration.TotalMilliseconds, 0.000001);
+            Assert.AreEqual(356521123456789d, duration.TotalNanoseconds, 1);
         }
 
         [Test]
@@ -331,8 +333,10 @@ namespace NodaTime.Test
             Assert.AreEqual(-99.0336, duration.TotalHours, 0.0001);
             Assert.AreEqual(-5942.0187, duration.TotalMinutes, 0.0001);
             Assert.AreEqual(-356521.123456789, duration.TotalSeconds, 0.000000001);
+            Assert.AreEqual(-356521123.456789, duration.TotalMilliseconds, 0.000001);
+            Assert.AreEqual(-356521123456789d, duration.TotalNanoseconds, 1);
         }
-        
+
         [Test]
         public void MaxMinRelationship()
         {

--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -654,7 +654,7 @@ namespace NodaTime.Test
                 4 * NodaConstants.TicksPerMinute +
                 5 * NodaConstants.TicksPerSecond +
                 6 * NodaConstants.TicksPerMillisecond + 7,
-                period.ToDuration().Ticks);
+                period.ToDuration().BclCompatibleTicks);
         }
 
         [Test]

--- a/src/NodaTime.Test/SystemClockTest.cs
+++ b/src/NodaTime.Test/SystemClockTest.cs
@@ -13,7 +13,7 @@ namespace NodaTime.Test
         {
             long frameworkNowTicks = NodaConstants.BclEpoch.PlusTicks(DateTime.UtcNow.Ticks).ToUnixTimeTicks();
             long nodaTicks = SystemClock.Instance.GetCurrentInstant().ToUnixTimeTicks();
-            Assert.Less(Math.Abs(nodaTicks - frameworkNowTicks), Duration.FromSeconds(1).Ticks);
+            Assert.Less(Math.Abs(nodaTicks - frameworkNowTicks), Duration.FromSeconds(1).BclCompatibleTicks);
         }
 
         [Test]

--- a/src/NodaTime.TzdbCompiler.Test/Tzdb/TokensTest.cs
+++ b/src/NodaTime.TzdbCompiler.Test/Tzdb/TokensTest.cs
@@ -42,7 +42,7 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
             const string text = "0:09:21";
             var offset = ParserHelper.ParseOffset(text);
             Duration duration = Duration.FromMinutes(9) + Duration.FromSeconds(21);
-            Assert.AreEqual(Offset.FromTicks(duration.Ticks), offset);
+            Assert.AreEqual(Offset.FromTicks(duration.BclCompatibleTicks), offset);
         }
 
         [Test]
@@ -52,7 +52,7 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
             const string text = "-0:06:04";
             var offset = ParserHelper.ParseOffset(text);
             Duration duration = Duration.FromMinutes(6) + Duration.FromSeconds(4);
-            Assert.AreEqual(Offset.FromTicks(-duration.Ticks), offset);
+            Assert.AreEqual(Offset.FromTicks(-duration.BclCompatibleTicks), offset);
         }
 
         private static void AssertTokensEqual(IList<string> expectedTokens, Tokens tokens)


### PR DESCRIPTION
- Ticks => BclCompatibleTicks
- ToDoubleNanoseconds() => TotalNanoseconds
- Add TotalMilliseconds
- Fix typos in XML comments

Fixes #402.