### PR TITLE
Rename LocalDate.IsoDayOfWeek (et al) to DayOfWeek

### DIFF
--- a/docs/userguide/unstable/migration-to-2.md
+++ b/docs/userguide/unstable/migration-to-2.md
@@ -74,6 +74,14 @@ methods introduced in `DateTimeOffset` in .NET 4.6:
 - The `Ticks` property is now `ToUnixTimeTicks()`
 - There are two new methods, `ToUnixTimeSeconds()` and `ToUnixTimeMilliseconds()`
 
+Static properties on the pattern classes have been renamed to remove the `Pattern` suffix. For example,
+`LocalDateTimePattern.ExtendedIsoPattern` is now just `LocalDateTimePattern.ExtendedIso`.
+
+The `IsoDayOfWeek` properties in `LocalDate`, `LocalDateTime`, `OffsetDateTime`
+and `ZonedDateTime` are now just called `DayOfWeek`. The previous numeric `DayOfWeek` properties
+have been removed, but in all cases if you were actually calling them, you can just cast the `IsoDayOfWeek`
+to `int` and always get the same result, as all calendar systems use ISO days of the week.
+
 Period
 ====
 
@@ -87,9 +95,6 @@ setting date-based units.
 
 Normalization of a period which has time units which add up to a "days" range outside the range
 of `int` will similarly fail.
-
-Static properties on the pattern classes have been renamed to remove the `Pattern` suffix. For example,
-`LocalDateTimePattern.ExtendedIsoPattern` is now just `LocalDateTimePattern.ExtendedIso`.
 
 Offset
 ====

--- a/docs/userguide/unstable/versions.md
+++ b/docs/userguide/unstable/versions.md
@@ -9,6 +9,8 @@ Breaking changes:
 See the [Noda Time 1.x to 2.0 migration guide](migration-to-2.md) for full details.
 
 - Renamed all static pattern properties to remove the `Pattern` suffix
+- Renamed the `IsoDayOfWeek` properties in `LocalDate`, `LocalDateTime`, `OffsetDateTime`
+  and `ZonedDateTime` to just `DayOfWeek`, and removed the previous numeric `DayOfWeek` properties.
 - Removed members which had already been made obsolete in the 1.x release line, including
   support for the legacy resource-based time zone data format.
 - Removed `Instant(long)` constructor from the public API.

--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateBenchmarks.cs
@@ -78,12 +78,12 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek() => Sample.IsoDayOfWeek;
+        public IsoDayOfWeek IsoDayOfWeek() => Sample.DayOfWeek;
 
         [Benchmark]
         public IsoDayOfWeek IsoDayOfWeek_BeforeEpoch()
         {
-            return SampleBeforeEpoch.IsoDayOfWeek;
+            return SampleBeforeEpoch.DayOfWeek;
         }
 
         [Benchmark]

--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateBenchmarks.cs
@@ -78,10 +78,10 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek() => Sample.DayOfWeek;
+        public IsoDayOfWeek DayOfWeek() => Sample.DayOfWeek;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek_BeforeEpoch()
+        public IsoDayOfWeek DayOfWeek_BeforeEpoch()
         {
             return SampleBeforeEpoch.DayOfWeek;
         }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateTimeBenchmarks.cs
@@ -43,7 +43,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek() => Sample.DayOfWeek;
+        public IsoDayOfWeek DayOfWeek() => Sample.DayOfWeek;
 
         [Benchmark]
         public int DayOfYear() => Sample.DayOfYear;

--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateTimeBenchmarks.cs
@@ -43,7 +43,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek() => Sample.IsoDayOfWeek;
+        public IsoDayOfWeek IsoDayOfWeek() => Sample.DayOfWeek;
 
         [Benchmark]
         public int DayOfYear() => Sample.DayOfYear;

--- a/src/NodaTime.Benchmarks/NodaTimeTests/OffsetDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/OffsetDateTimeBenchmarks.cs
@@ -36,7 +36,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek() => Sample.IsoDayOfWeek;
+        public IsoDayOfWeek IsoDayOfWeek() => Sample.DayOfWeek;
 
         [Benchmark]
         public int DayOfYear() => Sample.DayOfYear;

--- a/src/NodaTime.Benchmarks/NodaTimeTests/OffsetDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/OffsetDateTimeBenchmarks.cs
@@ -36,7 +36,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek() => Sample.DayOfWeek;
+        public IsoDayOfWeek DayOfWeek() => Sample.DayOfWeek;
 
         [Benchmark]
         public int DayOfYear() => Sample.DayOfYear;

--- a/src/NodaTime.Benchmarks/NodaTimeTests/PacificZonedDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/PacificZonedDateTimeBenchmarks.cs
@@ -25,7 +25,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int DayOfMonth() => SampleZoned.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek() => SampleZoned.IsoDayOfWeek;
+        public IsoDayOfWeek IsoDayOfWeek() => SampleZoned.DayOfWeek;
 
         [Benchmark]
         public int DayOfYear() => SampleZoned.DayOfYear;

--- a/src/NodaTime.Benchmarks/NodaTimeTests/PacificZonedDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/PacificZonedDateTimeBenchmarks.cs
@@ -25,7 +25,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int DayOfMonth() => SampleZoned.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek() => SampleZoned.DayOfWeek;
+        public IsoDayOfWeek DayOfWeek() => SampleZoned.DayOfWeek;
 
         [Benchmark]
         public int DayOfYear() => SampleZoned.DayOfYear;

--- a/src/NodaTime.Benchmarks/NodaTimeTests/UtcZonedDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/UtcZonedDateTimeBenchmarks.cs
@@ -28,7 +28,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek() => Sample.DayOfWeek;
+        public IsoDayOfWeek DayOfWeek() => Sample.DayOfWeek;
 
         [Benchmark]
         public int DayOfYear() => Sample.DayOfYear;

--- a/src/NodaTime.Benchmarks/NodaTimeTests/UtcZonedDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/UtcZonedDateTimeBenchmarks.cs
@@ -28,7 +28,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int DayOfMonth() => Sample.Day;
 
         [Benchmark]
-        public IsoDayOfWeek IsoDayOfWeek() => Sample.IsoDayOfWeek;
+        public IsoDayOfWeek IsoDayOfWeek() => Sample.DayOfWeek;
 
         [Benchmark]
         public int DayOfYear() => Sample.DayOfYear;

--- a/src/NodaTime.Test/Calendars/CopticCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/CopticCalendarSystemTest.cs
@@ -50,7 +50,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(10, coptic.Month);
             Assert.AreEqual(2, coptic.Day);
             
-            Assert.AreEqual(IsoDayOfWeek.Wednesday, coptic.IsoDayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Wednesday, coptic.DayOfWeek);
 
             Assert.AreEqual(9 * 30 + 2, coptic.DayOfYear);
 

--- a/src/NodaTime.Test/Calendars/IslamicCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/IslamicCalendarSystemTest.cs
@@ -28,7 +28,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(1364, ldt.Year);
             Assert.AreEqual(12, ldt.Month);
             Assert.AreEqual(6, ldt.Day);
-            Assert.AreEqual(IsoDayOfWeek.Monday, ldt.IsoDayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Monday, ldt.DayOfWeek);
             Assert.AreEqual(6 * 30 + 5 * 29 + 6, ldt.DayOfYear);
 
             Assert.AreEqual(0, ldt.Hour);
