### PR TITLE
Separate running coverage out of AppVeyor script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ BenchmarkDotNet.Artifacts
 
 # Packages installed during the build
 packages
+
+coverage.xml
+coverage

--- a/build/appveyor.sh
+++ b/build/appveyor.sh
@@ -3,27 +3,16 @@
 # Build script run by Appveyor. Might eventually be less
 # single-purpose, but let's get coverage going ASAP...
 
-set -e
-
-# cd to repository root
-cd $(dirname $0)/..
-
-dotnet restore src
-dotnet build -c Release src/NodaTime.Test
-dotnet test -c Release -f net451 src/NodaTime.Test --where=cat!=Slow
-
 if [ -n "$COVERALLS_REPO_TOKEN" ]
 then
-  nuget install -OutputDirectory packages -Version 4.6.519 OpenCover
-  nuget install -OutputDirectory packages -Version 0.7.0 coveralls.net
-  packages/OpenCover.4.6.519/tools/OpenCover.Console.exe \
-    -register:user \
-    -oldStyle \
-    -target:"c:\Program Files\dotnet\dotnet.exe" \
-    -targetargs:"test -f net451 src/NodaTime.Test -where=cat!=Slow" \
-    -output:coverage.xml \
-    -filter:"+[NodaTime]NodaTime.*" \
-    -searchdirs:NodaTime/bin/Release/net451/win7-x64
-
+  ./coverage.sh
+  cd $(dirname $0)/..
   packages/coveralls.net.0.7.0/tools/csmacnz.Coveralls.exe --opencover -i coverage.xml --useRelativePaths
+else
+  # Just do the build and test instead...
+  cd $(dirname $0)/..
+
+  dotnet restore src
+  dotnet build -c Release src/NodaTime.Test
+  dotnet test -c Release -f net451 src/NodaTime.Test --where=cat!=Slow
 fi

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+# cd to repository root
+cd $(dirname $0)/..
+
+nuget install -Verbosity quiet -OutputDirectory packages -Version 4.6.519 OpenCover
+nuget install -Verbosity quiet -OutputDirectory packages -Version 0.7.0 coveralls.net
+nuget install -Verbosity quiet -OutputDirectory packages -Version 2.4.5.0 ReportGenerator
+
+dotnet restore src
+dotnet build -c Release src/NodaTime.Test
+
+# Note: need to run netcoreapp1.0 build to avoid InvalidProgramException,
+# due to RyuJIT (I think). See 
+# http://stackoverflow.com/questions/36755337
+# This does mean we don't get coverage for types not in .NET Core though.
+packages/OpenCover.4.6.519/tools/OpenCover.Console.exe \
+  -register:user \
+  -oldStyle \
+  -target:"c:\Program Files\dotnet\dotnet.exe" \
+  -targetargs:"test -f netcoreapp1.0 -c Release src/NodaTime.Test -where=cat!=Slow" \
+  -output:coverage.xml \
+  -filter:"+[NodaTime]NodaTime.*" \
+  -searchdirs:NodaTime/bin/Release/net451/win7-x64
+
+packages/ReportGenerator.2.4.5.0/tools/ReportGenerator.exe \
+  -reports:coverage.xml \
+  -targetdir:coverage \
+  -verbosity:Error


### PR DESCRIPTION
Also run netcoreapp1.0 rather than net451 tests, to avoid
JIT errors. Not ideal, but better.