### PR TITLE
Remove Pattern suffix from text pattern factory properties

### DIFF
--- a/docs/userguide/unstable/migration-to-2.md
+++ b/docs/userguide/unstable/migration-to-2.md
@@ -88,6 +88,9 @@ setting date-based units.
 Normalization of a period which has time units which add up to a "days" range outside the range
 of `int` will similarly fail.
 
+Static properties on the pattern classes have been renamed to remove the `Pattern` suffix. For example,
+`LocalDateTimePattern.ExtendedIsoPattern` is now just `LocalDateTimePattern.ExtendedIso`.
+
 Offset
 ====
 

--- a/docs/userguide/unstable/versions.md
+++ b/docs/userguide/unstable/versions.md
@@ -8,6 +8,7 @@ Breaking changes:
 
 See the [Noda Time 1.x to 2.0 migration guide](migration-to-2.md) for full details.
 
+- Renamed all static pattern properties to remove the `Pattern` suffix
 - Removed members which had already been made obsolete in the 1.x release line, including
   support for the legacy resource-based time zone data format.
 - Removed `Instant(long)` constructor from the public API.

--- a/src/NodaTime.Benchmarks/NodaTimeTests/Text/InstantPatternBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Text/InstantPatternBenchmarks.cs
@@ -16,7 +16,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
         private static readonly InstantPattern GeneralPattern = InstantPattern.CreateWithInvariantCulture("g");
         private static readonly InstantPattern PatternWithNonTruncatedTicks = InstantPattern.CreateWithInvariantCulture("yyyy'-'MM'-'dd'T'HH':'mm':'ss;fffffff'Z'");
         private static readonly string SampleStringGeneral = GeneralPattern.Format(Sample);
-        private static readonly string SampleStringExtendedIso = InstantPattern.ExtendedIsoPattern.Format(Sample);
+        private static readonly string SampleStringExtendedIso = InstantPattern.ExtendedIso.Format(Sample);
         private static readonly CultureInfo MutableInvariantCulture = (CultureInfo) CultureInfo.InvariantCulture.Clone();
 
         [Benchmark]
@@ -28,13 +28,13 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
         [Benchmark]
         public void ExtendedIsoPatternFormat()
         {
-            InstantPattern.ExtendedIsoPattern.Format(Sample);
+            InstantPattern.ExtendedIso.Format(Sample);
         }
 
         [Benchmark]
         public void ExtendedIsoPatternFormatWithTicks()
         {
-            InstantPattern.ExtendedIsoPattern.Format(SampleWithTicks);
+            InstantPattern.ExtendedIso.Format(SampleWithTicks);
         }
 
         [Benchmark]
@@ -52,14 +52,14 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
         [Benchmark]
         public void ExtendedIsoPatternParse()
         {
-            InstantPattern.ExtendedIsoPattern.Parse(SampleStringExtendedIso);
+            InstantPattern.ExtendedIso.Parse(SampleStringExtendedIso);
         }
 
         [Benchmark]
         public void ParsePatternExtendedIso()
         {
             // Use a mutable culture info to prevent caching
-            InstantPattern.Create(InstantPattern.ExtendedIsoPattern.PatternText, MutableInvariantCulture);
+            InstantPattern.Create(InstantPattern.ExtendedIso.PatternText, MutableInvariantCulture);
         }
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/Text/LocalDatePatternBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Text/LocalDatePatternBenchmarks.cs
@@ -22,7 +22,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
         [Benchmark]
         public void FormatWithIso()
         {
-            LocalDatePattern.IsoPattern.Format(SampleLocalDate);
+            LocalDatePattern.Iso.Format(SampleLocalDate);
         }
 
 #if !V1
@@ -30,7 +30,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
         public void AppendFormatWithIso()
         {
             builder.Clear();
-            LocalDatePattern.IsoPattern.AppendFormat(SampleLocalDate, builder);
+            LocalDatePattern.Iso.AppendFormat(SampleLocalDate, builder);
         }
 #endif
 

--- a/src/NodaTime.Benchmarks/NodaTimeTests/Text/LocalDateTimePatternBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Text/LocalDateTimePatternBenchmarks.cs
@@ -39,21 +39,21 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
         [Benchmark]
         public void FormatIso()
         {
-            LocalDateTimePattern.ExtendedIsoPattern.Format(SampleLocalDateTime);
+            LocalDateTimePattern.ExtendedIso.Format(SampleLocalDateTime);
         }
 
 #if !V1
         [Benchmark]
         public void ParseIso_NanosecondPrecision()
         {
-            LocalDateTimePattern.ExtendedIsoPattern.Parse("2014-08-01T13:46:12.123456789").GetValueOrThrow();
+            LocalDateTimePattern.ExtendedIso.Parse("2014-08-01T13:46:12.123456789").GetValueOrThrow();
         }
 #endif
 
         [Benchmark]
         public void ParseIso_SecondPrecision()
         {
-            LocalDateTimePattern.ExtendedIsoPattern.Parse("2014-08-01T13:46:12").GetValueOrThrow();
+            LocalDateTimePattern.ExtendedIso.Parse("2014-08-01T13:46:12").GetValueOrThrow();
         }
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/Text/OffsetDateTimePatternBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Text/OffsetDateTimePatternBenchmarks.cs
@@ -44,21 +44,21 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
         [Benchmark]
         public void FormatIso()
         {
-            OffsetDateTimePattern.ExtendedIsoPattern.Format(SampleOffsetDateTime);
+            OffsetDateTimePattern.ExtendedIso.Format(SampleOffsetDateTime);
         }
 
 #if !V1
         [Benchmark]
         public void ParseIso_NanosecondPrecision()
         {
-            OffsetDateTimePattern.ExtendedIsoPattern.Parse("2014-08-01T13:46:12.123456789+02").GetValueOrThrow();
+            OffsetDateTimePattern.ExtendedIso.Parse("2014-08-01T13:46:12.123456789+02").GetValueOrThrow();
         }
 #endif
 
         [Benchmark]
         public void ParseIso_SecondPrecision()
         {
-            OffsetDateTimePattern.ExtendedIsoPattern.Parse("2014-08-01T13:46:12+02").GetValueOrThrow();
+            OffsetDateTimePattern.ExtendedIso.Parse("2014-08-01T13:46:12+02").GetValueOrThrow();
         }
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/Text/PeriodPatternBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Text/PeriodPatternBenchmarks.cs
@@ -15,31 +15,31 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
             Years = 100, Months = 1, Days = 10, Hours = 12, Minutes = 35, Seconds = 12, Milliseconds = 123, Ticks = 4567
         }.Build();
 
