### PR TITLE
Prefer fixed offset zones from the source rather than FixedOffsetZone

### DIFF
--- a/docs/userguide/unstable/versions.md
+++ b/docs/userguide/unstable/versions.md
@@ -60,6 +60,8 @@ Other:
 - Added a `ReturnForwardShifted` resolver, which shifts values in the daylight saving time "gap" forward by the duration of the gap,
   effectively returning the instant that would have occurred had the gap not existed.  This was added to support the new behavior of
   the "lenient" resolver (see above), but can also be used separately.
+- When an `IDateTimeZoneSource` advertises a zone with an ID corresponding to a fixed-offset
+  zone, `DateTimeZoneCache` now consults the source first. This fixes ([issue 332][]).
 
 ## 1.3.2, released 2016-04-14 with tzdb 2016c
 

--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneSourceTest.cs
@@ -75,6 +75,18 @@ namespace NodaTime.Test.TimeZones
 
             Assert.IsNotNull(zone);  // though really we only need to test that the call above didn't throw.
         }
+
+        // This is effectively a test for DateTimeZoneCache, but is particularly
+        // important for the BclDateTimeZoneSource. See
+        // https://github.com/nodatime/nodatime/issues/332
+        [Test]
+        public void ProviderReturnsBclDateTimeZoneForAllAdvertisedIds()
+        {
+            var source = new BclDateTimeZoneSource();
+            var provider = new DateTimeZoneCache(source);
+            var nonBclZones = provider.Ids.Select(id => provider[id]).Where(zone => !(zone is BclDateTimeZone));
+            Assert.IsEmpty(nonBclZones);
+        }
     }
 }
 #endif

--- a/src/NodaTime.Test/TimeZones/DateTimeZoneCacheTest.cs
+++ b/src/NodaTime.Test/TimeZones/DateTimeZoneCacheTest.cs
@@ -76,13 +76,13 @@ namespace NodaTime.Test.TimeZones
         }
 
         [Test]
-        public void SourceIsNotAskedForUtcIfAdvertised()
+        public void SourceIsAskedForUtcIfAdvertised()
         {
             var source = new TestDateTimeZoneSource("Test1", "Test2", "UTC");
             var provider = new DateTimeZoneCache(source);
             var zone = provider[DateTimeZone.UtcId];
             Assert.IsNotNull(zone);
-            Assert.IsNull(source.LastRequestedId);
+            Assert.AreEqual("UTC", source.LastRequestedId);
         }
 
         [Test]
@@ -123,15 +123,14 @@ namespace NodaTime.Test.TimeZones
         }
 
         [Test]
-        public void FixedOffsetSucceedsWithoutConsultingSourceWhenAdvertised()
+        public void FixedOffsetConsultsSourceWhenAdvertised()
         {
             string id = "UTC+05:30";
             var source = new TestDateTimeZoneSource("Test1", "Test2", id);
             var provider = new DateTimeZoneCache(source);
             DateTimeZone zone = provider[id];
-            Assert.AreEqual(DateTimeZone.ForOffset(Offset.FromHoursAndMinutes(5, 30)), zone);
             Assert.AreEqual(id, zone.Id);
-            Assert.IsNull(source.LastRequestedId);
+            Assert.AreEqual(id, source.LastRequestedId);
         }
 
         [Test]
@@ -150,7 +149,7 @@ namespace NodaTime.Test.TimeZones
         public void FixedOffsetZeroReturnsUtc()
         {
             string id = "UTC+00:00";
-            var source = new TestDateTimeZoneSource("Test1", "Test2", id);
+            var source = new TestDateTimeZoneSource("Test1", "Test2");
             var provider = new DateTimeZoneCache(source);
             DateTimeZone zone = provider[id];
             Assert.AreEqual(DateTimeZone.Utc, zone);
@@ -252,7 +251,7 @@ namespace NodaTime.Test.TimeZones
             public DateTimeZone ForId(string id)
             {
                 LastRequestedId = id;
-                return new SingleTransitionDateTimeZone(NodaConstants.UnixEpoch, 0, id.GetHashCode() % 18);
+                return new SingleTransitionDateTimeZone(NodaConstants.UnixEpoch, Offset.Zero, Offset.FromHours(id.GetHashCode() % 18), id);
             }
 
             public string VersionId { get; set; }

--- a/src/NodaTime/IDateTimeZoneProvider.cs
+++ b/src/NodaTime/IDateTimeZoneProvider.cs
@@ -110,8 +110,7 @@ namespace NodaTime
         /// as equal.
         /// </para>
         /// <para>
-        /// The fixed-offset timezones with IDs "UTC" and "UTC+/-Offset" are always available. These must
-        /// return instances that are equal to those returned by <see cref="DateTimeZone.ForOffset"/>.
+        /// The fixed-offset timezones with IDs "UTC" and "UTC+/-Offset" are always available.
         /// </para>
         /// </remarks>
         /// <param name="id">The time zone ID to find.</param>
@@ -137,8 +136,7 @@ namespace NodaTime
         /// as equal.
         /// </para>
         /// <para>
-        /// The fixed-offset timezones with IDs "UTC" and "UTC+/-Offset" are always available. These must
-        /// return instances that are equal to those returned by <see cref="DateTimeZone.ForOffset"/>.
+        /// The fixed-offset timezones with IDs "UTC" and "UTC+/-Offset" are always available.
         /// </para>
         /// </remarks>
         /// <param name="id">The time zone id to find.</param>

--- a/src/NodaTime/TimeZones/DateTimeZoneCache.cs
+++ b/src/NodaTime/TimeZones/DateTimeZoneCache.cs
@@ -92,11 +92,11 @@ namespace NodaTime.TimeZones
         public DateTimeZone GetZoneOrNull([NotNull] string id)
         {
             Preconditions.CheckNotNull(id, nameof(id));
-            DateTimeZone fixedZone = FixedDateTimeZone.GetFixedZoneOrNull(id);
-            if (fixedZone != null)
-            {
-                return fixedZone;
-            }
+            return GetZoneFromSourceOrNull(id) ?? FixedDateTimeZone.GetFixedZoneOrNull(id);
+        }
+
+        private DateTimeZone GetZoneFromSourceOrNull(string id)
+        {
             lock (accessLock)
             {
                 DateTimeZone zone;

--- a/www/unstable/userguide/versions.md
+++ b/www/unstable/userguide/versions.md
@@ -67,6 +67,8 @@ Other:
 - Added a `ReturnForwardShifted` resolver, which shifts values in the daylight saving time "gap" forward by the duration of the gap,
   effectively returning the instant that would have occurred had the gap not existed.  This was added to support the new behavior of
   the "lenient" resolver (see above), but can also be used separately.
+- When an `IDateTimeZoneSource` advertises a zone with an ID corresponding to a fixed-offset
+  zone, `DateTimeZoneCache` now consults the source first. This fixes ([issue 332][]).
 
 ## 1.3.2, released 2016-04-14 with tzdb 2016c
 


### PR DESCRIPTION
The source is only consulted for IDs it advertises, but that includes ones that are fixed, e.g. "UTC-2".

Fixes #332.