### PR TITLE
Revisit time zone mapping

### DIFF
--- a/docs/developer/tzdb-file-format.md
+++ b/docs/developer/tzdb-file-format.md
@@ -239,7 +239,7 @@ This field contains the data from the windowsZones.xml file in [CLDR](http://cld
 
 This field must occur exactly once, and it uses the string pool.
 
-## Field 5: Additional information for Windows mapping
+## Field 5: Additional information for Windows mapping (obsolete)
 
 This field is only present for the sake of the PCL version, but is loaded in both builds anyway.
 It contains a mapping from Windows `TimeZoneInfo` standard name (in the en-US
@@ -248,6 +248,8 @@ where the two differ. (There are only a few.) This is required as the PCL doesn'
 `TimeZoneInfo.Id` property.
 
 The field data is a single `dictionary`. It must occur exactly once, and it uses the string pool.
+
+This field is not read in Noda Time 2.x, which uses `TimeZoneInfo.Id` (present in netstandard1.3).
 
 ## Field 6: Zone location information
 
@@ -262,6 +264,23 @@ The field data consists of a `count` of elements, then the elements themselves. 
 - A `signed count` for the longitude of the sample location, as an integer number of seconds.
 - A `string` for the name of the country.
 - A `string` for the ISO-3166 two-letter country code.
+- A `string` for the zone ID.
+- A (possibly empty) `string` for the comment associated with the location (usually used to disambiguate between
+  locations in the same country).
+
+## Field 7: "Zone1970" locations
+
+This field provides the information in the `iso3166.tab` and `zone1970.tab` files within TZDB.
+
+The field data consists of a `count` of elements, then the elements themselves. Each element consists of:
+
+- A `signed count` for the latitude of the sample location, as an integer number of seconds.
+- A `signed count` for the longitude of the sample location, as an integer number of seconds.
+- A `signed count` for the number of countries.
+- For each country:
+  - A `string` for the name of the country.
+  - A `string` for the ISO-3166 two-letter country code.
+- A `string` for the zone ID.
 - A (possibly empty) `string` for the comment associated with the location (usually used to disambiguate between
   locations in the same country).
 

--- a/src/NodaTime.Serialization.JsonNet/project.json
+++ b/src/NodaTime.Serialization.JsonNet/project.json
@@ -42,7 +42,7 @@
   "frameworks": {
     "net45": {
     },
-    "netstandard1.1": {
+    "netstandard1.3": {
       "buildOptions": {
         "define": [ "PCL" ]
       },

--- a/src/NodaTime.Test/Testing/TimeZones/FakeDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/Testing/TimeZones/FakeDateTimeZoneSourceTest.cs
@@ -61,17 +61,13 @@ namespace NodaTime.Test.Testing.TimeZones
         [Test]
         public void ValidWindowsMapping()
         {
-#if PCL
-            string localId = TimeZoneInfo.Local.StandardName;
-#else
             string localId = TimeZoneInfo.Local.Id;
-#endif
             var source = new FakeDateTimeZoneSource.Builder
             {
                 BclIdsToZoneIds = { { localId, "x"} },
                 Zones = { CreateZone("x"), CreateZone("y") }
             }.Build();
-            Assert.AreEqual("x", source.MapTimeZoneId(TimeZoneInfo.Local));
+            Assert.AreEqual("x", source.GetSystemDefaultId());
         }
 
         [Test]

--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneSourceTest.cs
@@ -14,16 +14,6 @@ namespace NodaTime.Test.TimeZones
     public class BclDateTimeZoneSourceTest
     {
         [Test]
-        public void AllZonesMapToTheirId()
-        {
-            BclDateTimeZoneSource source = new BclDateTimeZoneSource();
-            foreach (var zone in TimeZoneInfo.GetSystemTimeZones())
-            {
-                Assert.AreEqual(zone.Id, source.MapTimeZoneId(zone));
-            }
-        }
-
-        [Test]
         public void UtcDoesNotEqualBuiltIn()
         {
             var zone = new BclDateTimeZoneSource().ForId("UTC");
@@ -76,7 +66,8 @@ namespace NodaTime.Test.TimeZones
             // Now that we have our BCL local time zone, we should be able to look it up in the source.
 
             var source = new BclDateTimeZoneSource();
-            string id = source.MapTimeZoneId(local);  // in this case, just returns the Id, but required in general.
+            string id = source.GetSystemDefaultId();
+            Assert.IsNotNull(id);
 
             // These lines replicate how DateTimeZoneCache implements GetSystemDefault().
             Assert.Contains(id, source.GetIds().ToList(), "BCL local time zone ID should be included in the source ID list");

--- a/src/NodaTime.Test/TimeZones/DateTimeZoneCacheTest.cs
+++ b/src/NodaTime.Test/TimeZones/DateTimeZoneCacheTest.cs
@@ -257,11 +257,7 @@ namespace NodaTime.Test.TimeZones
 
             public string VersionId { get; set; }
 
-
-            public string MapTimeZoneId(TimeZoneInfo timeZone)
-            {
-                return "map";
-            }
+            public string GetSystemDefaultId() => "map";
         }
     }
 }

--- a/src/NodaTime.Testing/TimeZones/FakeDateTimeZoneSource.cs
+++ b/src/NodaTime.Testing/TimeZones/FakeDateTimeZoneSource.cs
@@ -59,21 +59,15 @@ namespace NodaTime.Testing.TimeZones
         // TODO: Work out why inheritdoc doesn't work here. What's special about this method?
 
         /// <summary>
-        /// Returns this source's corresponding ID for the given BCL time zone.
+        /// Returns this source's ID for the system default time zone.
         /// </summary>
-        /// <param name="timeZone">The BCL time zone, which must be a known system time zone.</param>
         /// <returns>
-        /// The ID for the given system time zone for this source, or null if the system time
-        /// zone has no mapping in this source.
+        /// The ID for the system default time zone for this source,
+        /// or null if the system default time zone has no mapping in this source.
         /// </returns>
-        public string MapTimeZoneId(TimeZoneInfo timeZone)
+        public string GetSystemDefaultId()
         {
-            Preconditions.CheckNotNull(timeZone, nameof(timeZone));
-#if PCL
-            string id = timeZone.StandardName;
-#else
-            string id = timeZone.Id;
-#endif
+            string id = TimeZoneInfo.Local.Id;
             string canonicalId;
             // We don't care about the return value of TryGetValue - if it's false,
             // canonicalId will be null, which is what we want.

--- a/src/NodaTime.Testing/project.json
+++ b/src/NodaTime.Testing/project.json
@@ -39,7 +39,7 @@
       "frameworkAssemblies": {
       }
     },
-    "netstandard1.1": {
+    "netstandard1.3": {
       "buildOptions": {
         "define": [ "PCL" ]
       }

--- a/src/NodaTime.TzdbCompiler/Tzdb/PclSupport.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/PclSupport.cs
@@ -34,6 +34,10 @@ namespace NodaTime.TzdbCompiler.Tzdb
                 { "Russia TZ 8 Standard Time", "Yakutsk Standard Time" },
                 { "Russia TZ 9 Standard Time", "Vladivostok Standard Time" },
                 { "Cabo Verde Standard Time", "Cape Verde Standard Time" },
+                { "West Bank Gaza Standard Time", "West Bank Standard Time" },
+                { "Novosibirsk Standard Time", "N. Central Asia Standard Time" },
+                // Difference here is just the case of "and"!
+                { "Turks and Caicos Standard Time", "Turks And Caicos Standard Time" },
                 // The following name/ID mappings give an ID which then isn't present in CLDR
                 // (at least in v26 data); these zones will have to be mapped by transitions
                 // in the PCL.

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbStreamWriter.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbStreamWriter.cs
@@ -68,6 +68,8 @@ namespace NodaTime.TzdbCompiler.Tzdb
 
             // Windows mappings
             cldrWindowsZones.Write(fields.AddField(TzdbStreamFieldId.CldrSupplementalWindowsZones, stringPool).Writer);
+            // Additional names from Windows Standard Name to canonical ID, used in Noda Time 1.x BclDateTimeZone, when we
+            // didn't have access to TimeZoneInfo.Id.
             fields.AddField(TzdbStreamFieldId.WindowsAdditionalStandardNameToIdMapping, stringPool).Writer.WriteDictionary
                 (additionalWindowsNameToIdMappings.ToDictionary(pair => pair.Key, pair => cldrWindowsZones.PrimaryMapping[pair.Value]));
 

--- a/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
@@ -111,19 +111,8 @@ namespace NodaTime.TimeZones
             }
         }
 
-        /// <summary>
-        /// Maps the BCL ID to "our" ID as an identity projection.
-        /// </summary>
-        /// <param name="timeZone">The BCL time zone, which must be a known system time zone.</param>
-        /// <returns>
-        /// The ID for the given BCL time zone for this source; that is, the value of the <c>Id</c> property of the
-        /// passed-in <see cref="TimeZoneInfo"/>.
-        /// </returns>
-        public string MapTimeZoneId([NotNull] TimeZoneInfo timeZone)
-        {
-            Preconditions.CheckNotNull(timeZone, nameof(timeZone));
-            return timeZone.Id;
-        }
+        /// <inheritdoc />
+        public string GetSystemDefaultId() => TimeZoneInfo.Local.Id;
     }
 }
 #endif

--- a/src/NodaTime/TimeZones/DateTimeZoneCache.cs
+++ b/src/NodaTime/TimeZones/DateTimeZoneCache.cs
@@ -80,15 +80,10 @@ namespace NodaTime.TimeZones
         /// <inheritdoc />
         public DateTimeZone GetSystemDefault()
         {
-            TimeZoneInfo bcl = TimeZoneInfo.Local;
-            string id = source.MapTimeZoneId(bcl);
+            string id = source.GetSystemDefaultId();
             if (id == null)
             {
-#if PCL
-                throw new DateTimeZoneNotFoundException("TimeZoneInfo name " + bcl.StandardName + " is unknown to source " + VersionId);
-#else
-                throw new DateTimeZoneNotFoundException("TimeZoneInfo ID " + bcl.Id + " is unknown to source " + VersionId);
-#endif
+                throw new DateTimeZoneNotFoundException($"System default time zone is unknown to source {VersionId}");
             }
             return this[id];
         }
@@ -114,7 +109,8 @@ namespace NodaTime.TimeZones
                     zone = source.ForId(id);
                     if (zone == null)
                     {
-                        throw new InvalidDateTimeZoneSourceException("Time zone " + id + " is supported by source " + VersionId + " but not returned");
+                        throw new InvalidDateTimeZoneSourceException(
+                            $"Time zone {id} is supported by source {VersionId} but not returned");
                     }
                     timeZoneMap[id] = zone;
                 }
@@ -130,7 +126,7 @@ namespace NodaTime.TimeZones
                 var zone = GetZoneOrNull(id);
                 if (zone == null)
                 {
-                    throw new DateTimeZoneNotFoundException("Time zone " + id + " is unknown to source " + VersionId);
+                    throw new DateTimeZoneNotFoundException($"Time zone {id} is unknown to source {VersionId}");
                 }
                 return zone;
             }