-        private static readonly string NormalizedText = PeriodPattern.NormalizingIsoPattern.Format(SamplePeriod);
-        private static readonly string RoundtripText = PeriodPattern.RoundtripPattern.Format(SamplePeriod);
+        private static readonly string NormalizedText = PeriodPattern.NormalizingIso.Format(SamplePeriod);
+        private static readonly string RoundtripText = PeriodPattern.Roundtrip.Format(SamplePeriod);
 
         [Benchmark]
         public void ParseNormalized()
         {
-            PeriodPattern.NormalizingIsoPattern.Parse(NormalizedText).GetValueOrThrow();
+            PeriodPattern.NormalizingIso.Parse(NormalizedText).GetValueOrThrow();
         }
 
         [Benchmark]
         public void ParseRoundtrip()
         {
-            PeriodPattern.RoundtripPattern.Parse(RoundtripText).GetValueOrThrow();
+            PeriodPattern.Roundtrip.Parse(RoundtripText).GetValueOrThrow();
         }
 
         [Benchmark]
         public void FormatNormalized()
         {
-            PeriodPattern.NormalizingIsoPattern.Format(SamplePeriod);
+            PeriodPattern.NormalizingIso.Format(SamplePeriod);
         }
 
         [Benchmark]
         public void FormatRoundtrip()
         {
-            PeriodPattern.RoundtripPattern.Format(SamplePeriod);
+            PeriodPattern.Roundtrip.Format(SamplePeriod);
         }
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/Text/ZonedDateTimePatternBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Text/ZonedDateTimePatternBenchmarks.cs
@@ -24,7 +24,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
         [Benchmark]
         public void FormatIso()
         {
-            ZonedDateTimePattern.ExtendedFormatOnlyIsoPattern.Format(SampleZonedDateTime);
+            ZonedDateTimePattern.ExtendedFormatOnlyIso.Format(SampleZonedDateTime);
         }
     }
 }

--- a/src/NodaTime.Serialization.JsonNet/NodaConverters.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaConverters.cs
@@ -19,14 +19,14 @@ namespace NodaTime.Serialization.JsonNet
         /// specifying 'Z' at the end to show it's effectively in UTC.
         /// </summary>
         public static JsonConverter InstantConverter { get; }
-            = new NodaPatternConverter<Instant>(InstantPattern.ExtendedIsoPattern);
+            = new NodaPatternConverter<Instant>(InstantPattern.ExtendedIso);
 
         /// <summary>
         /// Converter for local dates, using the ISO-8601 date pattern.
         /// </summary>
         public static JsonConverter LocalDateConverter { get; }
             = new NodaPatternConverter<LocalDate>(
-                LocalDatePattern.IsoPattern, CreateIsoValidator<LocalDate>(x => x.Calendar));
+                LocalDatePattern.Iso, CreateIsoValidator<LocalDate>(x => x.Calendar));
 
         /// <summary>
         /// Converter for local dates and times, using the ISO-8601 date/time pattern, extended as required to accommodate milliseconds and ticks.
@@ -34,13 +34,13 @@ namespace NodaTime.Serialization.JsonNet
         /// </summary>
         public static JsonConverter LocalDateTimeConverter { get; }
             = new NodaPatternConverter<LocalDateTime>(
-                LocalDateTimePattern.ExtendedIsoPattern, CreateIsoValidator<LocalDateTime>(x => x.Calendar));
+                LocalDateTimePattern.ExtendedIso, CreateIsoValidator<LocalDateTime>(x => x.Calendar));
 
         /// <summary>
         /// Converter for local times, using the ISO-8601 time pattern, extended as required to accommodate milliseconds and ticks.
         /// </summary>
         public static JsonConverter LocalTimeConverter { get; }
-            = new NodaPatternConverter<LocalTime>(LocalTimePattern.ExtendedIsoPattern);
+            = new NodaPatternConverter<LocalTime>(LocalTimePattern.ExtendedIso);
 
         /// <summary>
         /// Converter for intervals. This must be used in a serializer which also has an instant converter.
@@ -57,14 +57,14 @@ namespace NodaTime.Serialization.JsonNet
         /// Converter for offsets.
         /// </summary>
         public static JsonConverter OffsetConverter { get; }
-            = new NodaPatternConverter<Offset>(OffsetPattern.GeneralInvariantPattern);
+            = new NodaPatternConverter<Offset>(OffsetPattern.GeneralInvariant);
 
         /// <summary>
         /// Converter for offset date/times.
         /// </summary>
         public static JsonConverter OffsetDateTimeConverter { get; } =
             new NodaPatternConverter<OffsetDateTime>(
-                OffsetDateTimePattern.Rfc3339Pattern, CreateIsoValidator<OffsetDateTime>(x => x.Calendar));
+                OffsetDateTimePattern.Rfc3339, CreateIsoValidator<OffsetDateTime>(x => x.Calendar));
 
         /// <summary>
         /// Creates a converter for zoned date/times, using the given time zone provider.
