### PR TITLE
Use reference equality for time zones other than FixedDateTimeZone

### DIFF
--- a/src/NodaTime.Test/DateTimeZoneTest.cs
+++ b/src/NodaTime.Test/DateTimeZoneTest.cs
@@ -30,7 +30,6 @@ namespace NodaTime.Test
             var zone2 = DateTimeZone.ForOffset(offset);
 
             Assert.AreNotSame(zone1, zone2);
-            Assert.AreEqual(zone1, zone2);
             Assert.IsTrue(zone1.IsFixed);
             Assert.AreEqual(offset, zone1.MaxOffset);
             Assert.AreEqual(offset, zone1.MinOffset);

--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.cs
@@ -142,22 +142,6 @@ namespace NodaTime.Test.TimeZones
             Assert.AreEqual(Offset.Zero, nodaZone.GetUtcOffset(Instant.FromUtc(-100, 10, 1, 0, 0)));
         }
 
-        [Test]
-        public void Equality()
-        {
-            if (BclZonesOrJustNullOnMono.Count < 2)
-            {
-                return;
-            }
-            var firstEqual = BclDateTimeZone.FromTimeZoneInfo(BclZonesOrJustNullOnMono[0]);
-            var secondEqual = BclDateTimeZone.FromTimeZoneInfo(BclZonesOrJustNullOnMono[0]);
-            var unequal = BclDateTimeZone.FromTimeZoneInfo(BclZonesOrJustNullOnMono[1]);
-            Assert.AreEqual(firstEqual, secondEqual);
-            Assert.AreEqual(firstEqual.GetHashCode(), secondEqual.GetHashCode());
-            Assert.AreNotSame(firstEqual, secondEqual);
-            Assert.AreNotEqual(firstEqual, unequal);
-        }
-
         private void ValidateZoneEquality(Instant instant, DateTimeZone nodaZone, TimeZoneInfo windowsZone)
         {
             // The BCL is basically broken (up to and including .NET 4.5.1 at least) around its interpretation

--- a/src/NodaTime.Test/TimeZones/FixedDateTimeZoneTest.cs
+++ b/src/NodaTime.Test/TimeZones/FixedDateTimeZoneTest.cs
@@ -132,11 +132,11 @@ namespace NodaTime.Test.TimeZones
         [Test]
         public void Equals()
         {
-            TestHelper.TestEqualsClass<DateTimeZone>(new FixedDateTimeZone(Offset.FromSeconds(300)),
+            TestHelper.TestEqualsClass(new FixedDateTimeZone(Offset.FromSeconds(300)),
                 new FixedDateTimeZone(Offset.FromSeconds(300)),
                 new FixedDateTimeZone(Offset.FromSeconds(500)));
 
-            TestHelper.TestEqualsClass<DateTimeZone>(new FixedDateTimeZone("Foo", Offset.FromSeconds(300)),
+            TestHelper.TestEqualsClass(new FixedDateTimeZone("Foo", Offset.FromSeconds(300)),
                 new FixedDateTimeZone("Foo", Offset.FromSeconds(300)),
                 new FixedDateTimeZone("Bar", Offset.FromSeconds(300)));
         }

--- a/src/NodaTime.Test/TimeZones/PrecalculatedDateTimeZoneTest.cs
+++ b/src/NodaTime.Test/TimeZones/PrecalculatedDateTimeZoneTest.cs
@@ -278,18 +278,5 @@ namespace NodaTime.Test.TimeZones
             };
             PrecalculatedDateTimeZone.ValidatePeriods(intervals, null);
         }
-
-        [Test]
-        public void Equals()
-        {
-            TestHelper.TestEqualsClass<DateTimeZone>
-                (new PrecalculatedDateTimeZone("Test", new[] { FirstInterval, SecondInterval, ThirdInterval }, TailZone),
-                 new PrecalculatedDateTimeZone("Test", new[] { FirstInterval, SecondInterval, ThirdInterval }, TailZone),
-                 new PrecalculatedDateTimeZone("Test other ID", new[] { FirstInterval, SecondInterval, ThirdInterval }, TailZone));
-            TestHelper.TestEqualsClass<DateTimeZone>
-                (new PrecalculatedDateTimeZone("Test", new[] { FirstInterval, SecondInterval, ThirdInterval }, TailZone),
-                 new PrecalculatedDateTimeZone("Test", new[] { FirstInterval, SecondInterval, ThirdInterval }, TailZone),
-                 new PrecalculatedDateTimeZone("Test", new[] { SecondInterval.WithStart(Instant.BeforeMinValue), ThirdInterval }, TailZone));
-        }
     }
 }

--- a/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
+++ b/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
@@ -63,19 +63,6 @@ namespace NodaTime.Testing.TimeZones
             throw new InvalidOperationException(string.Format("Instant {0} did not exist in time zone {1}", instant, Id));
         }
 