@@ -48,7 +48,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(1426, ldt.Year);
             Assert.AreEqual(10, ldt.Month);
             Assert.AreEqual(24, ldt.Day);
-            Assert.AreEqual(IsoDayOfWeek.Saturday, ldt.IsoDayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Saturday, ldt.DayOfWeek);
             Assert.AreEqual(5 * 30 + 4 * 29 + 24, ldt.DayOfYear);
             Assert.AreEqual(0, ldt.Hour);
             Assert.AreEqual(0, ldt.Minute);
@@ -65,7 +65,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(1426, ldt.Year);
             Assert.AreEqual(12, ldt.Month);
             Assert.AreEqual(24, ldt.Day);
-            Assert.AreEqual(IsoDayOfWeek.Tuesday, ldt.IsoDayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Tuesday, ldt.DayOfWeek);
             Assert.AreEqual(6 * 30 + 5 * 29 + 24, ldt.DayOfYear);
             Assert.AreEqual(0, ldt.Hour);
             Assert.AreEqual(0, ldt.Minute);

--- a/src/NodaTime.Test/Calendars/IsoCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/IsoCalendarSystemTest.cs
@@ -79,12 +79,6 @@ namespace NodaTime.Test.Calendars
         }
 
         [Test]
-        public void IsoCalendarUsesIsoDayOfWeek()
-        {
-            Assert.IsTrue(CalendarSystem.Iso.UsesIsoDayOfWeek);
-        }
-
-        [Test]
         public void IsLeapYear()
         {
             Assert.IsTrue(CalendarSystem.Iso.IsLeapYear(2012)); // 4 year rule

--- a/src/NodaTime.Test/Calendars/IsoCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/IsoCalendarSystemTest.cs
@@ -32,7 +32,6 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(1, epoch.Day);
             Assert.AreEqual(1, epoch.DayOfYear);
             Assert.AreEqual(IsoDayOfWeek.Thursday, epoch.IsoDayOfWeek);
-            Assert.AreEqual(4, epoch.DayOfWeek);
             Assert.AreEqual(Era.Common, epoch.Era);
             Assert.AreEqual(0, epoch.Hour);
             Assert.AreEqual(0, epoch.Minute);
@@ -55,7 +54,6 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(27, now.Day);
             Assert.AreEqual(TimeOfGreatAchievement.DayOfYear, now.DayOfYear);
             Assert.AreEqual(IsoDayOfWeek.Friday, now.IsoDayOfWeek);
-            Assert.AreEqual(5, now.DayOfWeek);
             Assert.AreEqual(Era.Common, now.Era);
             Assert.AreEqual(18, now.Hour);
             Assert.AreEqual(38, now.Minute);

--- a/src/NodaTime.Test/Calendars/IsoCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/IsoCalendarSystemTest.cs
@@ -31,7 +31,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(1, epoch.Month);
             Assert.AreEqual(1, epoch.Day);
             Assert.AreEqual(1, epoch.DayOfYear);
-            Assert.AreEqual(IsoDayOfWeek.Thursday, epoch.IsoDayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Thursday, epoch.DayOfWeek);
             Assert.AreEqual(Era.Common, epoch.Era);
             Assert.AreEqual(0, epoch.Hour);
             Assert.AreEqual(0, epoch.Minute);
@@ -53,7 +53,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(11, now.Month);
             Assert.AreEqual(27, now.Day);
             Assert.AreEqual(TimeOfGreatAchievement.DayOfYear, now.DayOfYear);
-            Assert.AreEqual(IsoDayOfWeek.Friday, now.IsoDayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Friday, now.DayOfWeek);
             Assert.AreEqual(Era.Common, now.Era);
             Assert.AreEqual(18, now.Hour);
             Assert.AreEqual(38, now.Minute);

--- a/src/NodaTime.Test/Calendars/SimpleWeekYearRuleTest.cs
+++ b/src/NodaTime.Test/Calendars/SimpleWeekYearRuleTest.cs
@@ -28,7 +28,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(date, rule.GetLocalDate(
                 rule.GetWeekYear(date),
                 rule.GetWeekOfWeekYear(date),
-                date.IsoDayOfWeek));
+                date.DayOfWeek));
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(date, rule.GetLocalDate(
                 rule.GetWeekYear(date),
                 rule.GetWeekOfWeekYear(date),
-                date.IsoDayOfWeek));
+                date.DayOfWeek));
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace NodaTime.Test.Calendars
             var date = new LocalDate(year, month, day);
             Assert.AreEqual(weekYear, WeekYearRules.Iso.GetWeekYear(date));
             Assert.AreEqual(weekOfWeekYear, WeekYearRules.Iso.GetWeekOfWeekYear(date));
-            Assert.AreEqual(dayOfWeek, date.IsoDayOfWeek);
+            Assert.AreEqual(dayOfWeek, date.DayOfWeek);
             Assert.AreEqual(date, WeekYearRules.Iso.GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek));
         }
 
@@ -138,7 +138,7 @@ namespace NodaTime.Test.Calendars
         public void Gregorian(int year, IsoDayOfWeek firstDayOfYear, int maxMinDaysInFirstWeekForSameWeekYear)
         {
             var startOfCalendarYear = new LocalDate(year, 1, 1);
-            Assert.AreEqual(firstDayOfYear, startOfCalendarYear.IsoDayOfWeek);
+            Assert.AreEqual(firstDayOfYear, startOfCalendarYear.DayOfWeek);
 
             // Rules which put the first day of the calendar year into the same week year
             for (int i = 1; i <= maxMinDaysInFirstWeekForSameWeekYear; i++)
@@ -170,7 +170,7 @@ namespace NodaTime.Test.Calendars
             var rule = WeekYearRules.Iso;
             Assert.AreEqual(weekYear, rule.GetWeekYear(viaCalendar));
             Assert.AreEqual(weekOfWeekYear, rule.GetWeekOfWeekYear(viaCalendar));
-            Assert.AreEqual(dayOfWeek, viaCalendar.IsoDayOfWeek);
+            Assert.AreEqual(dayOfWeek, viaCalendar.DayOfWeek);
             var viaRule = rule.GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek);
             Assert.AreEqual(viaCalendar, viaRule);
         }
@@ -196,7 +196,7 @@ namespace NodaTime.Test.Calendars
         {
             var civilDate = new LocalDate(year, 1, 1, HebrewCivil);
             var rule = WeekYearRules.Iso;
-            Assert.AreEqual(expectedFirstDay, civilDate.IsoDayOfWeek);
+            Assert.AreEqual(expectedFirstDay, civilDate.DayOfWeek);
             Assert.AreEqual(civilDate.WithCalendar(CalendarSystem.Iso), new LocalDate(isoYear, isoMonth, isoDay));
             Assert.AreEqual(expectedWeeks, rule.GetWeeksInWeekYear(year, HebrewCivil));
             Assert.AreEqual(expectedWeekYearOfFirstDay, rule.GetWeekYear(civilDate));
@@ -270,8 +270,8 @@ namespace NodaTime.Test.Calendars
 
                     Assert.AreEqual(bclWeek, nodaRule.GetWeekOfWeekYear(date), "Date: {0}", date);
                     Assert.AreEqual(bclWeekYear, nodaRule.GetWeekYear(date), "Date: {0}", date);
-                    Assert.AreEqual(date, nodaRule.GetLocalDate(bclWeekYear, bclWeek, date.IsoDayOfWeek, nodaCalendar),
-                        "Week-year:{0}; Week: {1}; Day: {2}", bclWeekYear, bclWeek, date.IsoDayOfWeek);
+                    Assert.AreEqual(date, nodaRule.GetLocalDate(bclWeekYear, bclWeek, date.DayOfWeek, nodaCalendar),
+                        "Week-year:{0}; Week: {1}; Day: {2}", bclWeekYear, bclWeek, date.DayOfWeek);
                 }
             }
         }