@@ -95,7 +95,7 @@ namespace NodaTime.Serialization.JsonNet
         /// and don't need interoperability with systems expecting ISO.
         /// </summary>
         public static JsonConverter RoundtripPeriodConverter { get; }
-            = new NodaPatternConverter<Period>(PeriodPattern.RoundtripPattern);
+            = new NodaPatternConverter<Period>(PeriodPattern.Roundtrip);
 
         /// <summary>
         /// Normalizing ISO converter for periods. Use this when you want compatibility with systems expecting
@@ -103,7 +103,7 @@ namespace NodaTime.Serialization.JsonNet
         /// this converter losees information - after serialization and deserialization, "90 minutes" will become "an hour and 30 minutes".
         /// </summary>
         public static JsonConverter NormalizingIsoPeriodConverter { get; }
-            = new NodaPatternConverter<Period>(PeriodPattern.NormalizingIsoPattern);
+            = new NodaPatternConverter<Period>(PeriodPattern.NormalizingIso);
 
         private static Action<T> CreateIsoValidator<T>(Func<T, CalendarSystem> calendarProjection) => value =>
         {

--- a/src/NodaTime.Serialization.JsonNet/NodaIsoIntervalConverter.cs
+++ b/src/NodaTime.Serialization.JsonNet/NodaIsoIntervalConverter.cs
@@ -29,7 +29,7 @@ namespace NodaTime.Serialization.JsonNet
 
             string startText = text.Substring(0, slash);
             string endText = text.Substring(slash + 1);
-            var pattern = InstantPattern.ExtendedIsoPattern;
+            var pattern = InstantPattern.ExtendedIso;
             var start = startText == "" ? (Instant?) null : pattern.Parse(startText).Value;
             var end = endText == "" ? (Instant?) null : pattern.Parse(endText).Value;
 
@@ -44,7 +44,7 @@ namespace NodaTime.Serialization.JsonNet
         /// <param name="serializer">The serializer for embedded serialization.</param>
         protected override void WriteJsonImpl(JsonWriter writer, Interval value, JsonSerializer serializer)
         {
-            var pattern = InstantPattern.ExtendedIsoPattern;
+            var pattern = InstantPattern.ExtendedIso;
             string text = (value.HasStart ? pattern.Format(value.Start) : "") + "/" + (value.HasEnd ? pattern.Format(value.End) : "");
             writer.WriteValue(text);
         }

--- a/src/NodaTime.Test/DateIntervalTest.cs
+++ b/src/NodaTime.Test/DateIntervalTest.cs
@@ -214,7 +214,7 @@ namespace NodaTime.Test
         {
             var start = new LocalDate(2000, 1, 1);
             var end = new LocalDate(2014, 06, 30);
-            var candidate = LocalDatePattern.IsoPattern.Parse(candidateText).Value;
+            var candidate = LocalDatePattern.Iso.Parse(candidateText).Value;
             var interval = new DateInterval(start, end, true);
             Assert.AreEqual(expectedInclusive, interval.Contains(candidate));
             interval = new DateInterval(start, end, false);

--- a/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
+++ b/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
@@ -266,7 +266,7 @@ namespace NodaTime.Test
         [TestCase("Pacific/Kwajalein", "1993-08-20")]
         public void AtStartOfDay_DayDoesntExist(string zoneId, string localDate)
         {
-            LocalDate badDate = LocalDatePattern.IsoPattern.Parse(localDate).Value;
+            LocalDate badDate = LocalDatePattern.Iso.Parse(localDate).Value;
             DateTimeZone zone = DateTimeZoneProviders.Tzdb[zoneId];
             var exception = Assert.Throws<SkippedTimeException>(() => zone.AtStartOfDay(badDate));
             Assert.AreEqual(badDate + LocalTime.Midnight, exception.LocalDateTime);

--- a/src/NodaTime.Test/Fields/TimePeriodFieldTest.cs
+++ b/src/NodaTime.Test/Fields/TimePeriodFieldTest.cs
@@ -23,8 +23,8 @@ namespace NodaTime.Test.Fields
         [TestCase("23:59:59.000", 1000, "00:00:00.000", 1)]
         public void Add(string start, long units, string expectedEnd, int expectedExtraDays)
         {
-            var startTime = LocalTimePattern.ExtendedIsoPattern.Parse(start).Value;
-            var expectedEndTime = LocalTimePattern.ExtendedIsoPattern.Parse(expectedEnd).Value;
+            var startTime = LocalTimePattern.ExtendedIso.Parse(start).Value;
+            var expectedEndTime = LocalTimePattern.ExtendedIso.Parse(expectedEnd).Value;
 
             int extraDays = 0;
             Assert.AreEqual(expectedEndTime, SampleField.Add(startTime, units, ref extraDays));
@@ -37,8 +37,8 @@ namespace NodaTime.Test.Fields
         [TestCase("00:00:01.0000", "00:00:00.9999", 0)]
         public void Subtract(string minuend, string subtrahend, long expected)
         {
-            var minuendTime = LocalTimePattern.ExtendedIsoPattern.Parse(minuend).Value;
-            var subtrahendTime = LocalTimePattern.ExtendedIsoPattern.Parse(subtrahend).Value;
+            var minuendTime = LocalTimePattern.ExtendedIso.Parse(minuend).Value;
+            var subtrahendTime = LocalTimePattern.ExtendedIso.Parse(subtrahend).Value;
             Assert.AreEqual(expected, SampleField.Subtract(minuendTime, subtrahendTime));
             Assert.AreEqual(-expected, SampleField.Subtract(subtrahendTime, minuendTime));
         }

--- a/src/NodaTime.Test/IntervalTest.cs
+++ b/src/NodaTime.Test/IntervalTest.cs
@@ -189,7 +189,7 @@ namespace NodaTime.Test
             var start = Instant.FromUtc(2000, 1, 1, 0, 0);
             var end = Instant.FromUtc(2020, 1, 1, 0, 0);
             var interval = new Interval(start, end);
-            var candidate = InstantPattern.ExtendedIsoPattern.Parse(candidateText).Value;
+            var candidate = InstantPattern.ExtendedIso.Parse(candidateText).Value;
             Assert.AreEqual(expectedResult, interval.Contains(candidate));
         }
 

--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -802,8 +802,8 @@ namespace NodaTime.Test
         [TestCase("2014-01-01T16:00:00", "2014-01-03T08:00:00", PeriodUnits.Hours, 40, -40)]
         public void Between_LocalDateTime_AwkwardTimeOfDayWithSingleUnit(string startText, string endText, PeriodUnits units, int expectedForward, int expectedBackward)
         {
-            LocalDateTime start = LocalDateTimePattern.ExtendedIsoPattern.Parse(startText).Value;
-            LocalDateTime end = LocalDateTimePattern.ExtendedIsoPattern.Parse(endText).Value;
+            LocalDateTime start = LocalDateTimePattern.ExtendedIso.Parse(startText).Value;
+            LocalDateTime end = LocalDateTimePattern.ExtendedIso.Parse(endText).Value;
             Period forward = Period.Between(start, end, units);
             Assert.AreEqual(expectedForward, forward.ToBuilder()[units]);
             Period backward = Period.Between(end, start, units);
@@ -837,7 +837,7 @@ namespace NodaTime.Test
         /// </summary>
         private static Period Parse(string text)
         {
-            return PeriodPattern.RoundtripPattern.Parse(text).Value;
+            return PeriodPattern.Roundtrip.Parse(text).Value;
         }
     }
 }

--- a/src/NodaTime.Test/Text/InstantPatternTest.cs
+++ b/src/NodaTime.Test/Text/InstantPatternTest.cs
@@ -39,7 +39,7 @@ namespace NodaTime.Test.Text
         public void IsoHandlesCommas()
         {
             Instant expected = Instant.FromUtc(2012, 1, 1, 0, 0) + Duration.Epsilon;
-            Instant actual = InstantPattern.ExtendedIsoPattern.Parse("2012-01-01T00:00:00,000000001Z").Value;
+            Instant actual = InstantPattern.ExtendedIso.Parse("2012-01-01T00:00:00,000000001Z").Value;
             Assert.AreEqual(actual, expected);
         }
 

--- a/src/NodaTime.Test/Text/LocalDatePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalDatePatternTest.cs
@@ -218,7 +218,7 @@ namespace NodaTime.Test.Text
         [Test]
         public void WithCalendar()
         {
-            var pattern = LocalDatePattern.IsoPattern.WithCalendar(CalendarSystem.Coptic);
+            var pattern = LocalDatePattern.Iso.WithCalendar(CalendarSystem.Coptic);
             var value = pattern.Parse("0284-08-29").Value;
             Assert.AreEqual(new LocalDate(284, 8, 29, CalendarSystem.Coptic), value);
         }

--- a/src/NodaTime.Test/Text/PatternNamingTest.cs
+++ b/src/NodaTime.Test/Text/PatternNamingTest.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NUnit.Framework;
+using System.Linq;
+using System.Reflection;
+
+namespace NodaTime.Test.Text
+{
+    public class PatternNamingTest
+    {
+        // https://github.com/nodatime/nodatime/issues/556
+        [Test]
+        public void NoPatternSuffix()
+        {
+            var properties =
+                from type in typeof(Instant).GetTypeInfo().Assembly.DefinedTypes
+                where type.Name.EndsWith("Pattern")
+                from property in type.DeclaredProperties
+                where property.GetMethod?.IsStatic == true && property.Name.EndsWith("Pattern")
+                select $"{type.Name}.{property.Name}";
+            Assert.IsEmpty(properties, $"Badly named properties: {string.Join(", ", properties)}");
+        }
+    }
+}

--- a/src/NodaTime.Test/Text/PeriodPatternTest.NormalizingIso.cs
+++ b/src/NodaTime.Test/Text/PeriodPatternTest.NormalizingIso.cs
@@ -95,7 +95,7 @@ namespace NodaTime.Test.Text
                 {
                     foreach (var item in sequence)
                     {
-                        item.StandardPattern = PeriodPattern.NormalizingIsoPattern;
+                        item.StandardPattern = PeriodPattern.NormalizingIso;
                     }
                 }
             }

--- a/src/NodaTime.Test/Text/PeriodPatternTest.cs
+++ b/src/NodaTime.Test/Text/PeriodPatternTest.cs
@@ -25,7 +25,7 @@ namespace NodaTime.Test.Text
 
             public Data(Period value) : base(value)
             {
-                this.StandardPattern = PeriodPattern.RoundtripPattern;
+                this.StandardPattern = PeriodPattern.Roundtrip;
             }
 
             public Data(PeriodBuilder builder) : this(builder.Build())

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -199,8 +199,8 @@ namespace NodaTime
         /// </returns>
         public override string ToString()
         {
-            string start = LocalDatePattern.IsoPattern.Format(Start);
-            string end = LocalDatePattern.IsoPattern.Format(End);
+            string start = LocalDatePattern.Iso.Format(Start);
+            string end = LocalDatePattern.Iso.Format(End);
             string endType = Inclusive ? "]" : ")";
             return $"[{start}, {end}{endType}";
         }

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -1122,7 +1122,7 @@ namespace NodaTime
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)
         {
             Preconditions.CheckNotNull(reader, nameof(reader));
-            var pattern = DurationPattern.RoundtripPattern;
+            var pattern = DurationPattern.Roundtrip;
             string text = reader.ReadElementContentAsString();
             this = pattern.Parse(text).Value;
         }