-        /// <inheritdoc />
-        protected override bool EqualsImpl(DateTimeZone zone)
-        {
-            // Just use reference equality...
-            return ReferenceEquals(this, zone);
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return RuntimeHelpers.GetHashCode(this);
-        }
-
         /// <summary>
         /// Builder to create instances of <see cref="MultiTransitionDateTimeZone"/>. Each builder
         /// can only be built once.

--- a/src/NodaTime.Testing/TimeZones/SingleTransitionDateTimeZone.cs
+++ b/src/NodaTime.Testing/TimeZones/SingleTransitionDateTimeZone.cs
@@ -72,22 +72,5 @@ namespace NodaTime.Testing.TimeZones
         /// This returns either the zone interval before or after the transition, based on the instant provided.
         /// </remarks>
         public override ZoneInterval GetZoneInterval(Instant instant) => EarlyInterval.Contains(instant) ? EarlyInterval : LateInterval;
-
-        /// <inheritdoc />
-        protected override bool EqualsImpl(DateTimeZone zone)
-        {
-            SingleTransitionDateTimeZone otherZone = (SingleTransitionDateTimeZone)zone;
-            return Id == otherZone.Id && EarlyInterval.Equals(otherZone.EarlyInterval) && LateInterval.Equals(otherZone.LateInterval);
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            int hash = 17;
-            hash = hash * 31 + Id.GetHashCode();
-            hash = hash * 31 + EarlyInterval.GetHashCode();
-            hash = hash * 31 + LateInterval.GetHashCode();
-            return hash;
-        }
     }
 }

--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -71,9 +71,12 @@ namespace NodaTime
     /// Note that <c>BclDateTimeZone</c> is not available on the PCL build of Noda Time, so this fallback strategy can
     /// only be used with the desktop version.
     /// </para>
-    /// <para>Note that Noda Time does not require that <see cref="DateTimeZone"/> instances be singletons.
-    /// As far as reasonably possible, implementations should implement <see cref="IEquatable{DateTimeZone}"/> in such a way
-    /// that equivalent time zones compare as equal.</para>
+    /// <para>
+    /// Note that Noda Time does not require that <see cref="DateTimeZone"/> instances be singletons.
+    /// Comparing two time zones for equality is not straightforward: if you care about whether two
+    /// zones act the same way within a particular portion of time, use <see cref="ZoneEqualityComparer"/>.
+    /// Additional guarantees are provided by <see cref="IDateTimeZoneProvider"/> and <see cref="ForOffset(Offset)"/>.
+    /// </para>
     /// </remarks>
     /// <threadsafety>
     /// All time zone implementations within Noda Time are immutable and thread-safe.
@@ -84,7 +87,7 @@ namespace NodaTime
     /// avoid this if possible.
     /// </threadsafety>
     [Immutable]
-    public abstract class DateTimeZone : IEquatable<DateTimeZone>, IZoneIntervalMapWithMinMax
+    public abstract class DateTimeZone : IZoneIntervalMapWithMinMax
     {
         /// <summary>
         /// The ID of the UTC (Coordinated Universal Time) time zone. This ID is always valid, whatever provider is
@@ -532,59 +535,6 @@ namespace NodaTime
             ret[-FixedZoneCacheMinimumSeconds / FixedZoneCacheGranularitySeconds] = Utc;
             return ret;
         }
-
-        #region Equality
-        /// <summary>
-        /// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
-        /// </summary>
-        /// <param name="obj">The <see cref="System.Object"/> to compare with this instance.</param>
-        /// <returns>
-        /// <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance;
-        /// otherwise, <c>false</c>.
-        /// </returns>
-        public override sealed bool Equals(object obj) => Equals(obj as DateTimeZone);
-
-        /// <summary>
-        /// Determines whether the specified <see cref="DateTimeZone"/> is equal to this instance.
-        /// </summary>
-        /// <remarks>
-        /// This implementation performs initial checks which would be common to all child implementations,
-        /// and then delegates to <see cref="EqualsImpl"/>.
-        /// </remarks>
-        /// <param name="obj">The <see cref="DateTimeZone"/> to compare with this instance.</param>
-        /// <returns>
-        /// <c>true</c> if the specified <see cref="DateTimeZone"/> is equal to this instance;
-        /// otherwise, <c>false</c>.
-        /// </returns>
-        public bool Equals(DateTimeZone obj)
-        {
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-            return !ReferenceEquals(obj, null) && obj.GetType() == GetType() && EqualsImpl(obj);
-        }
-
-        /// <summary>
-        /// Implements equality in derived classes.
-        /// </summary>
-        /// <param name="zone">The zone to compare with this one. This is guaranteed (when called by <see cref="Equals(DateTimeZone)"/>) to
-        /// be a non-null reference of the same type as this instance.</param>
-        /// <returns>
-        /// <c>true</c> if the specified <see cref="DateTimeZone"/> is equal to this instance;
-        /// otherwise, <c>false</c>.
-        /// </returns>
-        protected abstract bool EqualsImpl(DateTimeZone zone);
-
-        /// <summary>
-        /// Returns a hash code for this instance.
-        /// </summary>
-        /// <returns>
-        /// A hash code for this instance, suitable for use in hashing algorithms and data
-        /// structures like a hash table. 
-        /// </returns>
-        public abstract override int GetHashCode();
-        #endregion
 
         /// <summary>
         /// Returns all the zone intervals which occur for any instant in the interval [<paramref name="start"/>, <paramref name="end"/>).