@@ -324,7 +324,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(date, rule.GetLocalDate(
                 rule.GetWeekYear(date),
                 rule.GetWeekOfWeekYear(date),
-                date.IsoDayOfWeek));
+                date.DayOfWeek));
         }
 
         [Test]
@@ -338,7 +338,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(date, rule.GetLocalDate(
                 rule.GetWeekYear(date),
                 rule.GetWeekOfWeekYear(date),
-                date.IsoDayOfWeek));
+                date.DayOfWeek));
         }
 
         // TODO: Test the difference in ValidateWeekYear for 9999 between regular and non-regular rules.

--- a/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
+++ b/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
@@ -280,7 +280,7 @@ namespace NodaTime.Test
             Assert.AreEqual(2009, when.Year);
             Assert.AreEqual(12, when.Month);
             Assert.AreEqual(22, when.Day);
-            Assert.AreEqual(2, when.DayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Tuesday, when.IsoDayOfWeek);
             Assert.AreEqual(21, when.Hour);
             Assert.AreEqual(39, when.Minute);
             Assert.AreEqual(30, when.Second);

--- a/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
+++ b/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
@@ -280,7 +280,7 @@ namespace NodaTime.Test
             Assert.AreEqual(2009, when.Year);
             Assert.AreEqual(12, when.Month);
             Assert.AreEqual(22, when.Day);
-            Assert.AreEqual(IsoDayOfWeek.Tuesday, when.IsoDayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Tuesday, when.DayOfWeek);
             Assert.AreEqual(21, when.Hour);
             Assert.AreEqual(39, when.Minute);
             Assert.AreEqual(30, when.Second);

--- a/src/NodaTime.Test/LocalDateTest.BasicProperties.cs
+++ b/src/NodaTime.Test/LocalDateTest.BasicProperties.cs
@@ -17,7 +17,7 @@ namespace NodaTime.Test
             Assert.AreEqual(1970, date.Year);
             Assert.AreEqual(1970, date.YearOfEra);
             Assert.AreEqual(1, date.Day);
-            Assert.AreEqual(IsoDayOfWeek.Thursday, date.IsoDayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Thursday, date.DayOfWeek);
             Assert.AreEqual(1, date.DayOfYear);
             Assert.AreEqual(1, date.Month);
         }
@@ -33,7 +33,7 @@ namespace NodaTime.Test
             Assert.AreEqual(2011, date.Year);
             Assert.AreEqual(2011, date.YearOfEra);
             Assert.AreEqual(5, date.Day);
-            Assert.AreEqual(IsoDayOfWeek.Saturday, date.IsoDayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Saturday, date.DayOfWeek);
             Assert.AreEqual(64, date.DayOfYear);
             Assert.AreEqual(3, date.Month);
         }
@@ -47,7 +47,7 @@ namespace NodaTime.Test
             {
                 Assert.AreEqual(
                     BclConversions.ToIsoDayOfWeek(date.AtMidnight().ToDateTimeUnspecified().DayOfWeek),
-                    date.IsoDayOfWeek);
+                    date.DayOfWeek);
                 date = date.PlusDays(1);
             }
         }

--- a/src/NodaTime.Test/LocalDateTest.BasicProperties.cs
+++ b/src/NodaTime.Test/LocalDateTest.BasicProperties.cs
@@ -39,7 +39,7 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void IsoDayOfWeek_AroundEpoch()
+        public void DayOfWeek_AroundEpoch()
         {
             // Test about couple of months around the Unix epoch. If that works, I'm confident the rest will.
             LocalDate date = new LocalDate(1969, 12, 1);

--- a/src/NodaTime.Test/LocalDateTest.BasicProperties.cs
+++ b/src/NodaTime.Test/LocalDateTest.BasicProperties.cs
@@ -17,7 +17,6 @@ namespace NodaTime.Test
             Assert.AreEqual(1970, date.Year);
             Assert.AreEqual(1970, date.YearOfEra);
             Assert.AreEqual(1, date.Day);
-            Assert.AreEqual((int) IsoDayOfWeek.Thursday, date.DayOfWeek);
             Assert.AreEqual(IsoDayOfWeek.Thursday, date.IsoDayOfWeek);
             Assert.AreEqual(1, date.DayOfYear);
             Assert.AreEqual(1, date.Month);
@@ -34,7 +33,6 @@ namespace NodaTime.Test
             Assert.AreEqual(2011, date.Year);
             Assert.AreEqual(2011, date.YearOfEra);
             Assert.AreEqual(5, date.Day);
-            Assert.AreEqual((int)IsoDayOfWeek.Saturday, date.DayOfWeek);
             Assert.AreEqual(IsoDayOfWeek.Saturday, date.IsoDayOfWeek);
             Assert.AreEqual(64, date.DayOfYear);
             Assert.AreEqual(3, date.Month);

--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -162,7 +162,7 @@ namespace NodaTime.Test
                 for (int hour = 0; hour < 24; hour++)
                 {
                     Assert.AreEqual(BclConversions.ToIsoDayOfWeek(dateTime.ToDateTimeUnspecified().DayOfWeek),
-                        dateTime.IsoDayOfWeek);
+                        dateTime.DayOfWeek);
                     dateTime = dateTime.PlusHours(1);
                 }
             }

--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -152,7 +152,7 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void IsoDayOfWeek_AroundEpoch()
+        public void DayOfWeek_AroundEpoch()
         {
             // Test about couple of months around the Unix epoch. If that works, I'm confident the rest will.
             LocalDateTime dateTime = new LocalDateTime(1969, 12, 1, 0, 0);

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -39,7 +39,6 @@ namespace NodaTime.Test
             Assert.AreEqual(2, value.Month);
             Assert.AreEqual(10, value.Day);
             Assert.AreEqual(IsoDayOfWeek.Friday, value.IsoDayOfWeek);
-            Assert.AreEqual((int) IsoDayOfWeek.Friday, value.DayOfWeek);
             Assert.AreEqual(41, value.DayOfYear);
             Assert.AreEqual(8, value.ClockHourOfHalfDay);
             Assert.AreEqual(8, value.Hour);

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -38,7 +38,7 @@ namespace NodaTime.Test
             Assert.AreEqual(2012, value.YearOfEra);
             Assert.AreEqual(2, value.Month);
             Assert.AreEqual(10, value.Day);
-            Assert.AreEqual(IsoDayOfWeek.Friday, value.IsoDayOfWeek);
+            Assert.AreEqual(IsoDayOfWeek.Friday, value.DayOfWeek);
             Assert.AreEqual(41, value.DayOfYear);
             Assert.AreEqual(8, value.ClockHourOfHalfDay);
             Assert.AreEqual(8, value.Hour);

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -498,19 +498,17 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// Returns the IsoDayOfWeek corresponding to the day of week for the given local instant
-        /// if this calendar uses ISO days of the week, or throws an InvalidOperationException otherwise.
+        /// Returns the IsoDayOfWeek corresponding to the day of week for the given year, month and day.
         /// </summary>
         /// <param name="yearMonthDay">The year, month and day to use to find the day of the week</param>
         /// <returns>The day of the week as an IsoDayOfWeek</returns>
         internal IsoDayOfWeek GetIsoDayOfWeek([Trusted] YearMonthDay yearMonthDay)
         {
             DebugValidateYearMonthDay(yearMonthDay);
-            if (!UsesIsoDayOfWeek)
-            {
-                throw new InvalidOperationException("Calendar " + Id + " does not use ISO days of the week");
-            }
-            return (IsoDayOfWeek) GetDayOfWeek(yearMonthDay);
+            int daysSinceEpoch = YearMonthDayCalculator.GetDaysSinceEpoch(yearMonthDay);
+            int numericDayOfWeek = unchecked(daysSinceEpoch >= -3 ? 1 + ((daysSinceEpoch + 3) % 7)
+                                           : 7 + ((daysSinceEpoch + 4) % 7));
+            return (IsoDayOfWeek) numericDayOfWeek;
         }
 
         /// <summary>
@@ -587,14 +585,6 @@ namespace NodaTime
         }
 
         #region "Getter" methods which used to be DateTimeField