@@ -1131,7 +1131,7 @@ namespace NodaTime
         void IXmlSerializable.WriteXml([NotNull] XmlWriter writer)
         {
             Preconditions.CheckNotNull(writer, nameof(writer));
-            writer.WriteString(DurationPattern.RoundtripPattern.Format(this));
+            writer.WriteString(DurationPattern.Roundtrip.Format(this));
         }
         #endregion
 

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -707,7 +707,7 @@ namespace NodaTime
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)
         {
             Preconditions.CheckNotNull(reader, nameof(reader));
-            var pattern = InstantPattern.ExtendedIsoPattern;
+            var pattern = InstantPattern.ExtendedIso;
             string text = reader.ReadElementContentAsString();
             this = pattern.Parse(text).Value;
         }
@@ -716,7 +716,7 @@ namespace NodaTime
         void IXmlSerializable.WriteXml([NotNull] XmlWriter writer)
         {
             Preconditions.CheckNotNull(writer, nameof(writer));
-            writer.WriteString(InstantPattern.ExtendedIsoPattern.Format(this));
+            writer.WriteString(InstantPattern.ExtendedIso.Format(this));
         }
         #endregion
 

--- a/src/NodaTime/Interval.cs
+++ b/src/NodaTime/Interval.cs
@@ -197,7 +197,7 @@ namespace NodaTime
         /// <returns>A string representation of this interval.</returns>
         public override string ToString()
         {
-            var pattern = InstantPattern.ExtendedIsoPattern;
+            var pattern = InstantPattern.ExtendedIso;
             return pattern.Format(start) + "/" + pattern.Format(end);
         }
         #endregion