--- a/src/NodaTime/IDateTimeZoneProvider.cs
+++ b/src/NodaTime/IDateTimeZoneProvider.cs
@@ -15,8 +15,8 @@ namespace NodaTime
     /// </summary>
     /// <remarks>
     /// <para>Consumers should be able to treat an <see cref="IDateTimeZoneProvider"/> like a cache: 
-    /// lookups should be quick (after at most one lookup of a given ID), and the data for a given ID should always be
-    /// the same (even if the specific instance returned is not).
+    /// lookups should be quick (after at most one lookup of a given ID), and multiple calls for a given ID must
+    /// always return references to equal instances, even if they are not references to a single instance.
     /// Consumers should not feel the need to cache data accessed through this interface.</para>
     /// <para>Implementations designed to work with any <see cref="IDateTimeZoneSource"/> implementation (such as
     /// <see cref="DateTimeZoneCache"/>) should not attempt to handle exceptions thrown by the source. A source-specific

--- a/src/NodaTime/TimeZones/BclDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZone.cs
@@ -280,19 +280,6 @@ namespace NodaTime.TimeZones
             // Always return our local variable; the variable may have changed again.
             return currentSystemDefault;
         }
-
-        /// <inheritdoc />
-        /// <remarks>
-        /// This implementation simply compares the underlying `TimeZoneInfo` values for
-        /// reference equality.
-        /// </remarks>
-        protected override bool EqualsImpl(DateTimeZone zone)
-        {
-            return ReferenceEquals(OriginalZone, ((BclDateTimeZone) zone).OriginalZone);
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode() => OriginalZone.GetHashCode();
     }
 }
 #endif

--- a/src/NodaTime/TimeZones/CachedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/CachedDateTimeZone.cs
@@ -71,17 +71,5 @@ namespace NodaTime.TimeZones
         {
             return map.GetZoneInterval(instant);
         }
-
-        #region I/O
-        protected override bool EqualsImpl(DateTimeZone zone)
-        {
-            return TimeZone.Equals(((CachedDateTimeZone) zone).TimeZone);
-        }
-
-        public override int GetHashCode()
-        {
-            return TimeZone.GetHashCode();
-        }
-        #endregion
     }
 }

--- a/src/NodaTime/TimeZones/PrecalculatedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/PrecalculatedDateTimeZone.cs
@@ -217,44 +217,6 @@ namespace NodaTime.TimeZones
             }
             return ret;
         }
-        #endregion
-
-        protected override bool EqualsImpl(DateTimeZone zone)
-        {
-            PrecalculatedDateTimeZone otherZone = (PrecalculatedDateTimeZone)zone;
-
-            // Check the individual fields first...
-            if (Id != otherZone.Id ||
-                !Equals(tailZone, otherZone.tailZone) ||
-                tailZoneStart != otherZone.tailZoneStart ||
-                !Equals(firstTailZoneInterval, otherZone.firstTailZoneInterval))
-            {
-                return false;
-            }
-
-            // Now all the intervals
-            if (periods.Length != otherZone.periods.Length)
-            {
-                return false;
-            }
-            for (int i = 0; i < periods.Length; i++)
-            {
-                if (!periods[i].Equals(otherZone.periods[i]))
-                {
-                    return false;
-                }
-            }
-            return true;                        
-        }
-
-        public override int GetHashCode()
-        {
-            var hash = HashCodeHelper.Initialize().Hash(Id).Hash(tailZoneStart).Hash(firstTailZoneInterval).Hash(tailZone);
-            foreach (var period in periods)
-            {
-                hash = hash.Hash(period);
-            }
-            return hash.Value;
-        }
+        #endregion        
     }
 }


### PR DESCRIPTION
IDateTimeZoneProvider is now documented to return equal zones when asked for the same
ID, which CachedDateTimeZoneProvider will do by way of caching for all non-fixed-offset zones, and
regular equality for FixedOffsetDateTimeZone.

Fixes #180.