-
-        internal int GetDayOfWeek([Trusted] YearMonthDay yearMonthDay)
-        {
-            DebugValidateYearMonthDay(yearMonthDay);
-            int daysSinceEpoch = YearMonthDayCalculator.GetDaysSinceEpoch(yearMonthDay);
-            return unchecked(daysSinceEpoch >= -3 ? 1 + ((daysSinceEpoch + 3) % 7)
-                                           : 7 + ((daysSinceEpoch + 4) % 7));
-        }
 
         internal int GetDayOfYear([Trusted] YearMonthDay yearMonthDay)
         {

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -483,7 +483,7 @@ namespace NodaTime
         /// </summary>
         /// <param name="yearMonthDay">The year, month and day to use to find the day of the week</param>
         /// <returns>The day of the week as an IsoDayOfWeek</returns>
-        internal IsoDayOfWeek GetIsoDayOfWeek([Trusted] YearMonthDay yearMonthDay)
+        internal IsoDayOfWeek GetDayOfWeek([Trusted] YearMonthDay yearMonthDay)
         {
             DebugValidateYearMonthDay(yearMonthDay);
             int daysSinceEpoch = YearMonthDayCalculator.GetDaysSinceEpoch(yearMonthDay);

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -374,25 +374,6 @@ namespace NodaTime
         public string Name { get; }
 
         /// <summary>
-        /// Returns whether the day-of-week field refers to ISO days.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// If true, types such as <see cref="LocalDateTime" />
-        /// can use the <see cref="IsoDayOfWeek" /> property to avoid using magic numbers.
-        /// This defaults to true, but can be overridden by specific calendars.
-        /// </para>
-        /// <para>
-        /// Currently all calendar systems supported by Noda Time are deemed to use ISO
-        /// days, so every week is seven days long, and this property always returns true.
-        /// In the future, however, calendar systems with different - possibly even variable
-        /// - week lengths may be supported.
-        /// </para>
-        /// </remarks>
-        /// <value>true if the calendar system refers to ISO days; false otherwise.</value>
-        public bool UsesIsoDayOfWeek => true;
-
-        /// <summary>
         /// Gets the minimum valid year (inclusive) within this calendar.
         /// </summary>
         /// <value>The minimum valid year (inclusive) within this calendar.</value>

--- a/src/NodaTime/DateAdjusters.cs
+++ b/src/NodaTime/DateAdjusters.cs
@@ -68,7 +68,7 @@ namespace NodaTime
             {
                 throw new ArgumentOutOfRangeException(nameof(dayOfWeek));
             }
-            return date => date.IsoDayOfWeek == dayOfWeek ? date : date.Next(dayOfWeek);
+            return date => date.DayOfWeek == dayOfWeek ? date : date.Next(dayOfWeek);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace NodaTime
             {
                 throw new ArgumentOutOfRangeException(nameof(dayOfWeek));
             }
-            return date => date.IsoDayOfWeek == dayOfWeek ? date : date.Previous(dayOfWeek);
+            return date => date.DayOfWeek == dayOfWeek ? date : date.Previous(dayOfWeek);
         }
 
         /// <summary>

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -239,14 +239,14 @@ namespace NodaTime.Globalization
         /// Returns a read-only list of the names of the days of the week for the default calendar for this culture.
         /// See the usage guide for caveats around the use of these names for other calendars.
         /// Element 0 of the list is null, and the other elements correspond with the index values returned from
-        /// <see cref="LocalDateTime.IsoDayOfWeek"/> and similar properties.
+        /// <see cref="LocalDateTime.DayOfWeek"/> and similar properties.
         /// </summary>
         public IList<string> LongDayNames { get { EnsureDaysInitialized(); return longDayNames; } }
         /// <summary>
         /// Returns a read-only list of the abbreviated names of the days of the week for the default calendar for this culture.
         /// See the usage guide for caveats around the use of these names for other calendars.
         /// Element 0 of the list is null, and the other elements correspond with the index values returned from
-        /// <see cref="LocalDateTime.IsoDayOfWeek"/> and similar properties.
+        /// <see cref="LocalDateTime.DayOfWeek"/> and similar properties.
         /// </summary>
         public IList<string> ShortDayNames { get { EnsureDaysInitialized(); return shortDayNames; } }
 

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -239,14 +239,14 @@ namespace NodaTime.Globalization
         /// Returns a read-only list of the names of the days of the week for the default calendar for this culture.
         /// See the usage guide for caveats around the use of these names for other calendars.
         /// Element 0 of the list is null, and the other elements correspond with the index values returned from
-        /// <see cref="LocalDateTime.DayOfWeek"/> and similar properties.
+        /// <see cref="LocalDateTime.IsoDayOfWeek"/> and similar properties.
         /// </summary>
         public IList<string> LongDayNames { get { EnsureDaysInitialized(); return longDayNames; } }
         /// <summary>
         /// Returns a read-only list of the abbreviated names of the days of the week for the default calendar for this culture.
         /// See the usage guide for caveats around the use of these names for other calendars.
         /// Element 0 of the list is null, and the other elements correspond with the index values returned from
-        /// <see cref="LocalDateTime.DayOfWeek"/> and similar properties.
+        /// <see cref="LocalDateTime.IsoDayOfWeek"/> and similar properties.
         /// </summary>
         public IList<string> ShortDayNames { get { EnsureDaysInitialized(); return shortDayNames; } }
 

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -153,10 +153,8 @@ namespace NodaTime
         internal int DaysSinceEpoch => Calendar.GetDaysSinceEpoch(yearMonthDayCalendar.ToYearMonthDay());
 
         /// <summary>
-        /// Gets the week day of this local date expressed as an <see cref="NodaTime.IsoDayOfWeek"/> value,
-        /// for calendars which use ISO days of the week.
+        /// Gets the week day of this local date expressed as an <see cref="NodaTime.IsoDayOfWeek"/> value.
         /// </summary>
-        /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
         /// <value>The week day of this local date expressed as an <c>IsoDayOfWeek</c>.</value>
         public IsoDayOfWeek DayOfWeek => Calendar.GetIsoDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
 

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -158,7 +158,7 @@ namespace NodaTime
         /// </summary>
         /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
         /// <value>The week day of this local date expressed as an <c>IsoDayOfWeek</c>.</value>
-        public IsoDayOfWeek IsoDayOfWeek => Calendar.GetIsoDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
+        public IsoDayOfWeek DayOfWeek => Calendar.GetIsoDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
 
         /// <summary>Gets the year of this local date within the era.</summary>
         /// <value>The year of this local date within the era.</value>
@@ -265,7 +265,7 @@ namespace NodaTime
             Preconditions.CheckArgumentRange(nameof(dayOfWeek), (int) dayOfWeek, 1, 7);
 
             // Correct day of week, 1st week of month.
-            int week1Day = dayOfWeek - startOfMonth.IsoDayOfWeek + 1;
+            int week1Day = dayOfWeek - startOfMonth.DayOfWeek + 1;
             if (week1Day <= 0)
             {
                 week1Day += 7;
@@ -628,7 +628,7 @@ namespace NodaTime
         public LocalDate PlusWeeks(int weeks) => DatePeriodFields.WeeksField.Add(this, weeks);
 
         /// <summary>
-        /// Returns the next <see cref="LocalDate" /> falling on the specified <see cref="IsoDayOfWeek"/>.
+        /// Returns the next <see cref="LocalDate" /> falling on the specified <see cref="DayOfWeek"/>.
         /// This is a strict "next" - if this date on already falls on the target
         /// day of the week, the returned value will be a week later.
         /// </summary>
@@ -646,7 +646,7 @@ namespace NodaTime
                 throw new ArgumentOutOfRangeException(nameof(targetDayOfWeek));
             }
             // This will throw the desired exception for calendars with different week systems.
-            IsoDayOfWeek thisDay = IsoDayOfWeek;
+            IsoDayOfWeek thisDay = DayOfWeek;
             int difference = targetDayOfWeek - thisDay;
             if (difference <= 0)
             {
@@ -656,7 +656,7 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// Returns the previous <see cref="LocalDate" /> falling on the specified <see cref="IsoDayOfWeek"/>.
+        /// Returns the previous <see cref="LocalDate" /> falling on the specified <see cref="DayOfWeek"/>.
         /// This is a strict "previous" - if this date on already falls on the target
         /// day of the week, the returned value will be a week earlier.
         /// </summary>
@@ -674,7 +674,7 @@ namespace NodaTime
                 throw new ArgumentOutOfRangeException(nameof(targetDayOfWeek));
             }
             // This will throw the desired exception for calendars with different week systems.
-            IsoDayOfWeek thisDay = IsoDayOfWeek;
+            IsoDayOfWeek thisDay = DayOfWeek;
             int difference = targetDayOfWeek - thisDay;
             if (difference >= 0)
             {

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -156,7 +156,7 @@ namespace NodaTime
         /// Gets the week day of this local date expressed as an <see cref="NodaTime.IsoDayOfWeek"/> value.
         /// </summary>
         /// <value>The week day of this local date expressed as an <c>IsoDayOfWeek</c>.</value>
-        public IsoDayOfWeek DayOfWeek => Calendar.GetIsoDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
+        public IsoDayOfWeek DayOfWeek => Calendar.GetDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
 
         /// <summary>Gets the year of this local date within the era.</summary>
         /// <value>The year of this local date within the era.</value>
@@ -626,7 +626,7 @@ namespace NodaTime
         public LocalDate PlusWeeks(int weeks) => DatePeriodFields.WeeksField.Add(this, weeks);
 
         /// <summary>
-        /// Returns the next <see cref="LocalDate" /> falling on the specified <see cref="DayOfWeek"/>.
+        /// Returns the next <see cref="LocalDate" /> falling on the specified <see cref="IsoDayOfWeek"/>.
         /// This is a strict "next" - if this date on already falls on the target
         /// day of the week, the returned value will be a week later.
         /// </summary>
@@ -654,7 +654,7 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// Returns the previous <see cref="LocalDate" /> falling on the specified <see cref="DayOfWeek"/>.
+        /// Returns the previous <see cref="LocalDate" /> falling on the specified <see cref="IsoDayOfWeek"/>.
         /// This is a strict "previous" - if this date on already falls on the target
         /// day of the week, the returned value will be a week earlier.
         /// </summary>

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -157,19 +157,8 @@ namespace NodaTime
         /// for calendars which use ISO days of the week.
         /// </summary>
         /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
-        /// <seealso cref="DayOfWeek"/>
         /// <value>The week day of this local date expressed as an <c>IsoDayOfWeek</c>.</value>
         public IsoDayOfWeek IsoDayOfWeek => Calendar.GetIsoDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
-
-        /// <summary>
-        /// Gets the week day of this local date as a number.
-        /// </summary>
-        /// <remarks>
-        /// For calendars using ISO week days, this gives 1 for Monday to 7 for Sunday.
-        /// </remarks>
-        /// <seealso cref="IsoDayOfWeek"/>
-        /// <value>The week day of this local date as a number.</value>
-        public int DayOfWeek => Calendar.GetDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
 
         /// <summary>Gets the year of this local date within the era.</summary>
         /// <value>The year of this local date within the era.</value>
@@ -276,7 +265,7 @@ namespace NodaTime
             Preconditions.CheckArgumentRange(nameof(dayOfWeek), (int) dayOfWeek, 1, 7);
 
             // Correct day of week, 1st week of month.
-            int week1Day = (int) dayOfWeek - startOfMonth.DayOfWeek + 1;
+            int week1Day = dayOfWeek - startOfMonth.IsoDayOfWeek + 1;
             if (week1Day <= 0)
             {
                 week1Day += 7;

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -260,19 +260,8 @@ namespace NodaTime
         /// for calendars which use ISO days of the week.
         /// </summary>
         /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
-        /// <seealso cref="DayOfWeek"/>
         /// <value>The week day of this local date and time expressed as an <c>IsoDayOfWeek</c>.</value>
         public IsoDayOfWeek IsoDayOfWeek => date.IsoDayOfWeek;
-
-        /// <summary>
-        /// Gets the week day of this local date and time as a number.
-        /// </summary>
-        /// <remarks>
-        /// For calendars using ISO week days, this gives 1 for Monday to 7 for Sunday.
-        /// </remarks>
-        /// <seealso cref="IsoDayOfWeek"/>
-        /// <value>The week day of this local date and time as a number.</value>
-        public int DayOfWeek => date.DayOfWeek;
 
         /// <summary>
         /// Gets the hour of day of this local date and time, in the range 0 to 23 inclusive.

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -256,10 +256,8 @@ namespace NodaTime
         public int Day => date.Day;
 
         /// <summary>
-        /// Gets the week day of this local date and time expressed as an <see cref="NodaTime.IsoDayOfWeek"/> value,
-        /// for calendars which use ISO days of the week.
+        /// Gets the week day of this local date and time expressed as an <see cref="NodaTime.IsoDayOfWeek"/> value.
         /// </summary>
-        /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
         /// <value>The week day of this local date and time expressed as an <c>IsoDayOfWeek</c>.</value>
         public IsoDayOfWeek DayOfWeek => date.DayOfWeek;
 

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -788,7 +788,7 @@ namespace NodaTime
         public LocalDateTime PlusNanoseconds(long nanoseconds) => TimePeriodField.Nanoseconds.Add(this, nanoseconds);
 
         /// <summary>
-        /// Returns the next <see cref="LocalDateTime" /> falling on the specified <see cref="DayOfWeek"/>,
+        /// Returns the next <see cref="LocalDateTime" /> falling on the specified <see cref="IsoDayOfWeek"/>,
         /// at the same time of day as this value.
         /// This is a strict "next" - if this value on already falls on the target
         /// day of the week, the returned value will be a week later.
@@ -802,7 +802,7 @@ namespace NodaTime
         public LocalDateTime Next(IsoDayOfWeek targetDayOfWeek) => new LocalDateTime(date.Next(targetDayOfWeek), time);
 
         /// <summary>
-        /// Returns the previous <see cref="LocalDateTime" /> falling on the specified <see cref="DayOfWeek"/>,
+        /// Returns the previous <see cref="LocalDateTime" /> falling on the specified <see cref="IsoDayOfWeek"/>,
         /// at the same time of day as this value.
         /// This is a strict "previous" - if this value on already falls on the target
         /// day of the week, the returned value will be a week earlier.

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -261,7 +261,7 @@ namespace NodaTime
         /// </summary>
         /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
         /// <value>The week day of this local date and time expressed as an <c>IsoDayOfWeek</c>.</value>
-        public IsoDayOfWeek IsoDayOfWeek => date.IsoDayOfWeek;
+        public IsoDayOfWeek DayOfWeek => date.DayOfWeek;
 
         /// <summary>
         /// Gets the hour of day of this local date and time, in the range 0 to 23 inclusive.
@@ -790,7 +790,7 @@ namespace NodaTime
         public LocalDateTime PlusNanoseconds(long nanoseconds) => TimePeriodField.Nanoseconds.Add(this, nanoseconds);
 
         /// <summary>
-        /// Returns the next <see cref="LocalDateTime" /> falling on the specified <see cref="IsoDayOfWeek"/>,
+        /// Returns the next <see cref="LocalDateTime" /> falling on the specified <see cref="DayOfWeek"/>,
         /// at the same time of day as this value.
         /// This is a strict "next" - if this value on already falls on the target
         /// day of the week, the returned value will be a week later.
@@ -804,7 +804,7 @@ namespace NodaTime
         public LocalDateTime Next(IsoDayOfWeek targetDayOfWeek) => new LocalDateTime(date.Next(targetDayOfWeek), time);
 
         /// <summary>
-        /// Returns the previous <see cref="LocalDateTime" /> falling on the specified <see cref="IsoDayOfWeek"/>,
+        /// Returns the previous <see cref="LocalDateTime" /> falling on the specified <see cref="DayOfWeek"/>,
         /// at the same time of day as this value.
         /// This is a strict "previous" - if this value on already falls on the target
         /// day of the week, the returned value will be a week earlier.

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -163,16 +163,6 @@ namespace NodaTime
         /// <value>The week day of this offset date and time expressed as an <c>IsoDayOfWeek</c>.</value>
         public IsoDayOfWeek IsoDayOfWeek => Calendar.GetIsoDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
 
-        /// <summary>
-        /// Gets the week day of this offset date and time as a number.
-        /// </summary>
-        /// <remarks>
-        /// For calendars using ISO week days, this gives 1 for Monday to 7 for Sunday.
-        /// </remarks>
-        /// <seealso cref="IsoDayOfWeek"/>
-        /// <value>The week day of this offset date and time as a number.</value>
-        public int DayOfWeek => Calendar.GetDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
-
         /// <summary>Gets the year of this offset date and time within the era.</summary>
         /// <value>The year of this offset date and time within the era.</value>
         public int YearOfEra => Calendar.GetYearOfEra(yearMonthDayCalendar.Year);

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -155,11 +155,8 @@ namespace NodaTime
         internal YearMonthDay YearMonthDay=> yearMonthDayCalendar.ToYearMonthDay();
 
         /// <summary>
-        /// Gets the week day of this offset date and time expressed as an <see cref="NodaTime.IsoDayOfWeek"/> value,
-        /// for calendars which use ISO days of the week.
+        /// Gets the week day of this offset date and time expressed as an <see cref="NodaTime.IsoDayOfWeek"/> value.
         /// </summary>
-        /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
-        /// <seealso cref="System.DayOfWeek"/>
         /// <value>The week day of this offset date and time expressed as an <c>IsoDayOfWeek</c>.</value>
         public IsoDayOfWeek DayOfWeek => Calendar.GetIsoDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
 

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -159,9 +159,9 @@ namespace NodaTime
         /// for calendars which use ISO days of the week.
         /// </summary>
         /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
-        /// <seealso cref="DayOfWeek"/>
+        /// <seealso cref="System.DayOfWeek"/>
         /// <value>The week day of this offset date and time expressed as an <c>IsoDayOfWeek</c>.</value>
-        public IsoDayOfWeek IsoDayOfWeek => Calendar.GetIsoDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
+        public IsoDayOfWeek DayOfWeek => Calendar.GetIsoDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
 
         /// <summary>Gets the year of this offset date and time within the era.</summary>
         /// <value>The year of this offset date and time within the era.</value>

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -158,7 +158,7 @@ namespace NodaTime
         /// Gets the week day of this offset date and time expressed as an <see cref="NodaTime.IsoDayOfWeek"/> value.
         /// </summary>
         /// <value>The week day of this offset date and time expressed as an <c>IsoDayOfWeek</c>.</value>
-        public IsoDayOfWeek DayOfWeek => Calendar.GetIsoDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
+        public IsoDayOfWeek DayOfWeek => Calendar.GetDayOfWeek(yearMonthDayCalendar.ToYearMonthDay());
 
         /// <summary>Gets the year of this offset date and time within the era.</summary>
         /// <value>The year of this offset date and time within the era.</value>

--- a/src/NodaTime/Text/LocalDatePatternParser.cs
+++ b/src/NodaTime/Text/LocalDatePatternParser.cs
@@ -39,7 +39,7 @@ namespace NodaTime.Text
             { 'M', DatePatternHelper.CreateMonthOfYearHandler<LocalDate, LocalDateParseBucket>
                         (value => value.Month, (bucket, value) => bucket.MonthOfYearText = value, (bucket, value) => bucket.MonthOfYearNumeric = value) },
             { 'd', DatePatternHelper.CreateDayHandler<LocalDate, LocalDateParseBucket>
-                        (value => value.Day, value => (int) value.IsoDayOfWeek, (bucket, value) => bucket.DayOfMonth = value, (bucket, value) => bucket.DayOfWeek = value) },
+                        (value => value.Day, value => (int) value.DayOfWeek, (bucket, value) => bucket.DayOfMonth = value, (bucket, value) => bucket.DayOfWeek = value) },
             { 'c', DatePatternHelper.CreateCalendarHandler<LocalDate, LocalDateParseBucket>(value => value.Calendar, (bucket, value) => bucket.Calendar = value) },
             { 'g', DatePatternHelper.CreateEraHandler<LocalDate, LocalDateParseBucket>(date => date.Era, bucket => bucket) },
         };
@@ -158,7 +158,7 @@ namespace NodaTime.Text
 
                 LocalDate value = new LocalDate(Year, MonthOfYearNumeric, day, Calendar);
 
-                if (usedFields.HasAny(PatternFields.DayOfWeek) && DayOfWeek != (int) value.IsoDayOfWeek)
+                if (usedFields.HasAny(PatternFields.DayOfWeek) && DayOfWeek != (int) value.DayOfWeek)
                 {
                     return ParseResult<LocalDate>.InconsistentDayOfWeekTextValue(text);
                 }

--- a/src/NodaTime/Text/LocalDatePatternParser.cs
+++ b/src/NodaTime/Text/LocalDatePatternParser.cs
@@ -39,7 +39,7 @@ namespace NodaTime.Text
             { 'M', DatePatternHelper.CreateMonthOfYearHandler<LocalDate, LocalDateParseBucket>
                         (value => value.Month, (bucket, value) => bucket.MonthOfYearText = value, (bucket, value) => bucket.MonthOfYearNumeric = value) },
             { 'd', DatePatternHelper.CreateDayHandler<LocalDate, LocalDateParseBucket>
-                        (value => value.Day, value => value.DayOfWeek, (bucket, value) => bucket.DayOfMonth = value, (bucket, value) => bucket.DayOfWeek = value) },
+                        (value => value.Day, value => (int) value.IsoDayOfWeek, (bucket, value) => bucket.DayOfMonth = value, (bucket, value) => bucket.DayOfWeek = value) },
             { 'c', DatePatternHelper.CreateCalendarHandler<LocalDate, LocalDateParseBucket>(value => value.Calendar, (bucket, value) => bucket.Calendar = value) },
             { 'g', DatePatternHelper.CreateEraHandler<LocalDate, LocalDateParseBucket>(date => date.Era, bucket => bucket) },
         };