@@ -228,7 +228,7 @@ namespace NodaTime
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)
         {
             Preconditions.CheckNotNull(reader, nameof(reader));
-            var pattern = InstantPattern.ExtendedIsoPattern;
+            var pattern = InstantPattern.ExtendedIso;
             Instant newStart = reader.MoveToAttribute("start") ? pattern.Parse(reader.Value).Value : Instant.BeforeMinValue;
             Instant newEnd = reader.MoveToAttribute("end") ? pattern.Parse(reader.Value).Value : Instant.AfterMaxValue;
             this = new Interval(newStart, newEnd);
@@ -240,7 +240,7 @@ namespace NodaTime
         void IXmlSerializable.WriteXml([NotNull] XmlWriter writer)
         {
             Preconditions.CheckNotNull(writer, nameof(writer));
-            var pattern = InstantPattern.ExtendedIsoPattern;
+            var pattern = InstantPattern.ExtendedIso;
             if (HasStart)
             {
                 writer.WriteAttributeString("start", pattern.Format(start));

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -753,7 +753,7 @@ namespace NodaTime
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)
         {
             Preconditions.CheckNotNull(reader, nameof(reader));
-            var pattern = LocalDatePattern.IsoPattern;
+            var pattern = LocalDatePattern.Iso;
             if (reader.MoveToAttribute("calendar"))
             {
                 string newCalendarId = reader.Value;
@@ -774,7 +774,7 @@ namespace NodaTime
             {
                 writer.WriteAttributeString("calendar", Calendar.Id);
             }
-            writer.WriteString(LocalDatePattern.IsoPattern.Format(this));
+            writer.WriteString(LocalDatePattern.Iso.Format(this));
         }
         #endregion
 

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -948,7 +948,7 @@ namespace NodaTime
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)
         {
             Preconditions.CheckNotNull(reader, nameof(reader));
-            var pattern = LocalDateTimePattern.ExtendedIsoPattern;
+            var pattern = LocalDateTimePattern.ExtendedIso;
             if (reader.MoveToAttribute("calendar"))
             {
                 string newCalendarId = reader.Value;
@@ -969,7 +969,7 @@ namespace NodaTime
             {
                 writer.WriteAttributeString("calendar", Calendar.Id);
             }
-            writer.WriteString(LocalDateTimePattern.ExtendedIsoPattern.Format(this));
+            writer.WriteString(LocalDateTimePattern.ExtendedIso.Format(this));
         }
         #endregion
 

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -710,7 +710,7 @@ namespace NodaTime
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)
         {
             Preconditions.CheckNotNull(reader, nameof(reader));
-            var pattern = LocalTimePattern.ExtendedIsoPattern;
+            var pattern = LocalTimePattern.ExtendedIso;
             string text = reader.ReadElementContentAsString();
             this = pattern.Parse(text).Value;
         }
@@ -719,7 +719,7 @@ namespace NodaTime
         void IXmlSerializable.WriteXml([NotNull] XmlWriter writer)
         {
             Preconditions.CheckNotNull(writer, nameof(writer));
-            writer.WriteString(LocalTimePattern.ExtendedIsoPattern.Format(this));
+            writer.WriteString(LocalTimePattern.ExtendedIso.Format(this));
         }
         #endregion
 

--- a/src/NodaTime/Offset.cs
+++ b/src/NodaTime/Offset.cs
@@ -504,7 +504,7 @@ namespace NodaTime
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)
         {
             Preconditions.CheckNotNull(reader, nameof(reader));
-            var pattern = OffsetPattern.GeneralInvariantPattern;
+            var pattern = OffsetPattern.GeneralInvariant;
             string text = reader.ReadElementContentAsString();
             this = pattern.Parse(text).Value;
         }
@@ -513,7 +513,7 @@ namespace NodaTime
         void IXmlSerializable.WriteXml([NotNull] XmlWriter writer)
         {
             Preconditions.CheckNotNull(writer, nameof(writer));
-            writer.WriteString(OffsetPattern.GeneralInvariantPattern.Format(this));
+            writer.WriteString(OffsetPattern.GeneralInvariant.Format(this));
         }
         #endregion
 

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -847,7 +847,7 @@ namespace NodaTime
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)
         {
             Preconditions.CheckNotNull(reader, nameof(reader));
-            var pattern = OffsetDateTimePattern.Rfc3339Pattern;
+            var pattern = OffsetDateTimePattern.Rfc3339;
             if (reader.MoveToAttribute("calendar"))
             {
                 string newCalendarId = reader.Value;
@@ -868,7 +868,7 @@ namespace NodaTime
             {
                 writer.WriteAttributeString("calendar", Calendar.Id);
             }
-            writer.WriteString(OffsetDateTimePattern.Rfc3339Pattern.Format(this));
+            writer.WriteString(OffsetDateTimePattern.Rfc3339.Format(this));
         }
         #endregion
 

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -769,10 +769,10 @@ namespace NodaTime
         #region Object overrides
 
         /// <summary>
-        /// Returns this string formatted according to the <see cref="PeriodPattern.RoundtripPattern"/>.
+        /// Returns this string formatted according to the <see cref="PeriodPattern.Roundtrip"/>.
         /// </summary>
         /// <returns>A formatted representation of this period.</returns>
-        public override string ToString() => PeriodPattern.RoundtripPattern.Format(this);
+        public override string ToString() => PeriodPattern.Roundtrip.Format(this);
 
         /// <summary>
         /// Compares the given object for equality with this one, as per <see cref="Equals(Period)"/>.

--- a/src/NodaTime/PeriodBuilder.cs
+++ b/src/NodaTime/PeriodBuilder.cs
@@ -188,7 +188,7 @@ namespace NodaTime
         void IXmlSerializable.ReadXml(XmlReader reader)
         {
             string text = reader.ReadElementContentAsString();
-            Period period = PeriodPattern.RoundtripPattern.Parse(text).Value;
+            Period period = PeriodPattern.Roundtrip.Parse(text).Value;
             Years = period.Years;
             Months = period.Months;
             Weeks = period.Weeks;
@@ -204,7 +204,7 @@ namespace NodaTime
         /// <inheritdoc />
         void IXmlSerializable.WriteXml(XmlWriter writer)
         {
-            writer.WriteString(PeriodPattern.RoundtripPattern.Format(Build()));
+            writer.WriteString(PeriodPattern.Roundtrip.Format(Build()));
         }
     }
 }

