### PR TITLE
Document guarantees around DateTimeZone.Utc equality.

### DIFF
--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -97,10 +97,13 @@ namespace NodaTime
         internal const string UtcId = "UTC";
 
         /// <summary>
-        /// Gets the UTC (Coordinated Universal Time) time zone. This is a single instance which is not
-        /// provider-specific; it is guaranteed to have the ID "UTC", but may or may not be the instance returned by
-        /// e.g. <c>DateTimeZoneProviders.Tzdb["UTC"]</c>.
+        /// Gets the UTC (Coordinated Universal Time) time zone.
         /// </summary>
+        /// <remarks>
+        /// This is a single instance which is not provider-specific; it is guaranteed to have the ID "UTC", and to
+        /// compare equal to an instance returned by calling <see cref="ForOffset"/> with an offset of zero, but it may
+        /// or may not compare equal to an instance returned by e.g. <c>DateTimeZoneProviders.Tzdb["UTC"]</c>.
+        /// </remarks>
         /// <value>A UTC <see cref="T:NodaTime.DateTimeZone" />.</value>
         public static DateTimeZone Utc { get; } = new FixedDateTimeZone(Offset.Zero);
         private const int FixedZoneCacheGranularitySeconds = NodaConstants.SecondsPerMinute * 30;


### PR DESCRIPTION
In particular, document that it will be equal to (though not necessarily the same instance as[*]) whatever `DateTimeZone.ForOffset(Offset.Zero)` returns, and clarify that it may not be equal to any zone returned by `IDateTimeZoneProvider["UTC"]` (as after #332 is resolved, it won't be).

Refs #180.

[*] In practice, `DateTimeZone.ForOffset(Offset.Zero)` _will_ be the same instance as `DateTimeZone.Utc` (and we have tests to check that), but it doesn't need to be.