--- a/src/NodaTime/TimeZones/IDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/IDateTimeZoneSource.cs
@@ -96,13 +96,12 @@ namespace NodaTime.TimeZones
         DateTimeZone ForId([NotNull] string id);
 
         /// <summary>
-        /// Returns this source's corresponding ID for the given BCL time zone.
+        /// Returns this source's ID for the system default time zone.
         /// </summary>
-        /// <param name="timeZone">The BCL time zone, which must be a known system time zone.</param>
         /// <returns>
-        /// The ID for the given system time zone for this source, or null if the system time
-        /// zone has no mapping in this source.
+        /// The ID for the system default time zone for this source,
+        /// or null if the system default time zone has no mapping in this source.
         /// </returns>
-        string MapTimeZoneId([NotNull] TimeZoneInfo timeZone);
+        string GetSystemDefaultId();
     }
 }

--- a/src/NodaTime/project.json
+++ b/src/NodaTime/project.json
@@ -55,7 +55,7 @@
         "System.Numerics": ""
       }
     },
-    "netstandard1.1": {
+    "netstandard1.3": {
       "buildOptions": {
         "define": [ "PCL" ]
       },

--- a/www/developer/tzdb-file-format.md
+++ b/www/developer/tzdb-file-format.md
@@ -245,7 +245,7 @@ This field contains the data from the windowsZones.xml file in [CLDR](http://cld
 
 This field must occur exactly once, and it uses the string pool.
 
-## Field 5: Additional information for Windows mapping
+## Field 5: Additional information for Windows mapping (obsolete)
 
 This field is only present for the sake of the PCL version, but is loaded in both builds anyway.
 It contains a mapping from Windows `TimeZoneInfo` standard name (in the en-US
@@ -254,6 +254,8 @@ where the two differ. (There are only a few.) This is required as the PCL doesn'
 `TimeZoneInfo.Id` property.
 
 The field data is a single `dictionary`. It must occur exactly once, and it uses the string pool.
+
+This field is not read in Noda Time 2.x, which uses `TimeZoneInfo.Id` (present in netstandard1.3).
 
 ## Field 6: Zone location information
 
@@ -268,6 +270,22 @@ The field data consists of a `count` of elements, then the elements themselves. 
 - A `signed count` for the longitude of the sample location, as an integer number of seconds.
 - A `string` for the name of the country.
 - A `string` for the ISO-3166 two-letter country code.
+- A (possibly empty) `string` for the comment associated with the location (usually used to disambiguate between
+  locations in the same country).
+
+## Field 7: "Zone1970" locations
+
+This field provides the information in the `iso3166.tab` and `zone1970.tab` files within TZDB.
+
+The field data consists of a `count` of elements, then the elements themselves. Each element consists of:
+
+- A `signed count` for the latitude of the sample location, as an integer number of seconds.
+- A `signed count` for the longitude of the sample location, as an integer number of seconds.
+- A `signed count` for the number of countries.
+- For each country:
+  - A `string` for the name of the country.
+  - A `string` for the ISO-3166 two-letter country code.
+- A `string` for the zone ID.
 - A (possibly empty) `string` for the comment associated with the location (usually used to disambiguate between
   locations in the same country).
 


### PR DESCRIPTION
- IDateTimeZoneSource now only exposes GetSystemDefaultId
- Use TimeZoneInfo.Id instead of TimeZoneInfo.StandardName
  (requires netstandard1.3)
- Ignore the standard names field when reading NZD files. We
  still generate them for 1.x clients.
- If we can't find the local ID as a Windows ID, see if it's already
  a TZDB ID
- If we still can't find it, guess based on transitions.
- Fix missing standard name mappings.

Fixes #282.

Fixes #543.

Fixes #434.

(Apologies for several changes in one... they're all inter-related, and it was simpler to do them all in one go.)