--- a/src/NodaTime/Text/DurationPattern.cs
+++ b/src/NodaTime/Text/DurationPattern.cs
@@ -28,7 +28,7 @@ namespace NodaTime.Text
         /// This pattern round-trips.
         /// </summary>
         /// <value>The general pattern for durations using the invariant culture.</value>
-        public static DurationPattern RoundtripPattern => Patterns.RoundtripPatternImpl;
+        public static DurationPattern Roundtrip => Patterns.RoundtripPatternImpl;
 
         internal static readonly PatternBclSupport<Duration> BclSupport = new PatternBclSupport<Duration>("o", fi => fi.DurationPatternParser);
 

--- a/src/NodaTime/Text/InstantPattern.cs
+++ b/src/NodaTime/Text/InstantPattern.cs
@@ -28,7 +28,7 @@ namespace NodaTime.Text
         /// an instant as a UTC date/time in ISO-8601 style "uuuu-MM-ddTHH:mm:ss'Z'".
         /// </summary>
         /// <value>The general pattern, which always uses an invariant culture.</value>
-        public static InstantPattern GeneralPattern => Patterns.GeneralPatternImpl;
+        public static InstantPattern General => Patterns.GeneralPatternImpl;
 
         /// <summary>
         /// Gets an invariant instant pattern which is ISO-8601 compatible, providing up to 9 decimal places
@@ -37,7 +37,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <value>An invariant instant pattern which is ISO-8601 compatible, providing up to 9 decimal places
         /// of sub-second accuracy.</value>
-        public static InstantPattern ExtendedIsoPattern => Patterns.ExtendedIsoPatternImpl;
+        public static InstantPattern ExtendedIso => Patterns.ExtendedIsoPatternImpl;
 
         private const string DefaultFormatPattern = "g";
 

--- a/src/NodaTime/Text/LocalDatePattern.cs
+++ b/src/NodaTime/Text/LocalDatePattern.cs
@@ -35,7 +35,7 @@ namespace NodaTime.Text
         /// This corresponds to the text pattern "uuuu'-'MM'-'dd".
         /// </summary>
         /// <value>An invariant local date pattern which is ISO-8601 compatible.</value>
-        public static LocalDatePattern IsoPattern => Patterns.IsoPatternImpl;
+        public static LocalDatePattern Iso => Patterns.IsoPatternImpl;
 
         /// <summary>
         /// Class whose existence is solely to avoid type initialization order issues, most of which stem

--- a/src/NodaTime/Text/LocalDateTimePattern.cs
+++ b/src/NodaTime/Text/LocalDateTimePattern.cs
@@ -37,7 +37,7 @@ namespace NodaTime.Text
         /// standard pattern.
         /// </summary>
         /// <value>An invariant local date/time pattern which is ISO-8601 compatible, down to the second.</value>
-        public static LocalDateTimePattern GeneralIsoPattern => Patterns.GeneralIsoPatternImpl;
+        public static LocalDateTimePattern GeneralIso => Patterns.GeneralIsoPatternImpl;
 
         /// <summary>
         /// Gets an invariant local date/time pattern which is ISO-8601 compatible, providing up to 9 decimal places
@@ -46,7 +46,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <value>An invariant local date/time pattern which is ISO-8601 compatible, providing up to 9 decimal places
         /// of sub-second accuracy.</value>
-        public static LocalDateTimePattern ExtendedIsoPattern => Patterns.ExtendedIsoPatternImpl;
+        public static LocalDateTimePattern ExtendedIso => Patterns.ExtendedIsoPatternImpl;
 
         /// <summary>
         /// Gets an invariant local date/time pattern which is ISO-8601 compatible, providing up to 7 decimal places