@@ -158,7 +158,7 @@ namespace NodaTime.Text
 
                 LocalDate value = new LocalDate(Year, MonthOfYearNumeric, day, Calendar);
 
-                if (usedFields.HasAny(PatternFields.DayOfWeek) && DayOfWeek != value.DayOfWeek)
+                if (usedFields.HasAny(PatternFields.DayOfWeek) && DayOfWeek != (int) value.IsoDayOfWeek)
                 {
                     return ParseResult<LocalDate>.InconsistentDayOfWeekTextValue(text);
                 }

--- a/src/NodaTime/Text/LocalDateTimePatternParser.cs
+++ b/src/NodaTime/Text/LocalDateTimePatternParser.cs
@@ -34,7 +34,7 @@ namespace NodaTime.Text
             { 'M', DatePatternHelper.CreateMonthOfYearHandler<LocalDateTime, LocalDateTimeParseBucket>
                         (value => value.Month, (bucket, value) => bucket.Date.MonthOfYearText = value, (bucket, value) => bucket.Date.MonthOfYearNumeric = value) },
             { 'd', DatePatternHelper.CreateDayHandler<LocalDateTime, LocalDateTimeParseBucket>
-                        (value => value.Day, value => value.DayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
+                        (value => value.Day, value => (int) value.IsoDayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
             { '.', TimePatternHelper.CreatePeriodHandler<LocalDateTime, LocalDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ';', TimePatternHelper.CreateCommaDotHandler<LocalDateTime, LocalDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ':', (pattern, builder) => builder.AddLiteral(builder.FormatInfo.TimeSeparator, ParseResult<LocalDateTime>.TimeSeparatorMismatch) },

--- a/src/NodaTime/Text/LocalDateTimePatternParser.cs
+++ b/src/NodaTime/Text/LocalDateTimePatternParser.cs
@@ -34,7 +34,7 @@ namespace NodaTime.Text
             { 'M', DatePatternHelper.CreateMonthOfYearHandler<LocalDateTime, LocalDateTimeParseBucket>
                         (value => value.Month, (bucket, value) => bucket.Date.MonthOfYearText = value, (bucket, value) => bucket.Date.MonthOfYearNumeric = value) },
             { 'd', DatePatternHelper.CreateDayHandler<LocalDateTime, LocalDateTimeParseBucket>
-                        (value => value.Day, value => (int) value.IsoDayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
+                        (value => value.Day, value => (int) value.DayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
             { '.', TimePatternHelper.CreatePeriodHandler<LocalDateTime, LocalDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ';', TimePatternHelper.CreateCommaDotHandler<LocalDateTime, LocalDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ':', (pattern, builder) => builder.AddLiteral(builder.FormatInfo.TimeSeparator, ParseResult<LocalDateTime>.TimeSeparatorMismatch) },

--- a/src/NodaTime/Text/OffsetDateTimePatternParser.cs
+++ b/src/NodaTime/Text/OffsetDateTimePatternParser.cs
@@ -32,7 +32,7 @@ namespace NodaTime.Text
             { 'M', DatePatternHelper.CreateMonthOfYearHandler<OffsetDateTime, OffsetDateTimeParseBucket>
                         (value => value.Month, (bucket, value) => bucket.Date.MonthOfYearText = value, (bucket, value) => bucket.Date.MonthOfYearNumeric = value) },
             { 'd', DatePatternHelper.CreateDayHandler<OffsetDateTime, OffsetDateTimeParseBucket>
-                        (value => value.Day, value => (int) value.IsoDayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
+                        (value => value.Day, value => (int) value.DayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
             { '.', TimePatternHelper.CreatePeriodHandler<OffsetDateTime, OffsetDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ';', TimePatternHelper.CreateCommaDotHandler<OffsetDateTime, OffsetDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ':', (pattern, builder) => builder.AddLiteral(builder.FormatInfo.TimeSeparator, ParseResult<OffsetDateTime>.TimeSeparatorMismatch) },

--- a/src/NodaTime/Text/OffsetDateTimePatternParser.cs
+++ b/src/NodaTime/Text/OffsetDateTimePatternParser.cs
@@ -32,7 +32,7 @@ namespace NodaTime.Text
             { 'M', DatePatternHelper.CreateMonthOfYearHandler<OffsetDateTime, OffsetDateTimeParseBucket>
                         (value => value.Month, (bucket, value) => bucket.Date.MonthOfYearText = value, (bucket, value) => bucket.Date.MonthOfYearNumeric = value) },
             { 'd', DatePatternHelper.CreateDayHandler<OffsetDateTime, OffsetDateTimeParseBucket>
-                        (value => value.Day, value => value.DayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
+                        (value => value.Day, value => (int) value.IsoDayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
             { '.', TimePatternHelper.CreatePeriodHandler<OffsetDateTime, OffsetDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ';', TimePatternHelper.CreateCommaDotHandler<OffsetDateTime, OffsetDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ':', (pattern, builder) => builder.AddLiteral(builder.FormatInfo.TimeSeparator, ParseResult<OffsetDateTime>.TimeSeparatorMismatch) },

--- a/src/NodaTime/Text/ZonedDateTimePatternParser.cs
+++ b/src/NodaTime/Text/ZonedDateTimePatternParser.cs
@@ -35,7 +35,7 @@ namespace NodaTime.Text
             { 'M', DatePatternHelper.CreateMonthOfYearHandler<ZonedDateTime, ZonedDateTimeParseBucket>
                         (value => value.Month, (bucket, value) => bucket.Date.MonthOfYearText = value, (bucket, value) => bucket.Date.MonthOfYearNumeric = value) },
             { 'd', DatePatternHelper.CreateDayHandler<ZonedDateTime, ZonedDateTimeParseBucket>
-                        (value => value.Day, value => value.DayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
+                        (value => value.Day, value => (int) value.IsoDayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
             { '.', TimePatternHelper.CreatePeriodHandler<ZonedDateTime, ZonedDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ';', TimePatternHelper.CreateCommaDotHandler<ZonedDateTime, ZonedDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ':', (pattern, builder) => builder.AddLiteral(builder.FormatInfo.TimeSeparator, ParseResult<ZonedDateTime>.TimeSeparatorMismatch) },

--- a/src/NodaTime/Text/ZonedDateTimePatternParser.cs
+++ b/src/NodaTime/Text/ZonedDateTimePatternParser.cs
@@ -35,7 +35,7 @@ namespace NodaTime.Text
             { 'M', DatePatternHelper.CreateMonthOfYearHandler<ZonedDateTime, ZonedDateTimeParseBucket>
                         (value => value.Month, (bucket, value) => bucket.Date.MonthOfYearText = value, (bucket, value) => bucket.Date.MonthOfYearNumeric = value) },
             { 'd', DatePatternHelper.CreateDayHandler<ZonedDateTime, ZonedDateTimeParseBucket>
-                        (value => value.Day, value => (int) value.IsoDayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
+                        (value => value.Day, value => (int) value.DayOfWeek, (bucket, value) => bucket.Date.DayOfMonth = value, (bucket, value) => bucket.Date.DayOfWeek = value) },
             { '.', TimePatternHelper.CreatePeriodHandler<ZonedDateTime, ZonedDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ';', TimePatternHelper.CreateCommaDotHandler<ZonedDateTime, ZonedDateTimeParseBucket>(9, value => value.NanosecondOfSecond, (bucket, value) => bucket.Time.FractionalSeconds = value) },
             { ':', (pattern, builder) => builder.AddLiteral(builder.FormatInfo.TimeSeparator, ParseResult<ZonedDateTime>.TimeSeparatorMismatch) },

--- a/src/NodaTime/TimeZones/ZoneYearOffset.cs
+++ b/src/NodaTime/TimeZones/ZoneYearOffset.cs
@@ -205,7 +205,7 @@ namespace NodaTime.TimeZones
                 {
                     // Optimized "go to next or previous occurrence of day or week". Try to do as few comparisons
                     // as possible, and only fetch DayOfWeek once. (If we call Next or Previous, it will work it out again.)
-                    int currentDayOfWeek = (int) date.IsoDayOfWeek;
+                    int currentDayOfWeek = (int) date.DayOfWeek;
                     if (currentDayOfWeek != dayOfWeek)
                     {
                         int diff = dayOfWeek - currentDayOfWeek;

--- a/src/NodaTime/TimeZones/ZoneYearOffset.cs
+++ b/src/NodaTime/TimeZones/ZoneYearOffset.cs
@@ -205,7 +205,7 @@ namespace NodaTime.TimeZones
                 {
                     // Optimized "go to next or previous occurrence of day or week". Try to do as few comparisons
                     // as possible, and only fetch DayOfWeek once. (If we call Next or Previous, it will work it out again.)
-                    int currentDayOfWeek = date.DayOfWeek;
+                    int currentDayOfWeek = (int) date.IsoDayOfWeek;
                     if (currentDayOfWeek != dayOfWeek)
                     {
                         int diff = dayOfWeek - currentDayOfWeek;

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -185,10 +185,8 @@ namespace NodaTime
         public int Day => offsetDateTime.Day;
 
         /// <summary>
-        /// Gets the week day of this zoned date and time expressed as an <see cref="NodaTime.IsoDayOfWeek"/> value,
-        /// for calendars which use ISO days of the week.
+        /// Gets the week day of this zoned date and time expressed as an <see cref="NodaTime.IsoDayOfWeek"/> value.
         /// </summary>
-        /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
         /// <value>The week day of this zoned date and time expressed as an <c>IsoDayOfWeek</c> value.</value>
         public IsoDayOfWeek DayOfWeek => offsetDateTime.DayOfWeek;
 

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -189,19 +189,8 @@ namespace NodaTime
         /// for calendars which use ISO days of the week.
         /// </summary>
         /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
-        /// <seealso cref="DayOfWeek"/>
         /// <value>The week day of this zoned date and time expressed as an <c>IsoDayOfWeek</c> value.</value>
         public IsoDayOfWeek IsoDayOfWeek => offsetDateTime.IsoDayOfWeek;
-
-        /// <summary>
-        /// Gets the week day of this zoned date and time as a number.
-        /// </summary>
-        /// <remarks>
-        /// For calendars using ISO week days, this gives 1 for Monday to 7 for Sunday.
-        /// </remarks>
-        /// <value>The week day of this zoned date and time as a number.</value>
-        /// <seealso cref="IsoDayOfWeek"/>
-        public int DayOfWeek => offsetDateTime.DayOfWeek;
 
         /// <summary>
         /// Gets the hour of day of this zoned date and time, in the range 0 to 23 inclusive.

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -190,7 +190,7 @@ namespace NodaTime
         /// </summary>
         /// <exception cref="InvalidOperationException">The underlying calendar doesn't use ISO days of the week.</exception>
         /// <value>The week day of this zoned date and time expressed as an <c>IsoDayOfWeek</c> value.</value>
-        public IsoDayOfWeek IsoDayOfWeek => offsetDateTime.IsoDayOfWeek;
+        public IsoDayOfWeek DayOfWeek => offsetDateTime.DayOfWeek;
 
         /// <summary>
         /// Gets the hour of day of this zoned date and time, in the range 0 to 23 inclusive.

--- a/www/unstable/userguide/migration-to-2.md
+++ b/www/unstable/userguide/migration-to-2.md
@@ -84,6 +84,11 @@ methods introduced in `DateTimeOffset` in .NET 4.6:
 Static properties on the pattern classes have been renamed to remove the `Pattern` suffix. For example,
 `LocalDateTimePattern.ExtendedIsoPattern` is now just `LocalDateTimePattern.ExtendedIso`.
 
+The `IsoDayOfWeek` properties in `LocalDate`, `LocalDateTime`, `OffsetDateTime`
+and `ZonedDateTime` are now just called `DayOfWeek`. The previous numeric `DayOfWeek` properties
+have been removed, but in all cases if you were actually calling them, you can just cast the `IsoDayOfWeek`
+to `int` and always get the same result, as all calendar systems use ISO days of the week.
+
 Period
 ====
 

--- a/www/unstable/userguide/versions.md
+++ b/www/unstable/userguide/versions.md
@@ -16,6 +16,8 @@ Breaking changes:
 See the [Noda Time 1.x to 2.0 migration guide](migration-to-2.html) for full details.
 
 - Renamed all static pattern properties to remove the `Pattern` suffix
+- Renamed the `IsoDayOfWeek` properties in `LocalDate`, `LocalDateTime`, `OffsetDateTime`
+  and `ZonedDateTime` to just `DayOfWeek`, and removed the previous numeric `DayOfWeek` properties.
 - Removed members which had already been made obsolete in the 1.x release line, including
   support for the legacy resource-based time zone data format.
 - Removed `Instant(long)` constructor from the public API.


### PR DESCRIPTION
(Numeric versions are removed.)

This is done as several commits for clarity - will preserve them (rather than squashing) when I merge.
I don't *think* we refer to the properties in the user guide...

Fixes #472.