### PR TITLE
Implement additional equality comparers for DateInterval.

### DIFF
--- a/src/NodaTime.Test/DateIntervalTest.cs
+++ b/src/NodaTime.Test/DateIntervalTest.cs
@@ -4,12 +4,15 @@
 using NodaTime.Text;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace NodaTime.Test
 {
     public class DateIntervalTest
     {
         private static readonly CalendarSystem JulianCalendar = CalendarSystem.Julian;
+        private static readonly List<CalendarSystem> SupportedCalendars = CalendarSystem.Ids.ToList().Select(CalendarSystem.ForId).ToList();
 
         [Test]
         public void Construction_DifferentCalendars()
@@ -77,7 +80,6 @@ namespace NodaTime.Test
             LocalDate start1 = new LocalDate(2000, 1, 1);
             LocalDate end1 = new LocalDate(2001, 6, 19);
             // This is a really, really similar calendar to ISO, but we do distinguish.
-            // TODO: Should we?
             LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
             LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
             var interval1 = new DateInterval(start1, end1, false);
@@ -166,6 +168,423 @@ namespace NodaTime.Test
             LocalDate end = new LocalDate(2001, 6, 19);
             var interval = new DateInterval(start, end, false);
             Assert.IsFalse(interval.Equals(Instant.FromUnixTimeTicks(0)));
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_EqualValues()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval1 = new DateInterval(start, end, false);
+            var interval2 = new DateInterval(start, end, false);
+            Assert.AreEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_DifferentCalendars()
+        {
+            LocalDate start1 = new LocalDate(2000, 1, 1);
+            LocalDate end1 = new LocalDate(2001, 6, 19);
+            // This is a really, really similar calendar to ISO, but we do distinguish.
+            LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
+            LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
+            var interval1 = new DateInterval(start1, end1, false);
+            var interval2 = new DateInterval(start2, end2, false);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_DifferentStart()
+        {
+            LocalDate start1 = new LocalDate(2000, 1, 1);
+            LocalDate start2 = new LocalDate(2000, 1, 2);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval1 = new DateInterval(start1, end, false);
+            var interval2 = new DateInterval(start2, end, false);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_DifferentEnd()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end1 = new LocalDate(2001, 6, 19);
+            LocalDate end2 = new LocalDate(2001, 6, 20);
+            var interval1 = new DateInterval(start, end1, false);
+            var interval2 = new DateInterval(start, end2, false);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_DifferentInclusivity()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval1 = new DateInterval(start, end, false);
+            var interval2 = new DateInterval(start, end, true);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_SameRangeButNotEquivalent()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end1 = new LocalDate(2001, 6, 19);
+            LocalDate end2 = new LocalDate(2001, 6, 20);
+            var interval1 = new DateInterval(start, end1, true);
+            var interval2 = new DateInterval(start, end2, false);
+            Assert.AreEqual(interval1.Length, interval2.Length);
+            Assert.AreNotEqual(interval1, interval2);
+
+            // This is the key difference between this comparer and standard equality.
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_Extremes_Equal()
+        {
+            LocalDate start = new LocalDate(-9998, 1, 1);
+            LocalDate end1 = new LocalDate(9999, 12, 30);
+            LocalDate end2 = new LocalDate(9999, 12, 31);
+            var interval1 = new DateInterval(start, end1, true);
+            var interval2 = new DateInterval(start, end2, false);
+            Assert.AreEqual(interval1.Length, interval2.Length);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_Extremes_Equal_BothInclusive()
+        {
+            LocalDate start = new LocalDate(-9998, 1, 1);
+            LocalDate end1 = new LocalDate(9999, 12, 31);
+            LocalDate end2 = new LocalDate(9999, 12, 31);
+            var interval1 = new DateInterval(start, end1, true);
+            var interval2 = new DateInterval(start, end2, true);
+            Assert.AreEqual(interval1, interval2);
+
+            // These are equal under the regular equality operation; they should still be equal under this comparer,
+            // even though neither interval can be represented as an exclusive interval.
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+
+        [Test]
+        public void NormalizingEqualityComparer_Extremes_Unequal()
+        {
+            LocalDate start = new LocalDate(-9998, 1, 1);
+            LocalDate end1 = new LocalDate(9999, 12, 31);
+            LocalDate end2 = new LocalDate(9999, 12, 31);
+            var interval1 = new DateInterval(start, end1, true);
+            var interval2 = new DateInterval(start, end2, false);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_Extremes_Unequal_DifferentCalendars()
+        {
+            LocalDate start1 = new LocalDate(2000, 1, 1);
+            LocalDate end1 = new LocalDate(2001, 6, 19);
+            LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
+            LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
+            var interval1 = new DateInterval(start1, end1, true);
+            var interval2 = new DateInterval(start2, end2, true);
+            Assert.AreNotEqual(interval1, interval2);
+
+            // Neither interval above can be represented as an exclusive interval, but they must still compare unequal.
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_EmptyRange()
+        {
+            LocalDate date1 = new LocalDate(2000, 1, 1);
+            LocalDate date2 = new LocalDate(2000, 1, 2);
+            var interval1 = new DateInterval(date1, date1, false);
+            var interval2 = new DateInterval(date2, date2, false);
+            Assert.AreEqual(0, interval2.Length);
+            Assert.AreEqual(0, interval1.Length);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_NullToNonNull()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval = new DateInterval(start, end, false);
+            Assert.IsFalse(DateInterval.NormalizingEqualityComparer.Equals(interval, null));
+            Assert.IsFalse(DateInterval.NormalizingEqualityComparer.Equals(null, interval));
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_NullToNull()
+        {
+            Assert.IsTrue(DateInterval.NormalizingEqualityComparer.Equals(null, null));
+        }
+
+        [Test]
+        public void NormalizingEqualityComparer_DateIntervalToItself()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval = new DateInterval(start, end, false);
+            Assert.IsTrue(DateInterval.NormalizingEqualityComparer.Equals(interval, interval));
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_EqualValues()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval1 = new DateInterval(start, end, false);
+            var interval2 = new DateInterval(start, end, false);
+            Assert.AreEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_DifferentCalendars()
+        {
+            LocalDate start1 = new LocalDate(2000, 1, 1);
+            LocalDate end1 = new LocalDate(2001, 6, 19);
+            // This is a really, really similar calendar to ISO, but we do distinguish.
+            LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
+            LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
+            var interval1 = new DateInterval(start1, end1, false);
+            var interval2 = new DateInterval(start2, end2, false);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_DifferentStart()
+        {
+            LocalDate start1 = new LocalDate(2000, 1, 1);
+            LocalDate start2 = new LocalDate(2000, 1, 2);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval1 = new DateInterval(start1, end, false);
+            var interval2 = new DateInterval(start2, end, false);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_DifferentEnd()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end1 = new LocalDate(2001, 6, 19);
+            LocalDate end2 = new LocalDate(2001, 6, 20);
+            var interval1 = new DateInterval(start, end1, false);
+            var interval2 = new DateInterval(start, end2, false);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_DifferentInclusivity()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval1 = new DateInterval(start, end, false);
+            var interval2 = new DateInterval(start, end, true);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_SameRangeButNotEquivalent()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end1 = new LocalDate(2001, 6, 19);
+            LocalDate end2 = new LocalDate(2001, 6, 20);
+            var interval1 = new DateInterval(start, end1, true);
+            var interval2 = new DateInterval(start, end2, false);
+            Assert.AreEqual(interval1.Length, interval2.Length);
+            Assert.AreNotEqual(interval1, interval2);
+
+            // The same range with different inclusivity is equal, like NormalizingEqualityComparer.
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_Extremes_Equal()
+        {
+            LocalDate start = new LocalDate(-9998, 1, 1);
+            LocalDate end1 = new LocalDate(9999, 12, 30);
+            LocalDate end2 = new LocalDate(9999, 12, 31);
+            var interval1 = new DateInterval(start, end1, true);
+            var interval2 = new DateInterval(start, end2, false);
+            Assert.AreEqual(interval1.Length, interval2.Length);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_Extremes_Equal_BothInclusive()
+        {
+            LocalDate start = new LocalDate(-9998, 1, 1);
+            LocalDate end1 = new LocalDate(9999, 12, 31);
+            LocalDate end2 = new LocalDate(9999, 12, 31);
+            var interval1 = new DateInterval(start, end1, true);
+            var interval2 = new DateInterval(start, end2, true);
+            Assert.AreEqual(interval1, interval2);
+
+            // These are equal under the regular equality operation; they should still be equal under this comparer,
+            // even though neither interval can be represented as an exclusive interval.
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_Extremes_Unequal()
+        {
+            LocalDate start = new LocalDate(-9998, 1, 1);
+            LocalDate end1 = new LocalDate(9999, 12, 31);
+            LocalDate end2 = new LocalDate(9999, 12, 31);
+            var interval1 = new DateInterval(start, end1, true);
+            var interval2 = new DateInterval(start, end2, false);
+            Assert.AreNotEqual(interval1, interval2);
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_Extremes_Unequal_DifferentCalendars()
+        {
+            LocalDate start1 = new LocalDate(2000, 1, 1);
+            LocalDate end1 = new LocalDate(2001, 6, 19);
+            LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
+            LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
+            var interval1 = new DateInterval(start1, end1, true);
+            var interval2 = new DateInterval(start2, end2, true);
+            Assert.AreNotEqual(interval1, interval2);
+
+            // Neither interval above can be represented as an exclusive interval, but they must still compare unequal.
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SupportedCalendars))]
+        public void ContainedDatesEqualityComparer_EmptyRange(CalendarSystem calendar)
+        {
+            int year = (calendar.MaxYear + calendar.MinYear) / 2;
+            LocalDate date1 = new LocalDate(year, 2, 1, calendar);
+            LocalDate date2 = new LocalDate(year, 2, 2, calendar);
+            var interval1 = new DateInterval(date1, date1, false);
+            var interval2 = new DateInterval(date2, date2, false);
+            Assert.AreEqual(0, interval2.Length);
+            Assert.AreEqual(0, interval1.Length);
+            Assert.AreNotEqual(interval1, interval2);
+
+            // This is the key difference between this comparer and the normalizing comparer.
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_EmptyRange_DifferentCalendars()
+        {
+            LocalDate date1 = new LocalDate(2000, 2, 1);
+            LocalDate date2 = new LocalDate(2000, 2, 2, CalendarSystem.Gregorian);
+            var interval1 = new DateInterval(date1, date1, false);
+            var interval2 = new DateInterval(date2, date2, false);
+            Assert.AreEqual(0, interval2.Length);
+            Assert.AreEqual(0, interval1.Length);
+            Assert.AreNotEqual(interval1, interval2);
+
+            // Different calendar systems are still unequal, even if they're both empty.
+            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_NullToNonNull()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval = new DateInterval(start, end, false);
+            Assert.IsFalse(DateInterval.ContainedDatesEqualityComparer.Equals(interval, null));
+            Assert.IsFalse(DateInterval.ContainedDatesEqualityComparer.Equals(null, interval));
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_NullToNull()
+        {
+            Assert.IsTrue(DateInterval.ContainedDatesEqualityComparer.Equals(null, null));
+        }
+
+        [Test]
+        public void ContainedDatesEqualityComparer_DateIntervalToItself()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval = new DateInterval(start, end, false);
+            Assert.IsTrue(DateInterval.ContainedDatesEqualityComparer.Equals(interval, interval));
         }
 
         [Test]

--- a/src/NodaTime.Test/DateIntervalTest.cs
+++ b/src/NodaTime.Test/DateIntervalTest.cs
@@ -63,17 +63,51 @@ namespace NodaTime.Test
         }
 
         [Test]
+        public void Equals_SameInstance()
+        {
+            LocalDate start = new LocalDate(2000, 1, 1);
+            LocalDate end = new LocalDate(2001, 6, 19);
+            var interval = new DateInterval(start, end, false);
+
+            Assert.AreEqual(interval, interval);
+            Assert.AreEqual(interval.GetHashCode(), interval.GetHashCode());
+            // CS1718: Comparison made to same variable.  This is intentional to test operator ==.
+#pragma warning disable 1718
+            Assert.IsTrue(interval == interval);
+            Assert.IsFalse(interval != interval);
+#pragma warning restore 1718
+            Assert.IsTrue(interval.Equals(interval)); // IEquatable implementation
+
+            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval, interval));
+            Assert.AreEqual(comparer.GetHashCode(interval), comparer.GetHashCode(interval));
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval, interval));
+            Assert.AreEqual(comparer.GetHashCode(interval), comparer.GetHashCode(interval));
+        }
+
+        [Test]
         public void Equals_EqualValues()
         {
             LocalDate start = new LocalDate(2000, 1, 1);
             LocalDate end = new LocalDate(2001, 6, 19);
             var interval1 = new DateInterval(start, end, false);
             var interval2 = new DateInterval(start, end, false);
+
             Assert.AreEqual(interval1, interval2);
             Assert.AreEqual(interval1.GetHashCode(), interval2.GetHashCode());
             Assert.IsTrue(interval1 == interval2);
             Assert.IsFalse(interval1 != interval2);
             Assert.IsTrue(interval1.Equals(interval2)); // IEquatable implementation
+
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
         }
 
         [Test]
@@ -86,11 +120,20 @@ namespace NodaTime.Test
             LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
             var interval1 = new DateInterval(start1, end1, false);
             var interval2 = new DateInterval(start2, end2, false);
+
             Assert.AreNotEqual(interval1, interval2);
             Assert.AreNotEqual(interval1.GetHashCode(), interval2.GetHashCode());
             Assert.IsFalse(interval1 == interval2);
             Assert.IsTrue(interval1 != interval2);
             Assert.IsFalse(interval1.Equals(interval2)); // IEquatable implementation
+
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
         }
 
         [Test]
@@ -101,11 +144,20 @@ namespace NodaTime.Test
             LocalDate end = new LocalDate(2001, 6, 19);
             var interval1 = new DateInterval(start1, end, false);
             var interval2 = new DateInterval(start2, end, false);
+
             Assert.AreNotEqual(interval1, interval2);
             Assert.AreNotEqual(interval1.GetHashCode(), interval2.GetHashCode());
             Assert.IsFalse(interval1 == interval2);
             Assert.IsTrue(interval1 != interval2);
             Assert.IsFalse(interval1.Equals(interval2)); // IEquatable implementation
+
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
         }
 
         [Test]
@@ -116,11 +168,20 @@ namespace NodaTime.Test
             LocalDate end2 = new LocalDate(2001, 6, 20);
             var interval1 = new DateInterval(start, end1, false);
             var interval2 = new DateInterval(start, end2, false);
+
             Assert.AreNotEqual(interval1, interval2);
             Assert.AreNotEqual(interval1.GetHashCode(), interval2.GetHashCode());
             Assert.IsFalse(interval1 == interval2);
             Assert.IsTrue(interval1 != interval2);
             Assert.IsFalse(interval1.Equals(interval2)); // IEquatable implementation
+
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
         }
 
         [Test]
@@ -130,11 +191,20 @@ namespace NodaTime.Test
             LocalDate end = new LocalDate(2001, 6, 19);
             var interval1 = new DateInterval(start, end, false);
             var interval2 = new DateInterval(start, end, true);
+
             Assert.AreNotEqual(interval1, interval2);
             Assert.AreNotEqual(interval1.GetHashCode(), interval2.GetHashCode());
             Assert.IsFalse(interval1 == interval2);
             Assert.IsTrue(interval1 != interval2);
             Assert.IsFalse(interval1.Equals(interval2)); // IEquatable implementation
+
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
         }
 
         [Test]
@@ -152,6 +222,160 @@ namespace NodaTime.Test
             Assert.IsFalse(interval1 == interval2);
             Assert.IsTrue(interval1 != interval2);
             Assert.IsFalse(interval1.Equals(interval2)); // IEquatable implementation
+
+            // This is the key difference between this comparer and standard equality.
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+
+            // The same range with different inclusivity is equal, like NormalizingEqualityComparer.
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void Equals_SameRangeButNotEquivalent_Extremes_Equal()
+        {
+            // As above, but for an extreme range.
+            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate.PlusDays(-1), true);
+            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, false);
+
+            Assert.AreEqual(interval1.Length, interval2.Length);
+            Assert.AreNotEqual(interval1, interval2);
+
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void Equals_Extremes_Equal_BothInclusive()
+        {
+            // An extreme range where both intervals are inclusive.
+            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
+            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, true);
+
+            Assert.AreEqual(interval1, interval2);
+
+            // These are equal under the regular equality operation; they should still be equal under this comparer,
+            // even though neither interval can be represented as an exclusive interval.
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void Equals_Extremes_Unequal()
+        {
+            // Two extreme ranges, where one interval is inclusive.
+            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
+            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, false);
+
+            Assert.AreNotEqual(interval1, interval2);
+
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void Equals_Extremes_Unequal_DifferentCalendars()
+        {
+            // Two extreme ranges with different calendars but the 'same' dates are still unequal.
+            LocalDate start1 = MinIsoDate;
+            LocalDate end1 = MaxIsoDate;
+            LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
+            LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
+            var interval1 = new DateInterval(start1, end1, true);
+            var interval2 = new DateInterval(start2, end2, true);
+
+            Assert.AreNotEqual(interval1, interval2);
+
+            // Neither interval above can be represented as an exclusive interval, but they must still compare unequal.
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+        }
+
+        [Test]
+        public void Equals_EmptyRange()
+        {
+            LocalDate date1 = new LocalDate(2000, 1, 1);
+            LocalDate date2 = new LocalDate(2000, 1, 2);
+            var interval1 = new DateInterval(date1, date1, false);
+            var interval2 = new DateInterval(date2, date2, false);
+            Assert.AreEqual(0, interval1.Length);
+            Assert.AreEqual(0, interval2.Length);
+
+            Assert.AreNotEqual(interval1, interval2);
+
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+
+            // This is the key difference between this comparer and the normalizing comparer.
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        [TestCaseSource(nameof(SupportedCalendars))]
+        public void ContainedDatesEqualityComparer_EmptyRange(CalendarSystem calendar)
+        {
+            // Similar to Equals_EmptyRange, but specifically for ContainedDatesEqualityComparer, which must be able to
+            // construct a canonical empty range for every possible calendar.
+            int year = (calendar.MaxYear + calendar.MinYear) / 2;
+            LocalDate date1 = new LocalDate(year, 2, 1, calendar);
+            LocalDate date2 = new LocalDate(year, 2, 2, calendar);
+            var interval1 = new DateInterval(date1, date1, false);
+            var interval2 = new DateInterval(date2, date2, false);
+            Assert.AreEqual(0, interval1.Length);
+            Assert.AreEqual(0, interval2.Length);
+            Assert.AreNotEqual(interval1, interval2);
+
+            var comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsTrue(comparer.Equals(interval1, interval2));
+            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
+        }
+
+        [Test]
+        public void Equals_EmptyRange_DifferentCalendars()
+        {
+            LocalDate date1 = new LocalDate(2000, 2, 1);
+            LocalDate date2 = new LocalDate(2000, 2, 2, CalendarSystem.Gregorian);
+            var interval1 = new DateInterval(date1, date1, false);
+            var interval2 = new DateInterval(date2, date2, false);
+            Assert.AreEqual(0, interval1.Length);
+            Assert.AreEqual(0, interval2.Length);
+
+            Assert.AreNotEqual(interval1, interval2);
+
+            // Different calendar systems are still unequal, even if they're both empty.
+            var comparer = DateInterval.NormalizingEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
+
+            comparer = DateInterval.ContainedDatesEqualityComparer;
+            Assert.IsFalse(comparer.Equals(interval1, interval2));
+            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
         }
 
         [Test]
@@ -160,7 +384,14 @@ namespace NodaTime.Test
             LocalDate start = new LocalDate(2000, 1, 1);
             LocalDate end = new LocalDate(2001, 6, 19);
             var interval = new DateInterval(start, end, false);
+
             Assert.IsFalse(interval.Equals(null));
+
+            Assert.IsFalse(DateInterval.NormalizingEqualityComparer.Equals(interval, null));
+            Assert.IsFalse(DateInterval.NormalizingEqualityComparer.Equals(null, interval));
+
+            Assert.IsFalse(DateInterval.ContainedDatesEqualityComparer.Equals(interval, null));
+            Assert.IsFalse(DateInterval.ContainedDatesEqualityComparer.Equals(null, interval));
         }
 
         [Test]
@@ -173,402 +404,10 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void NormalizingEqualityComparer_EqualValues()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end = new LocalDate(2001, 6, 19);
-            var interval1 = new DateInterval(start, end, false);
-            var interval2 = new DateInterval(start, end, false);
-            Assert.AreEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsTrue(comparer.Equals(interval1, interval2));
-            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_DifferentCalendars()
-        {
-            LocalDate start1 = new LocalDate(2000, 1, 1);
-            LocalDate end1 = new LocalDate(2001, 6, 19);
-            // This is a really, really similar calendar to ISO, but we do distinguish.
-            LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
-            LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
-            var interval1 = new DateInterval(start1, end1, false);
-            var interval2 = new DateInterval(start2, end2, false);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_DifferentStart()
-        {
-            LocalDate start1 = new LocalDate(2000, 1, 1);
-            LocalDate start2 = new LocalDate(2000, 1, 2);
-            LocalDate end = new LocalDate(2001, 6, 19);
-            var interval1 = new DateInterval(start1, end, false);
-            var interval2 = new DateInterval(start2, end, false);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_DifferentEnd()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end1 = new LocalDate(2001, 6, 19);
-            LocalDate end2 = new LocalDate(2001, 6, 20);
-            var interval1 = new DateInterval(start, end1, false);
-            var interval2 = new DateInterval(start, end2, false);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_DifferentInclusivity()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end = new LocalDate(2001, 6, 19);
-            var interval1 = new DateInterval(start, end, false);
-            var interval2 = new DateInterval(start, end, true);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_SameRangeButNotEquivalent()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end1 = new LocalDate(2001, 6, 19);
-            LocalDate end2 = new LocalDate(2001, 6, 20);
-            var interval1 = new DateInterval(start, end1, true);
-            var interval2 = new DateInterval(start, end2, false);
-            Assert.AreEqual(interval1.Length, interval2.Length);
-            Assert.AreNotEqual(interval1, interval2);
-
-            // This is the key difference between this comparer and standard equality.
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsTrue(comparer.Equals(interval1, interval2));
-            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_Extremes_Equal()
-        {
-            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate.PlusDays(-1), true);
-            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, false);
-            Assert.AreEqual(interval1.Length, interval2.Length);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsTrue(comparer.Equals(interval1, interval2));
-            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_Extremes_Equal_BothInclusive()
-        {
-            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
-            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, true);
-            Assert.AreEqual(interval1, interval2);
-
-            // These are equal under the regular equality operation; they should still be equal under this comparer,
-            // even though neither interval can be represented as an exclusive interval.
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsTrue(comparer.Equals(interval1, interval2));
-            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
-        }
-
-
-        [Test]
-        public void NormalizingEqualityComparer_Extremes_Unequal()
-        {
-            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
-            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, false);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_Extremes_Unequal_DifferentCalendars()
-        {
-            LocalDate start1 = MinIsoDate;
-            LocalDate end1 = MaxIsoDate;
-            LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
-            LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
-            var interval1 = new DateInterval(start1, end1, true);
-            var interval2 = new DateInterval(start2, end2, true);
-            Assert.AreNotEqual(interval1, interval2);
-
-            // Neither interval above can be represented as an exclusive interval, but they must still compare unequal.
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_EmptyRange()
-        {
-            LocalDate date1 = new LocalDate(2000, 1, 1);
-            LocalDate date2 = new LocalDate(2000, 1, 2);
-            var interval1 = new DateInterval(date1, date1, false);
-            var interval2 = new DateInterval(date2, date2, false);
-            Assert.AreEqual(0, interval2.Length);
-            Assert.AreEqual(0, interval1.Length);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_NullToNonNull()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end = new LocalDate(2001, 6, 19);
-            var interval = new DateInterval(start, end, false);
-            Assert.IsFalse(DateInterval.NormalizingEqualityComparer.Equals(interval, null));
-            Assert.IsFalse(DateInterval.NormalizingEqualityComparer.Equals(null, interval));
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_NullToNull()
+        public void Equals_NullToNull()
         {
             Assert.IsTrue(DateInterval.NormalizingEqualityComparer.Equals(null, null));
-        }
-
-        [Test]
-        public void NormalizingEqualityComparer_DateIntervalToItself()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end = new LocalDate(2001, 6, 19);
-            var interval = new DateInterval(start, end, false);
-            Assert.IsTrue(DateInterval.NormalizingEqualityComparer.Equals(interval, interval));
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_EqualValues()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end = new LocalDate(2001, 6, 19);
-            var interval1 = new DateInterval(start, end, false);
-            var interval2 = new DateInterval(start, end, false);
-            Assert.AreEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsTrue(comparer.Equals(interval1, interval2));
-            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_DifferentCalendars()
-        {
-            LocalDate start1 = new LocalDate(2000, 1, 1);
-            LocalDate end1 = new LocalDate(2001, 6, 19);
-            // This is a really, really similar calendar to ISO, but we do distinguish.
-            LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
-            LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
-            var interval1 = new DateInterval(start1, end1, false);
-            var interval2 = new DateInterval(start2, end2, false);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_DifferentStart()
-        {
-            LocalDate start1 = new LocalDate(2000, 1, 1);
-            LocalDate start2 = new LocalDate(2000, 1, 2);
-            LocalDate end = new LocalDate(2001, 6, 19);
-            var interval1 = new DateInterval(start1, end, false);
-            var interval2 = new DateInterval(start2, end, false);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_DifferentEnd()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end1 = new LocalDate(2001, 6, 19);
-            LocalDate end2 = new LocalDate(2001, 6, 20);
-            var interval1 = new DateInterval(start, end1, false);
-            var interval2 = new DateInterval(start, end2, false);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_DifferentInclusivity()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end = new LocalDate(2001, 6, 19);
-            var interval1 = new DateInterval(start, end, false);
-            var interval2 = new DateInterval(start, end, true);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_SameRangeButNotEquivalent()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end1 = new LocalDate(2001, 6, 19);
-            LocalDate end2 = new LocalDate(2001, 6, 20);
-            var interval1 = new DateInterval(start, end1, true);
-            var interval2 = new DateInterval(start, end2, false);
-            Assert.AreEqual(interval1.Length, interval2.Length);
-            Assert.AreNotEqual(interval1, interval2);
-
-            // The same range with different inclusivity is equal, like NormalizingEqualityComparer.
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsTrue(comparer.Equals(interval1, interval2));
-            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_Extremes_Equal()
-        {
-            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate.PlusDays(-1), true);
-            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, false);
-            Assert.AreEqual(interval1.Length, interval2.Length);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsTrue(comparer.Equals(interval1, interval2));
-            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_Extremes_Equal_BothInclusive()
-        {
-            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
-            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, true);
-            Assert.AreEqual(interval1, interval2);
-
-            // These are equal under the regular equality operation; they should still be equal under this comparer,
-            // even though neither interval can be represented as an exclusive interval.
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsTrue(comparer.Equals(interval1, interval2));
-            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_Extremes_Unequal()
-        {
-            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
-            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, false);
-            Assert.AreNotEqual(interval1, interval2);
-
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_Extremes_Unequal_DifferentCalendars()
-        {
-            LocalDate start1 = new LocalDate(2000, 1, 1);
-            LocalDate end1 = new LocalDate(2001, 6, 19);
-            LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
-            LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
-            var interval1 = new DateInterval(start1, end1, true);
-            var interval2 = new DateInterval(start2, end2, true);
-            Assert.AreNotEqual(interval1, interval2);
-
-            // Neither interval above can be represented as an exclusive interval, but they must still compare unequal.
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        [TestCaseSource(nameof(SupportedCalendars))]
-        public void ContainedDatesEqualityComparer_EmptyRange(CalendarSystem calendar)
-        {
-            int year = (calendar.MaxYear + calendar.MinYear) / 2;
-            LocalDate date1 = new LocalDate(year, 2, 1, calendar);
-            LocalDate date2 = new LocalDate(year, 2, 2, calendar);
-            var interval1 = new DateInterval(date1, date1, false);
-            var interval2 = new DateInterval(date2, date2, false);
-            Assert.AreEqual(0, interval2.Length);
-            Assert.AreEqual(0, interval1.Length);
-            Assert.AreNotEqual(interval1, interval2);
-
-            // This is the key difference between this comparer and the normalizing comparer.
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsTrue(comparer.Equals(interval1, interval2));
-            Assert.AreEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_EmptyRange_DifferentCalendars()
-        {
-            LocalDate date1 = new LocalDate(2000, 2, 1);
-            LocalDate date2 = new LocalDate(2000, 2, 2, CalendarSystem.Gregorian);
-            var interval1 = new DateInterval(date1, date1, false);
-            var interval2 = new DateInterval(date2, date2, false);
-            Assert.AreEqual(0, interval2.Length);
-            Assert.AreEqual(0, interval1.Length);
-            Assert.AreNotEqual(interval1, interval2);
-
-            // Different calendar systems are still unequal, even if they're both empty.
-            IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;
-            Assert.IsFalse(comparer.Equals(interval1, interval2));
-            Assert.AreNotEqual(comparer.GetHashCode(interval1), comparer.GetHashCode(interval2));  // probably
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_NullToNonNull()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end = new LocalDate(2001, 6, 19);
-            var interval = new DateInterval(start, end, false);
-            Assert.IsFalse(DateInterval.ContainedDatesEqualityComparer.Equals(interval, null));
-            Assert.IsFalse(DateInterval.ContainedDatesEqualityComparer.Equals(null, interval));
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_NullToNull()
-        {
             Assert.IsTrue(DateInterval.ContainedDatesEqualityComparer.Equals(null, null));
-        }
-
-        [Test]
-        public void ContainedDatesEqualityComparer_DateIntervalToItself()
-        {
-            LocalDate start = new LocalDate(2000, 1, 1);
-            LocalDate end = new LocalDate(2001, 6, 19);
-            var interval = new DateInterval(start, end, false);
-            Assert.IsTrue(DateInterval.ContainedDatesEqualityComparer.Equals(interval, interval));
         }
 
         [Test]

--- a/src/NodaTime.Test/DateIntervalTest.cs
+++ b/src/NodaTime.Test/DateIntervalTest.cs
@@ -13,6 +13,8 @@ namespace NodaTime.Test
     {
         private static readonly CalendarSystem JulianCalendar = CalendarSystem.Julian;
         private static readonly List<CalendarSystem> SupportedCalendars = CalendarSystem.Ids.ToList().Select(CalendarSystem.ForId).ToList();
+        private static readonly LocalDate MinIsoDate = new LocalDate(-9998, 1, 1);
+        private static readonly LocalDate MaxIsoDate = new LocalDate(9999, 12, 31);
 
         [Test]
         public void Construction_DifferentCalendars()
@@ -265,11 +267,8 @@ namespace NodaTime.Test
         [Test]
         public void NormalizingEqualityComparer_Extremes_Equal()
         {
-            LocalDate start = new LocalDate(-9998, 1, 1);
-            LocalDate end1 = new LocalDate(9999, 12, 30);
-            LocalDate end2 = new LocalDate(9999, 12, 31);
-            var interval1 = new DateInterval(start, end1, true);
-            var interval2 = new DateInterval(start, end2, false);
+            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate.PlusDays(-1), true);
+            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, false);
             Assert.AreEqual(interval1.Length, interval2.Length);
             Assert.AreNotEqual(interval1, interval2);
 
@@ -281,11 +280,8 @@ namespace NodaTime.Test
         [Test]
         public void NormalizingEqualityComparer_Extremes_Equal_BothInclusive()
         {
-            LocalDate start = new LocalDate(-9998, 1, 1);
-            LocalDate end1 = new LocalDate(9999, 12, 31);
-            LocalDate end2 = new LocalDate(9999, 12, 31);
-            var interval1 = new DateInterval(start, end1, true);
-            var interval2 = new DateInterval(start, end2, true);
+            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
+            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, true);
             Assert.AreEqual(interval1, interval2);
 
             // These are equal under the regular equality operation; they should still be equal under this comparer,
@@ -299,11 +295,8 @@ namespace NodaTime.Test
         [Test]
         public void NormalizingEqualityComparer_Extremes_Unequal()
         {
-            LocalDate start = new LocalDate(-9998, 1, 1);
-            LocalDate end1 = new LocalDate(9999, 12, 31);
-            LocalDate end2 = new LocalDate(9999, 12, 31);
-            var interval1 = new DateInterval(start, end1, true);
-            var interval2 = new DateInterval(start, end2, false);
+            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
+            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, false);
             Assert.AreNotEqual(interval1, interval2);
 
             IEqualityComparer<DateInterval> comparer = DateInterval.NormalizingEqualityComparer;
@@ -314,8 +307,8 @@ namespace NodaTime.Test
         [Test]
         public void NormalizingEqualityComparer_Extremes_Unequal_DifferentCalendars()
         {
-            LocalDate start1 = new LocalDate(-9998, 1, 1);
-            LocalDate end1 = new LocalDate(9999, 12, 31);
+            LocalDate start1 = MinIsoDate;
+            LocalDate end1 = MaxIsoDate;
             LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
             LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
             var interval1 = new DateInterval(start1, end1, true);
@@ -464,11 +457,8 @@ namespace NodaTime.Test
         [Test]
         public void ContainedDatesEqualityComparer_Extremes_Equal()
         {
-            LocalDate start = new LocalDate(-9998, 1, 1);
-            LocalDate end1 = new LocalDate(9999, 12, 30);
-            LocalDate end2 = new LocalDate(9999, 12, 31);
-            var interval1 = new DateInterval(start, end1, true);
-            var interval2 = new DateInterval(start, end2, false);
+            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate.PlusDays(-1), true);
+            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, false);
             Assert.AreEqual(interval1.Length, interval2.Length);
             Assert.AreNotEqual(interval1, interval2);
 
@@ -480,11 +470,8 @@ namespace NodaTime.Test
         [Test]
         public void ContainedDatesEqualityComparer_Extremes_Equal_BothInclusive()
         {
-            LocalDate start = new LocalDate(-9998, 1, 1);
-            LocalDate end1 = new LocalDate(9999, 12, 31);
-            LocalDate end2 = new LocalDate(9999, 12, 31);
-            var interval1 = new DateInterval(start, end1, true);
-            var interval2 = new DateInterval(start, end2, true);
+            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
+            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, true);
             Assert.AreEqual(interval1, interval2);
 
             // These are equal under the regular equality operation; they should still be equal under this comparer,
@@ -497,11 +484,8 @@ namespace NodaTime.Test
         [Test]
         public void ContainedDatesEqualityComparer_Extremes_Unequal()
         {
-            LocalDate start = new LocalDate(-9998, 1, 1);
-            LocalDate end1 = new LocalDate(9999, 12, 31);
-            LocalDate end2 = new LocalDate(9999, 12, 31);
-            var interval1 = new DateInterval(start, end1, true);
-            var interval2 = new DateInterval(start, end2, false);
+            var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
+            var interval2 = new DateInterval(MinIsoDate, MaxIsoDate, false);
             Assert.AreNotEqual(interval1, interval2);
 
             IEqualityComparer<DateInterval> comparer = DateInterval.ContainedDatesEqualityComparer;

--- a/src/NodaTime.Test/DateIntervalTest.cs
+++ b/src/NodaTime.Test/DateIntervalTest.cs
@@ -314,8 +314,8 @@ namespace NodaTime.Test
         [Test]
         public void NormalizingEqualityComparer_Extremes_Unequal_DifferentCalendars()
         {
-            LocalDate start1 = new LocalDate(2000, 1, 1);
-            LocalDate end1 = new LocalDate(2001, 6, 19);
+            LocalDate start1 = new LocalDate(-9998, 1, 1);
+            LocalDate end1 = new LocalDate(9999, 12, 31);
             LocalDate start2 = start1.WithCalendar(CalendarSystem.Gregorian);
             LocalDate end2 = end1.WithCalendar(CalendarSystem.Gregorian);
             var interval1 = new DateInterval(start1, end1, true);

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -276,18 +276,19 @@ namespace NodaTime
 
             /// <summary>
             /// Returns a normalized version of this interval such that intervals that have the same start date and
-            /// length are mapped to values that compare equal, while other intervals are left alone.  This is
-            /// conceptually equivalent to converting the passed-in interval to an equivalent exclusive interval.
+            /// length are mapped to values that compare equal (while remaining unequal to intervals with a different
+            /// start date or length).  This is conceptually equivalent to converting each passed-in interval to an
+            /// equivalent exclusive interval.
             /// </summary>
             /// <remarks>
             /// <para>
             /// This method does not convert the passed-in interval to an exclusive interval.  That would be too easy.
+            /// For example, consider the interval [..., 9999-12-31] (in the ISO calendar).  This is equivalent to [...,
+            /// 10000-01-01), which cannot be represented as a DateInterval.
             /// </para>
             /// <para>
-            /// For example, consider the interval [..., 9999-12-31] (in the ISO calendar).  This is equivalent to [...,
-            /// 10000-01-01), which cannot be represented as a DateInterval.  Instead, this method maps all non-empty
-            /// intervals to inclusive intervals, and retains all empty intervals as empty (and exclusive by definition)
-            /// intervals.
+            /// Instead, this method maps all non-empty intervals to inclusive intervals, and retains all empty
+            /// intervals as empty intervals (which are exclusive by definition, and unequal to any non-empty interval).
             /// </para>
             /// </remarks>
             /// <returns>The normalized interval.</returns>

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -299,7 +299,7 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// Equality comparer that considers the dates containing within intervals.
+        /// Equality comparer that considers the dates contained within intervals.
         /// </summary>
         private sealed class ContainedDatesDateIntervalEqualityComparer : EqualityComparer<DateInterval>
         {

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -285,7 +285,7 @@ namespace NodaTime
             /// </para>
             /// <para>
             /// For example, consider the interval [..., 9999-12-31] (in the ISO calendar).  This is equivalent to [...,
-            /// 10000-12-31), which cannot be represented as a DateInterval.  Instead, this method maps all non-empty
+            /// 10000-01-01), which cannot be represented as a DateInterval.  Instead, this method maps all non-empty
             /// intervals to inclusive intervals, and retains all empty intervals as empty (and exclusive by definition)
             /// intervals.
             /// </para>

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
 using NodaTime.Annotations;
 using NodaTime.Text;
 using NodaTime.Utility;
@@ -32,6 +34,46 @@ namespace NodaTime
     [Immutable]
     public sealed class DateInterval : IEquatable<DateInterval>
     {
+        /// <summary>
+        /// Returns an equality comparer which compares intervals by first normalizing them to exclusive intervals.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This comparer considers date intervals to be equal if they have the same start and end dates when considered
+        /// as exclusive intervals.  Alternatively: this comparer is identical to the built-in equality for
+        /// <c>DateInterval</c>, except that it also considers an exclusive date interval of [2001-01-01, 2001-02-01) as
+        /// equal to an inclusive date interval of [2001-01-01, 2001-01-31].
+        /// </para>
+        /// <para>
+        /// Note that intervals with different start dates are still considered unequal by this comparer (even empty
+        /// intervals that contain no dates), as are intervals containing dates from different calendars.
+        /// </para>
+        /// </remarks>
+        /// <value>An equality comparer which compares intervals by first normalizing them to exclusive
+        /// intervals.</value>
+        /// <seealso cref="ContainedDatesEqualityComparer"/>
+        public static IEqualityComparer<DateInterval> NormalizingEqualityComparer => NormalizingDateIntervalEqualityComparer.Instance;
+
+        /// <summary>
+        /// Returns an equality comparer which compares intervals by comparing the set of dates contained within them.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This comparer considers date intervals to be equal if they would contain the same dates.  Alternatively:
+        /// this comparer is identical to the built-in equality for <c>DateInterval</c>, except that it also considers
+        /// an exclusive date interval of [2001-01-01, 2001-02-01) as equal to an inclusive date interval of
+        /// [2001-01-01, 2001-01-31] and considers all empty intervals — e.g. [2001-01-01, 2001-01-01) or [1900-01-01,
+        /// 1900-01-01) — to be equal to each other (as every empty interval contains the same set of dates).
+        /// </para>
+        /// <para>
+        /// Note that intervals containing dates from different calendars are still considered unequal by this comparer.
+        /// </para>
+        /// </remarks>
+        /// <value>An equality comparer which compares intervals by comparing the set of dates contained within
+        /// them.</value>
+        /// <seealso cref="NormalizingEqualityComparer"/>
+        public static IEqualityComparer<DateInterval> ContainedDatesEqualityComparer => ContainedDatesDateIntervalEqualityComparer.Instance;
+
         /// <summary>
         /// Gets the start date of the interval, which is always included in the interval.
         /// </summary>
@@ -203,6 +245,109 @@ namespace NodaTime
             string end = LocalDatePattern.Iso.Format(End);
             string endType = Inclusive ? "]" : ")";
             return $"[{start}, {end}{endType}";
+        }
+
+        /// <summary>
+        /// Equality comparer that normalizes intervals before comparing them.
+        /// </summary>
+        private sealed class NormalizingDateIntervalEqualityComparer : EqualityComparer<DateInterval>
+        {
+            internal static readonly NormalizingDateIntervalEqualityComparer Instance = new NormalizingDateIntervalEqualityComparer();
+
+            private NormalizingDateIntervalEqualityComparer()
+            {
+            }
+
+            public override bool Equals(DateInterval x, DateInterval y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+                if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+                {
+                    return false;
+                }
+                return Normalize(x) == Normalize(y);
+            }
+
+            public override int GetHashCode([NotNull] DateInterval obj) =>
+                Normalize(Preconditions.CheckNotNull(obj, nameof(obj))).GetHashCode();
+
+            /// <summary>
+            /// Returns a normalized version of this interval such that intervals that have the same start date and
+            /// length are mapped to values that compare equal, while other intervals are left alone.  This is
+            /// conceptually equivalent to converting the passed-in interval to an equivalent exclusive interval.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// This method does not convert the passed-in interval to an exclusive interval.  That would be too easy.
+            /// </para>
+            /// <para>
+            /// For example, consider the interval [..., 9999-12-31] (in the ISO calendar).  This is equivalent to [...,
+            /// 10000-12-31), which cannot be represented as a DateInterval.  Instead, this method maps all non-empty
+            /// intervals to inclusive intervals, and retains all empty intervals as empty (and exclusive by definition)
+            /// intervals.
+            /// </para>
+            /// </remarks>
+            /// <returns>The normalized interval.</returns>
+            [NotNull]
+            internal static DateInterval Normalize([NotNull] DateInterval obj)
+            {
+                return obj.Inclusive || obj.Length == 0 ? obj : new DateInterval(obj.Start, obj.End.PlusDays(-1), true);
+            }
+        }
+
+        /// <summary>
+        /// Equality comparer that considers the dates containing within intervals.
+        /// </summary>
+        private sealed class ContainedDatesDateIntervalEqualityComparer : EqualityComparer<DateInterval>
+        {
+            internal static readonly ContainedDatesDateIntervalEqualityComparer Instance = new ContainedDatesDateIntervalEqualityComparer();
+            private static readonly DateInterval CanonicalIsoEmptyInterval = CreateCanonicalEmptyInterval(CalendarSystem.Iso);
+
+            private ContainedDatesDateIntervalEqualityComparer()
+            {
+            }
+
+            public override bool Equals(DateInterval x, DateInterval y)
+            {
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+                if (ReferenceEquals(x, null) || ReferenceEquals(y, null))
+                {
+                    return false;
+                }
+                return Normalize(x) == Normalize(y);
+            }
+
+            public override int GetHashCode([NotNull] DateInterval obj) =>
+                Normalize(Preconditions.CheckNotNull(obj, nameof(obj))).GetHashCode();
+
+            /// <summary>
+            /// Returns a normalized version of this interval, by converting non-empty exclusive intervals to inclusive
+            /// ones, and canonicalizing empty intervals to the same start date.
+            /// </summary>
+            /// <returns>The normalized interval.</returns>
+            [NotNull]
+            private static DateInterval Normalize([NotNull] DateInterval obj)
+            {
+                if (obj.Length > 0)
+                {
+                    return NormalizingDateIntervalEqualityComparer.Normalize(obj);
+                }
+                var calendar = obj.Start.Calendar;
+                return calendar == CalendarSystem.Iso ? CanonicalIsoEmptyInterval : CreateCanonicalEmptyInterval(calendar);
+            }
+
+            private static DateInterval CreateCanonicalEmptyInterval(CalendarSystem calendar)
+            {
+                // This can use any arbitrary date for the given calendar, so long as it's a valid date.
+                var date = new LocalDate(calendar.MinYear, 1, 1, calendar);
+                return new DateInterval(date, date, false);
+            }
         }
     }
 }


### PR DESCRIPTION
Specifically, add `DateInterval.NormalizingEqualityComparer` and `ContainedDatesEqualityComparer`.

`NormalizingEqualityComparer` additionally considers as equal two intervals that differ only in whether they are closed or half-open (inclusive or exclusive), meaning that [2001-01-01, 2001-01-31] is considered equal to [2001-01-01, 2001-02-01).  However, empty intervals with different start dates are still considered unequal.

(This is documented in terms of normalizing all intervals to exclusive intervals, since that's mathematically simpler; however, in practice we cannot actually represent all inclusive intervals as exclusive, and so we implement this by normalizing in the _other_ direction, then treating empty intervals as a special case.)

`ContainedDatesEqualityComparer` additionally considers all empty intervals (for the same calendar) to be equal, effectively implementing equality on the set of dates contained within the interval.

Fixes #383.