@@ -57,14 +57,14 @@ namespace NodaTime.Text
         /// </summary>
         /// <value>An invariant local date/time pattern which is ISO-8601 compatible, providing up to 7 decimal places
         /// of sub-second accuracy which are always present (including trailing zeroes).</value>
-        public static LocalDateTimePattern BclRoundtripPattern => Patterns.BclRoundtripPatternImpl;
+        public static LocalDateTimePattern BclRoundtrip => Patterns.BclRoundtripPatternImpl;
 
         /// <summary>
         /// Gets an invariant local date/time pattern which round trips values including the calendar system.
         /// This corresponds to the text pattern "uuuu'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffff '('c')'".
         /// </summary>
         /// <value>An invariant local date/time pattern which round trips values including the calendar system.</value>
-        public static LocalDateTimePattern FullRoundtripPattern => Patterns.FullRoundtripPatternImpl;
+        public static LocalDateTimePattern FullRoundtrip => Patterns.FullRoundtripPatternImpl;
 
         /// <summary>
         /// Class whose existence is solely to avoid type initialization order issues, most of which stem

--- a/src/NodaTime/Text/LocalTimePattern.cs
+++ b/src/NodaTime/Text/LocalTimePattern.cs
@@ -29,7 +29,7 @@ namespace NodaTime.Text
         /// This corresponds to the text pattern "HH':'mm':'ss;FFFFFFF".
         /// </summary>
         /// <value>An invariant local time pattern which is ISO-8601 compatible, providing up to 7 decimal places.</value>
-        public static LocalTimePattern ExtendedIsoPattern => Patterns.ExtendedIsoPatternImpl;
+        public static LocalTimePattern ExtendedIso => Patterns.ExtendedIsoPatternImpl;
 
         private const string DefaultFormatPattern = "T"; // Long
 

--- a/src/NodaTime/Text/OffsetDateTimePattern.cs
+++ b/src/NodaTime/Text/OffsetDateTimePattern.cs
@@ -34,7 +34,7 @@ namespace NodaTime.Text
         /// standard pattern (even though it is invariant).
         /// </remarks>
         /// <value>An invariant offset date/time pattern based on ISO-8601 (down to the second), including offset from UTC.</value>
-        public static OffsetDateTimePattern GeneralIsoPattern => Patterns.GeneralIsoPatternImpl;
+        public static OffsetDateTimePattern GeneralIso => Patterns.GeneralIsoPatternImpl;
 
         /// <summary>
         /// Gets an invariant offset date/time pattern based on ISO-8601 (down to the nanosecond), including offset from UTC.
@@ -45,7 +45,7 @@ namespace NodaTime.Text
         /// in the ISO calendar, and is available as the "o" standard pattern.
         /// </remarks>
         /// <value>An invariant offset date/time pattern based on ISO-8601 (down to the nanosecond), including offset from UTC.</value>
-        public static OffsetDateTimePattern ExtendedIsoPattern => Patterns.ExtendedIsoPatternImpl;
+        public static OffsetDateTimePattern ExtendedIso => Patterns.ExtendedIsoPatternImpl;
 
         /// <summary>
         /// Gets an invariant offset date/time pattern based on RFC 3339 (down to the nanosecond), including offset from UTC
@@ -61,7 +61,7 @@ namespace NodaTime.Text
         /// </remarks>
         /// <value>An invariant offset date/time pattern based on RFC 3339 (down to the nanosecond), including offset from UTC
         /// as hours and minutes only.</value>
-        public static OffsetDateTimePattern Rfc3339Pattern => Patterns.Rfc3339PatternImpl;
+        public static OffsetDateTimePattern Rfc3339 => Patterns.Rfc3339PatternImpl;
 
         /// <summary>
         /// Gets an invariant offset date/time pattern based on ISO-8601 (down to the nanosecond)
@@ -74,7 +74,7 @@ namespace NodaTime.Text
         /// </remarks>
         /// <value>An invariant offset date/time pattern based on ISO-8601 (down to the nanosecond)
         /// including offset from UTC and calendar ID.</value>
-        public static OffsetDateTimePattern FullRoundtripPattern => Patterns.FullRoundtripPatternImpl;
+        public static OffsetDateTimePattern FullRoundtrip => Patterns.FullRoundtripPatternImpl;
 
         /// <summary>
         /// Class whose existence is solely to avoid type initialization order issues, most of which stem

--- a/src/NodaTime/Text/OffsetPattern.cs
+++ b/src/NodaTime/Text/OffsetPattern.cs
@@ -26,13 +26,13 @@ namespace NodaTime.Text
         /// <summary>
         /// The "general" offset pattern (e.g. +HH, +HH:mm, +HH:mm:ss, +HH:mm:ss.fff) for the invariant culture.
         /// </summary>
-        public static OffsetPattern GeneralInvariantPattern { get; } = CreateWithInvariantCulture("g");
+        public static OffsetPattern GeneralInvariant { get; } = CreateWithInvariantCulture("g");
 
         /// <summary>
         /// The "general" offset pattern (e.g. +HH, +HH:mm, +HH:mm:ss, +HH:mm:ss.fff) for the invariant culture,
         /// but producing (and allowing) Z as a value for a zero offset.
         /// </summary>
-        public static OffsetPattern GeneralInvariantPatternWithZ { get; } = CreateWithInvariantCulture("G");
+        public static OffsetPattern GeneralInvariantWithZ { get; } = CreateWithInvariantCulture("G");
 
         private const string DefaultFormatPattern = "g";
 

--- a/src/NodaTime/Text/PeriodPattern.cs
+++ b/src/NodaTime/Text/PeriodPattern.cs
@@ -26,7 +26,7 @@ namespace NodaTime.Text
         /// Each element may also be negative, independently of other elements. This pattern round-trips its
         /// values: a parse/format cycle will produce an identical period, including units.
         /// </summary>
-        public static PeriodPattern RoundtripPattern { get; } = new PeriodPattern(new RoundtripPatternImpl());
+        public static PeriodPattern Roundtrip { get; } = new PeriodPattern(new RoundtripPatternImpl());
 
         /// <summary>
         /// A "normalizing" pattern which abides by the ISO-8601 duration format as far as possible.
@@ -40,7 +40,7 @@ namespace NodaTime.Text
         /// combined weeks/days/time portions are considered. Such a period could never
         /// be useful anyway, however.
         /// </remarks>
-        public static PeriodPattern NormalizingIsoPattern { get; } = new PeriodPattern(new NormalizingIsoPatternImpl());
+        public static PeriodPattern NormalizingIso { get; } = new PeriodPattern(new NormalizingIsoPatternImpl());
 
         private readonly IPattern<Period> pattern;
 

--- a/src/NodaTime/Text/ZonedDateTimePattern.cs
+++ b/src/NodaTime/Text/ZonedDateTimePattern.cs
@@ -37,7 +37,7 @@ namespace NodaTime.Text
         /// pattern which can be used for parsing.
         /// </remarks>
         /// <value>An zoned local date/time pattern based on ISO-8601 (down to the second) including offset from UTC and zone ID.</value>
-        public static ZonedDateTimePattern GeneralFormatOnlyIsoPattern => Patterns.GeneralFormatOnlyPatternImpl;
+        public static ZonedDateTimePattern GeneralFormatOnlyIso => Patterns.GeneralFormatOnlyPatternImpl;
 
         // TODO(2.0): Add tests for this and other patterns from properties.
         /// <summary>
@@ -51,7 +51,7 @@ namespace NodaTime.Text
         /// pattern which can be used for parsing.
         /// </remarks>
         /// <value>An invariant zoned date/time pattern based on ISO-8601 (down to the nanosecond) including offset from UTC and zone ID.</value>
-        public static ZonedDateTimePattern ExtendedFormatOnlyIsoPattern => Patterns.ExtendedFormatOnlyPatternImpl;
+        public static ZonedDateTimePattern ExtendedFormatOnlyIso => Patterns.ExtendedFormatOnlyPatternImpl;
 
         private readonly IPattern<ZonedDateTime> pattern;
 

--- a/src/NodaTime/Text/ZonedDateTimePatternParser.cs
+++ b/src/NodaTime/Text/ZonedDateTimePatternParser.cs
@@ -178,7 +178,7 @@ namespace NodaTime.Text
                     return null;
                 }
                 value.Move(value.Index + 3);
-                var pattern = OffsetPattern.GeneralInvariantPattern.UnderlyingPattern;
+                var pattern = OffsetPattern.GeneralInvariant.UnderlyingPattern;
                 var parseResult = pattern.ParsePartial(value);
                 return parseResult.Success ? DateTimeZone.ForOffset(parseResult.Value) : DateTimeZone.Utc;
             }

--- a/src/NodaTime/TimeZones/FixedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/FixedDateTimeZone.cs
@@ -64,7 +64,7 @@ namespace NodaTime.TimeZones
             {
                 return UtcId;
             }
-            return UtcId + OffsetPattern.GeneralInvariantPattern.Format(offset);
+            return UtcId + OffsetPattern.GeneralInvariant.Format(offset);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace NodaTime.TimeZones
             {
                 return Utc;
             }
-            var parseResult = OffsetPattern.GeneralInvariantPattern.Parse(id.Substring(UtcId.Length));
+            var parseResult = OffsetPattern.GeneralInvariant.Parse(id.Substring(UtcId.Length));
             return parseResult.Success ? ForOffset(parseResult.Value) : null;
         }
 

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -760,7 +760,7 @@ namespace NodaTime
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)
         {
             Preconditions.CheckNotNull(reader, nameof(reader));
-            var pattern = OffsetDateTimePattern.ExtendedIsoPattern;
+            var pattern = OffsetDateTimePattern.ExtendedIso;
             if (!reader.MoveToAttribute("zone"))
             {
                 throw new ArgumentException("No zone specified in XML for ZonedDateTime");
@@ -794,7 +794,7 @@ namespace NodaTime
             {
                 writer.WriteAttributeString("calendar", Calendar.Id);
             }
-            writer.WriteString(OffsetDateTimePattern.ExtendedIsoPattern.Format(ToOffsetDateTime()));
+            writer.WriteString(OffsetDateTimePattern.ExtendedIso.Format(ToOffsetDateTime()));
         }
         #endregion
 

--- a/www/unstable/userguide/migration-to-2.md
+++ b/www/unstable/userguide/migration-to-2.md
@@ -81,6 +81,9 @@ methods introduced in `DateTimeOffset` in .NET 4.6:
 - The `Ticks` property is now `ToUnixTimeTicks()`
 - There are two new methods, `ToUnixTimeSeconds()` and `ToUnixTimeMilliseconds()`
 
+Static properties on the pattern classes have been renamed to remove the `Pattern` suffix. For example,
+`LocalDateTimePattern.ExtendedIsoPattern` is now just `LocalDateTimePattern.ExtendedIso`.
+
 Period
 ====
 

--- a/www/unstable/userguide/versions.md
+++ b/www/unstable/userguide/versions.md
@@ -15,6 +15,7 @@ Breaking changes:
 
 See the [Noda Time 1.x to 2.0 migration guide](migration-to-2.html) for full details.
 
+- Renamed all static pattern properties to remove the `Pattern` suffix
 - Removed members which had already been made obsolete in the 1.x release line, including
   support for the legacy resource-based time zone data format.
 - Removed `Instant(long)` constructor from the public API.


### PR DESCRIPTION
Fixes #556.

(This time I've remembered to do the version history and migration guide... the fact that we've got two copies of everything is getting annoying though...)