### PR TITLE
Address "tick-oriented" APIs

### DIFF
--- a/docs/userguide/unstable/migration-to-2.md
+++ b/docs/userguide/unstable/migration-to-2.md
@@ -82,6 +82,9 @@ and `ZonedDateTime` are now just called `DayOfWeek`. The previous numeric `DayOf
 have been removed, but in all cases if you were actually calling them, you can just cast the `IsoDayOfWeek`
 to `int` and always get the same result, as all calendar systems use ISO days of the week.
 
+The `LocalTime` constructors accepting tick values (tick-of-second and tick-of-millisecond)
+have been converted to static factory methods (`FromHourMinuteSecondTick` and `FromHourMinuteSecondMillisecondTick`).
+
 Period
 ====
 

--- a/docs/userguide/unstable/migration-to-2.md
+++ b/docs/userguide/unstable/migration-to-2.md
@@ -85,6 +85,11 @@ to `int` and always get the same result, as all calendar systems use ISO days of
 The `LocalTime` constructors accepting tick values (tick-of-second and tick-of-millisecond)
 have been converted to static factory methods (`FromHourMinuteSecondTick` and `FromHourMinuteSecondMillisecondTick`).
 
+The `LocalDateTime` constructors accepting tick values have been removed. To construct a `LocalDateTime`
+value with a value more fine-grained than milliseconds, either construct separate `LocalDate` and `LocalTime`
+values and add them together, or construct a `LocalDateTime` to the nearest second (or millisecond) and use
+`PlusTicks` or `PlusNanoseconds` to construct the final one.
+
 Period
 ====
 

--- a/docs/userguide/unstable/versions.md
+++ b/docs/userguide/unstable/versions.md
@@ -8,6 +8,8 @@ Breaking changes:
 
 See the [Noda Time 1.x to 2.0 migration guide](migration-to-2.md) for full details.
 
+- Changed `LocalTime` constructors accepting tick values (tick-of-second and tick-of-millisecond)
+  to be static factory methods.
 - Renamed all static pattern properties to remove the `Pattern` suffix
 - Renamed the `IsoDayOfWeek` properties in `LocalDate`, `LocalDateTime`, `OffsetDateTime`
   and `ZonedDateTime` to just `DayOfWeek`, and removed the previous numeric `DayOfWeek` properties.

--- a/docs/userguide/unstable/versions.md
+++ b/docs/userguide/unstable/versions.md
@@ -8,6 +8,7 @@ Breaking changes:
 
 See the [Noda Time 1.x to 2.0 migration guide](migration-to-2.md) for full details.
 
+- Removed `LocalDateTime` constructors accepting tick values
 - Changed `LocalTime` constructors accepting tick values (tick-of-second and tick-of-millisecond)
   to be static factory methods.
 - Renamed all static pattern properties to remove the `Pattern` suffix

--- a/src/NodaTime.Benchmarks/NodaTimeTests/JsonNet/FormattingBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/JsonNet/FormattingBenchmarks.cs
@@ -16,7 +16,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests.JsonNet
 
         private static readonly Instant sampleInstant = Instant.FromUtc(2012, 1, 2, 3, 4, 5);
         private static readonly DateTimeZone sampleDateTimeZone = DateTimeZoneProviders.Tzdb["Europe/London"];
-        private static readonly LocalDateTime sampleLocalDateTime = new LocalDateTime(2013, 12, 11, 8, 31, 20, 123, 4567);
+        private static readonly LocalDateTime sampleLocalDateTime = new LocalDateTime(2013, 12, 11, 8, 31, 20).PlusNanoseconds(123456789);
         private static readonly LocalDate sampleLocalDate = sampleLocalDateTime.Date;
         private static readonly LocalTime sampleLocalTime = sampleLocalDateTime.TimeOfDay;
         private static readonly Offset sampleOffset = Offset.FromHoursAndMinutes(5, 30);

--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateTimeBenchmarks.cs
@@ -25,9 +25,6 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public LocalDateTime ConstructionToSecond() => new LocalDateTime(2009, 12, 26, 10, 8, 30);
 
         [Benchmark]
-        public LocalDateTime ConstructionToTick() => new LocalDateTime(2009, 12, 26, 10, 8, 30, 0, 0);
-
-        [Benchmark]
         public LocalDateTime FromDateTime() => LocalDateTime.FromDateTime(SampleDateTime);
 
         [Benchmark]

--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalTimeBenchmarks.cs
@@ -8,7 +8,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
 {
     public class LocalTimeBenchmarks
     {
-        private static readonly LocalTime Sample = new LocalTime(10, 8, 30, 300, 1234);
+        private static readonly LocalTime Sample = LocalTime.FromHourMinuteSecondMillisecondTick(10, 8, 30, 300, 1234);
         private static readonly Period SamplePeriod = new PeriodBuilder { Hours = 10, Minutes = 4, Seconds = 5, Milliseconds = 20, Ticks = 30 }.Build();
         private static readonly LocalDateTime LocalDateTime = new LocalDateTime(2011, 9, 14, 15, 10, 25);
 
@@ -22,7 +22,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public LocalTime ConstructionToMillisecond() => new LocalTime(15, 10, 25, 500);
 
         [Benchmark]
-        public LocalTime ConstructionToTick() => new LocalTime(15, 10, 25, 500, 1234);
+        public LocalTime ConstructionToTick() => LocalTime.FromHourMinuteSecondMillisecondTick(15, 10, 25, 500, 1234);
 
         [Benchmark]
         public LocalTime ConversionFromLocalDateTime() => LocalDateTime.TimeOfDay;

--- a/src/NodaTime.Serialization.Test/JsonNet/NodaConvertersTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/NodaConvertersTest.cs
@@ -90,7 +90,7 @@ namespace NodaTime.Serialization.Test.JsonNet
         [Test]
         public void LocalTimeConverter()
         {
-            var value = new LocalTime(1, 2, 3, 4, 5).PlusNanoseconds(67);
+            var value = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5).PlusNanoseconds(67);
             var json = "\"01:02:03.004000567\"";
             AssertConversions(value, json, NodaConverters.LocalTimeConverter);
         }

--- a/src/NodaTime.Serialization.Test/JsonNet/NodaConvertersTest.cs
+++ b/src/NodaTime.Serialization.Test/JsonNet/NodaConvertersTest.cs
@@ -62,8 +62,8 @@ namespace NodaTime.Serialization.Test.JsonNet
         [Test]
         public void LocalDateTimeConverter()
         {
-            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5, 6, 7, CalendarSystem.Iso).PlusNanoseconds(89);
-            var json = "\"2012-01-02T03:04:05.006000789\"";
+            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5, CalendarSystem.Iso).PlusNanoseconds(123456789);
+            var json = "\"2012-01-02T03:04:05.123456789\"";
             AssertConversions(value, json, NodaConverters.LocalDateTimeConverter);
         }
 
@@ -140,8 +140,8 @@ namespace NodaTime.Serialization.Test.JsonNet
         [Test]
         public void OffsetDateTimeConverter()
         {
-            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5, 6, 7).PlusNanoseconds(89).WithOffset(Offset.FromHoursAndMinutes(-1, -30));
-            string json = "\"2012-01-02T03:04:05.006000789-01:30\"";
+            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5).PlusNanoseconds(123456789).WithOffset(Offset.FromHoursAndMinutes(-1, -30));
+            string json = "\"2012-01-02T03:04:05.123456789-01:30\"";
             AssertConversions(value, json, NodaConverters.OffsetDateTimeConverter);
         }
 
@@ -150,8 +150,8 @@ namespace NodaTime.Serialization.Test.JsonNet
         {
             // Redundantly specify the minutes, so that Javascript can parse it and it's RFC3339-compliant.
             // See issue 284 for details.
-            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5, 6, 7).PlusNanoseconds(89).WithOffset(Offset.FromHours(5));
-            string json = "\"2012-01-02T03:04:05.006000789+05:00\"";
+            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5).PlusNanoseconds(123456789).WithOffset(Offset.FromHours(5));
+            string json = "\"2012-01-02T03:04:05.123456789+05:00\"";
             AssertConversions(value, json, NodaConverters.OffsetDateTimeConverter);
         }
 
@@ -160,8 +160,8 @@ namespace NodaTime.Serialization.Test.JsonNet
         {
             // Redundantly specify the minutes, so that Javascript can parse it and it's RFC3339-compliant.
             // See issue 284 for details.
-            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5, 6, 7).PlusNanoseconds(89).WithOffset(Offset.Zero);
-            string json = "\"2012-01-02T03:04:05.006000789Z\"";
+            var value = new LocalDateTime(2012, 1, 2, 3, 4, 5).PlusNanoseconds(123456789).WithOffset(Offset.Zero);
+            string json = "\"2012-01-02T03:04:05.123456789Z\"";
             AssertConversions(value, json, NodaConverters.OffsetDateTimeConverter);
         }
 

--- a/src/NodaTime.Test/Calendars/IsoCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/IsoCalendarSystemTest.cs
@@ -70,7 +70,7 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void ConstructLocalInstant_WithAllFields()
         {
-            LocalInstant localAchievement = new LocalDateTime(2009, 11, 27, 18, 38, 25, 345, 8765).ToLocalInstant();
+            LocalInstant localAchievement = new LocalDateTime(2009, 11, 27, 18, 38, 25, 345).PlusTicks(8765).ToLocalInstant();
             long bclTicks = (TimeOfGreatAchievement - UnixEpochDateTime).Ticks;
             int bclDays = (int) (bclTicks / NodaConstants.TicksPerDay);
             long bclTickOfDay = bclTicks % NodaConstants.TicksPerDay;

--- a/src/NodaTime.Test/InstantTest.Operators.cs
+++ b/src/NodaTime.Test/InstantTest.Operators.cs
@@ -43,6 +43,13 @@ namespace NodaTime.Test
         }
 
         [Test]
+        public void PlusNanoseconds()
+        {
+            Instant instant = Instant.FromUnixTimeTicks(5);
+            Assert.AreEqual(Instant.FromUnixTimeTicks(8), instant.PlusNanoseconds(300));
+        }
+
+        [Test]
         public void OperatorPlusDuration_Zero_IsNeutralElement()
         {
             Assert.AreEqual(NodaConstants.UnixEpoch, NodaConstants.UnixEpoch + Duration.Zero, "UnixEpoch + Duration.Zero");

--- a/src/NodaTime.Test/InstantTest.cs
+++ b/src/NodaTime.Test/InstantTest.cs
@@ -283,8 +283,8 @@ namespace NodaTime.Test
         [Test]
         public void XmlSerialization()
         {
-            var value = new LocalDateTime(2013, 4, 12, 17, 53, 23, 123, 4567).InUtc().ToInstant();
-            TestHelper.AssertXmlRoundtrip(value, "<value>2013-04-12T17:53:23.1234567Z</value>");
+            var value = new LocalDateTime(2013, 4, 12, 17, 53, 23).PlusNanoseconds(123456789).InUtc().ToInstant();
+            TestHelper.AssertXmlRoundtrip(value, "<value>2013-04-12T17:53:23.123456789Z</value>");
         }
 
         [Test]

--- a/src/NodaTime.Test/IntervalTest.cs
+++ b/src/NodaTime.Test/IntervalTest.cs
@@ -95,10 +95,10 @@ namespace NodaTime.Test
         [Test]
         public void ToStringUsesExtendedIsoFormat()
         {
-            var start = new LocalDateTime(2013, 4, 12, 17, 53, 23, 123, 4567).InUtc().ToInstant();
+            var start = new LocalDateTime(2013, 4, 12, 17, 53, 23).PlusNanoseconds(123456789).InUtc().ToInstant();
             var end = new LocalDateTime(2013, 10, 12, 17, 1, 2, 120).InUtc().ToInstant();
             var value = new Interval(start, end);
-            Assert.AreEqual("2013-04-12T17:53:23.1234567Z/2013-10-12T17:01:02.12Z", value.ToString());
+            Assert.AreEqual("2013-04-12T17:53:23.123456789Z/2013-10-12T17:01:02.12Z", value.ToString());
         }
 
         [Test]
@@ -111,10 +111,10 @@ namespace NodaTime.Test
         [Test]
         public void XmlSerialization()
         {
-            var start = new LocalDateTime(2013, 4, 12, 17, 53, 23, 123, 4567).InUtc().ToInstant();
+            var start = new LocalDateTime(2013, 4, 12, 17, 53, 23).PlusNanoseconds(123456789).InUtc().ToInstant();
             var end = new LocalDateTime(2013, 10, 12, 17, 1, 2).InUtc().ToInstant();
             var value = new Interval(start, end);
-            TestHelper.AssertXmlRoundtrip(value, "<value start=\"2013-04-12T17:53:23.1234567Z\" end=\"2013-10-12T17:01:02Z\" />");
+            TestHelper.AssertXmlRoundtrip(value, "<value start=\"2013-04-12T17:53:23.123456789Z\" end=\"2013-10-12T17:01:02Z\" />");
         }
 
         [Test]
@@ -127,20 +127,20 @@ namespace NodaTime.Test
         [Test]
         public void XmlSerialization_ExtraContent()
         {
-            var start = new LocalDateTime(2013, 4, 12, 17, 53, 23, 123, 4567).InUtc().ToInstant();
+            var start = new LocalDateTime(2013, 4, 12, 17, 53, 23).PlusNanoseconds(123456789).InUtc().ToInstant();
             var end = new LocalDateTime(2013, 10, 12, 17, 1, 2).InUtc().ToInstant();
             var value = new Interval(start, end);
             TestHelper.AssertParsableXml(value,
-                "<value start=\"2013-04-12T17:53:23.1234567Z\" end=\"2013-10-12T17:01:02Z\">Text<child attr=\"value\"/>Text 2</value>");
+                "<value start=\"2013-04-12T17:53:23.123456789Z\" end=\"2013-10-12T17:01:02Z\">Text<child attr=\"value\"/>Text 2</value>");
         }
 
         [Test]
         public void XmlSerialization_SwapAttributeOrder()
         {
-            var start = new LocalDateTime(2013, 4, 12, 17, 53, 23, 123, 4567).InUtc().ToInstant();
+            var start = new LocalDateTime(2013, 4, 12, 17, 53, 23).PlusNanoseconds(123456789).InUtc().ToInstant();
             var end = new LocalDateTime(2013, 10, 12, 17, 1, 2).InUtc().ToInstant();
             var value = new Interval(start, end);
-            TestHelper.AssertParsableXml(value, "<value end=\"2013-10-12T17:01:02Z\" start=\"2013-04-12T17:53:23.1234567Z\" />");
+            TestHelper.AssertParsableXml(value, "<value end=\"2013-10-12T17:01:02Z\" start=\"2013-04-12T17:53:23.123456789Z\" />");
         }
 
         [Test]

--- a/src/NodaTime.Test/LocalDateTimeTest.Pseudomutators.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.Pseudomutators.cs
@@ -191,11 +191,12 @@ namespace NodaTime.Test
         [Test]
         public void PlusTicks_Simple()
         {
-            LocalDateTime start = new LocalDateTime(2011, 4, 2, 12, 15, 8, 300, 7500);
-            LocalDateTime expectedForward = new LocalDateTime(2011, 4, 2, 12, 15, 8, 301, 1500);
-            LocalDateTime expectedBackward = new LocalDateTime(2011, 4, 2, 12, 15, 8, 300, 3500);
-            Assert.AreEqual(expectedForward, start.PlusTicks(4000));
-            Assert.AreEqual(expectedBackward, start.PlusTicks(-4000));
+            LocalDate date = new LocalDate(2011, 4, 2);
+            LocalTime startTime = LocalTime.FromHourMinuteSecondMillisecondTick(12, 15, 8, 300, 7500);
+            LocalTime expectedForwardTime = LocalTime.FromHourMinuteSecondMillisecondTick(12, 15, 8, 301, 1500);
+            LocalTime expectedBackwardTime = LocalTime.FromHourMinuteSecondMillisecondTick(12, 15, 8, 300, 3500);
+            Assert.AreEqual(date + expectedForwardTime, (date + startTime).PlusTicks(4000));
+            Assert.AreEqual(date + expectedBackwardTime, (date + startTime).PlusTicks(-4000));
         }
 
         [Test]
@@ -213,11 +214,12 @@ namespace NodaTime.Test
         public void PlusNanoseconds_Simple()
         {
             // Just use the ticks values
-            LocalDateTime start = new LocalDateTime(2011, 4, 2, 12, 15, 8, 300, 7500);
-            LocalDateTime expectedForward = new LocalDateTime(2011, 4, 2, 12, 15, 8, 300, 7540);
-            LocalDateTime expectedBackward = new LocalDateTime(2011, 4, 2, 12, 15, 8, 300, 7460);
-            Assert.AreEqual(expectedForward, start.PlusNanoseconds(4000));
-            Assert.AreEqual(expectedBackward, start.PlusNanoseconds(-4000));
+            LocalDate date = new LocalDate(2011, 4, 2);
+            LocalTime startTime = LocalTime.FromHourMinuteSecondMillisecondTick(12, 15, 8, 300, 7500);
+            LocalTime expectedForwardTime = LocalTime.FromHourMinuteSecondMillisecondTick(12, 15, 8, 300, 7540);
+            LocalTime expectedBackwardTime = LocalTime.FromHourMinuteSecondMillisecondTick(12, 15, 8, 300, 7460);
+            Assert.AreEqual(date + expectedForwardTime, (date + startTime).PlusNanoseconds(4000));
+            Assert.AreEqual(date + expectedBackwardTime, (date + startTime).PlusNanoseconds(-4000));
         }
 
         [Test]
@@ -235,10 +237,10 @@ namespace NodaTime.Test
         {
             LocalDateTime start = new LocalDateTime(2011, 4, 2, 12, 15, 8);
             var period = new PeriodBuilder { Years = 1, Months = 2, Weeks = 3, Days = 4, Hours = 5, Minutes = 6,
-                                             Seconds = 7, Milliseconds = 8, Ticks = 9 }.Build();
+                                             Seconds = 7, Milliseconds = 8, Ticks = 9, Nanoseconds = 11 }.Build();
             var actual = start.Plus(period);
-            var expected = new LocalDateTime(2012, 6, 27, 17, 21, 15, 8, 9);
-            Assert.AreEqual(expected, actual);
+            var expected = new LocalDateTime(2012, 6, 27, 17, 21, 15).PlusNanoseconds(8000911);
+            Assert.AreEqual(expected, actual, $"{expected:yyyy-MM-dd HH:mm:ss.fffffffff} != {actual:yyyy-MM-dd HH:mm:ss.fffffffff}");
         }
 
         // Each test case gives a day-of-month in November 2011 and a target "next day of week";
@@ -256,7 +258,7 @@ namespace NodaTime.Test
         [TestCase(13, IsoDayOfWeek.Friday, ExpectedResult = 18)]
         public int Next(int dayOfMonth, IsoDayOfWeek targetDayOfWeek)
         {
-            LocalDateTime start = new LocalDateTime(2011, 11, dayOfMonth, 15, 25, 30, 100, 5000);
+            LocalDateTime start = new LocalDateTime(2011, 11, dayOfMonth, 15, 25, 30).PlusNanoseconds(123456789);
             LocalDateTime target = start.Next(targetDayOfWeek);
             Assert.AreEqual(2011, target.Year);
             Assert.AreEqual(11, target.Month);
@@ -269,7 +271,7 @@ namespace NodaTime.Test
         [TestCase(8)]
         public void Next_InvalidArgument(IsoDayOfWeek targetDayOfWeek)
         {
-            LocalDateTime start = new LocalDateTime(2011, 1, 1, 15, 25, 30, 100, 5000);
+            LocalDateTime start = new LocalDateTime(2011, 1, 1, 15, 25, 30).PlusNanoseconds(123456789);
             Assert.Throws<ArgumentOutOfRangeException>(() => start.Next(targetDayOfWeek));
         }
 
@@ -287,7 +289,7 @@ namespace NodaTime.Test
         [TestCase(13, IsoDayOfWeek.Friday, ExpectedResult = 11)]
         public int Previous(int dayOfMonth, IsoDayOfWeek targetDayOfWeek)
         {
-            LocalDateTime start = new LocalDateTime(2011, 11, dayOfMonth, 15, 25, 30, 100, 5000);
+            LocalDateTime start = new LocalDateTime(2011, 11, dayOfMonth, 15, 25, 30).PlusNanoseconds(123456789);
             LocalDateTime target = start.Previous(targetDayOfWeek);
             Assert.AreEqual(2011, target.Year);
             Assert.AreEqual(11, target.Month);
@@ -299,7 +301,7 @@ namespace NodaTime.Test
         [TestCase(8)]
         public void Previous_InvalidArgument(IsoDayOfWeek targetDayOfWeek)
         {
-            LocalDateTime start = new LocalDateTime(2011, 1, 1, 15, 25, 30, 100, 5000);
+            LocalDateTime start = new LocalDateTime(2011, 1, 1, 15, 25, 30).PlusNanoseconds(123456789);
             Assert.Throws<ArgumentOutOfRangeException>(() => start.Previous(targetDayOfWeek));
         }
 
@@ -308,7 +310,7 @@ namespace NodaTime.Test
         [Test]
         public void Operator_MethodEquivalents()
         {
-            LocalDateTime start = new LocalDateTime(2011, 1, 1, 15, 25, 30, 100, 5000);
+            LocalDateTime start = new LocalDateTime(2011, 1, 1, 15, 25, 30).PlusNanoseconds(123456789);
             Period period = Period.FromHours(1) + Period.FromDays(1);
             LocalDateTime end = start + period;
             Assert.AreEqual(start + period, LocalDateTime.Add(start, period));
@@ -323,7 +325,7 @@ namespace NodaTime.Test
         [Test]
         public void With_TimeAdjuster()
         {
-            LocalDateTime start = new LocalDateTime(2014, 6, 27, 12, 15, 8, 100, 1234);
+            LocalDateTime start = new LocalDateTime(2014, 6, 27, 12, 15, 8).PlusNanoseconds(123456789);
             LocalDateTime expected = new LocalDateTime(2014, 6, 27, 12, 15, 8);
             Assert.AreEqual(expected, start.With(TimeAdjusters.TruncateToSecond));
         }
@@ -331,8 +333,8 @@ namespace NodaTime.Test
         [Test]
         public void With_DateAdjuster()
         {
-            LocalDateTime start = new LocalDateTime(2014, 6, 27, 12, 5, 8, 100, 1234);
-            LocalDateTime expected = new LocalDateTime(2014, 6, 30, 12, 5, 8, 100, 1234);
+            LocalDateTime start = new LocalDateTime(2014, 6, 27, 12, 5, 8).PlusNanoseconds(123456789);
+            LocalDateTime expected = new LocalDateTime(2014, 6, 30, 12, 5, 8).PlusNanoseconds(123456789);
             Assert.AreEqual(expected, start.With(DateAdjusters.EndOfMonth));
         }
 

--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -61,34 +61,44 @@ namespace NodaTime.Test
         public void TimeProperties_AfterEpoch()
         {
             // Use the largest valid year as part of validating against overflow
-            LocalDateTime ldt = new LocalDateTime(GregorianYearMonthDayCalculator.MaxGregorianYear, 1, 2, 15, 48, 25, 456, 3456);
+            LocalDateTime ldt = new LocalDateTime(GregorianYearMonthDayCalculator.MaxGregorianYear, 1, 2, 15, 48, 25).PlusNanoseconds(123456789);
             Assert.AreEqual(15, ldt.Hour);
             Assert.AreEqual(3, ldt.ClockHourOfHalfDay);
             Assert.AreEqual(48, ldt.Minute);
             Assert.AreEqual(25, ldt.Second);
-            Assert.AreEqual(456, ldt.Millisecond);
-            Assert.AreEqual(4563456, ldt.TickOfSecond);
+            Assert.AreEqual(123, ldt.Millisecond);
+            Assert.AreEqual(1234567, ldt.TickOfSecond);
             Assert.AreEqual(15 * NodaConstants.TicksPerHour + 
                             48 * NodaConstants.TicksPerMinute +
                             25 * NodaConstants.TicksPerSecond +
-                            4563456, ldt.TickOfDay);
+                            1234567, ldt.TickOfDay);
+            Assert.AreEqual(15 * NodaConstants.NanosecondsPerHour +
+                            48 * NodaConstants.NanosecondsPerMinute +
+                            25 * NodaConstants.NanosecondsPerSecond +
+                            123456789, ldt.NanosecondOfDay);
+            Assert.AreEqual(123456789, ldt.NanosecondOfSecond);
         }
 
         [Test]
         public void TimeProperties_BeforeEpoch()
         {
             // Use the smallest valid year number as part of validating against overflow
-            LocalDateTime ldt = new LocalDateTime(GregorianYearMonthDayCalculator.MinGregorianYear, 1, 2, 15, 48, 25, 456, 3456);
+            LocalDateTime ldt = new LocalDateTime(GregorianYearMonthDayCalculator.MinGregorianYear, 1, 2, 15, 48, 25).PlusNanoseconds(123456789);
             Assert.AreEqual(15, ldt.Hour);
             Assert.AreEqual(3, ldt.ClockHourOfHalfDay);
             Assert.AreEqual(48, ldt.Minute);
             Assert.AreEqual(25, ldt.Second);
-            Assert.AreEqual(456, ldt.Millisecond);
-            Assert.AreEqual(4563456, ldt.TickOfSecond);
+            Assert.AreEqual(123, ldt.Millisecond);
+            Assert.AreEqual(1234567, ldt.TickOfSecond);
             Assert.AreEqual(15 * NodaConstants.TicksPerHour +
                             48 * NodaConstants.TicksPerMinute +
                             25 * NodaConstants.TicksPerSecond +
-                            4563456, ldt.TickOfDay);
+                            1234567, ldt.TickOfDay);
+            Assert.AreEqual(15 * NodaConstants.NanosecondsPerHour +
+                            48 * NodaConstants.NanosecondsPerMinute +
+                            25 * NodaConstants.NanosecondsPerSecond +
+                            123456789, ldt.NanosecondOfDay);
+            Assert.AreEqual(123456789, ldt.NanosecondOfSecond);
         }
 
         [Test]
@@ -395,15 +405,15 @@ namespace NodaTime.Test
         [Test]
         public void XmlSerialization_Iso()
         {
-            var value = new LocalDateTime(2013, 4, 12, 17, 53, 23, 123, 4567);
-            TestHelper.AssertXmlRoundtrip(value, "<value>2013-04-12T17:53:23.1234567</value>");
+            var value = new LocalDateTime(2013, 4, 12, 17, 53, 23).PlusNanoseconds(123456789);
+            TestHelper.AssertXmlRoundtrip(value, "<value>2013-04-12T17:53:23.123456789</value>");
         }
 
         [Test]
         public void BinarySerialization()
         {
             TestHelper.AssertBinaryRoundtrip(new LocalDateTime(2013, 4, 12, 17, 53, 23, CalendarSystem.Julian));
-            TestHelper.AssertBinaryRoundtrip(new LocalDateTime(2013, 4, 12, 17, 53, 23, 123, 4567));
+            TestHelper.AssertBinaryRoundtrip(new LocalDateTime(2013, 4, 12, 17, 53, 23).PlusNanoseconds(123456789));
         }
 
         [Test]

--- a/src/NodaTime.Test/LocalTimeTest.Pseudomutators.cs
+++ b/src/NodaTime.Test/LocalTimeTest.Pseudomutators.cs
@@ -72,9 +72,9 @@ namespace NodaTime.Test
         [Test]
         public void PlusTicks_Simple()
         {
-            LocalTime start = new LocalTime(12, 15, 8, 300, 7500);
-            LocalTime expectedForward = new LocalTime(12, 15, 8, 301, 1500);
-            LocalTime expectedBackward = new LocalTime(12, 15, 8, 300, 3500);
+            LocalTime start = LocalTime.FromHourMinuteSecondMillisecondTick(12, 15, 8, 300, 7500);
+            LocalTime expectedForward = LocalTime.FromHourMinuteSecondMillisecondTick(12, 15, 8, 301, 1500);
+            LocalTime expectedBackward = LocalTime.FromHourMinuteSecondMillisecondTick(12, 15, 8, 300, 3500);
             Assert.AreEqual(expectedForward, start.PlusTicks(4000));
             Assert.AreEqual(expectedBackward, start.PlusTicks(-4000));
         }
@@ -93,7 +93,7 @@ namespace NodaTime.Test
         [Test]
         public void With()
         {
-            LocalTime start = new LocalTime(12, 15, 8, 100, 1234);
+            LocalTime start = LocalTime.FromHourMinuteSecondMillisecondTick(12, 15, 8, 100, 1234);
             LocalTime expected = new LocalTime(12, 15, 8);
             Assert.AreEqual(expected, start.With(TimeAdjusters.TruncateToSecond));
         }

--- a/src/NodaTime.Test/LocalTimeTest.cs
+++ b/src/NodaTime.Test/LocalTimeTest.cs
@@ -45,13 +45,13 @@ namespace NodaTime.Test
         [Test]
         public void BinarySerialization()
         {
-            TestHelper.AssertBinaryRoundtrip(new LocalTime(12, 34, 56, 123, 4567));
+            TestHelper.AssertBinaryRoundtrip(LocalTime.FromHourMinuteSecondMillisecondTick(12, 34, 56, 123, 4567));
         }
 
         [Test]
         public void XmlSerialization()
         {
-            var value = new LocalTime(17, 53, 23, 123, 4567);
+            var value = LocalTime.FromHourMinuteSecondMillisecondTick(17, 53, 23, 123, 4567);
             TestHelper.AssertXmlRoundtrip(value, "<value>17:53:23.1234567</value>");
         }
 

--- a/src/NodaTime.Test/OffsetDateTimeTest.cs
+++ b/src/NodaTime.Test/OffsetDateTimeTest.cs
@@ -20,7 +20,7 @@ namespace NodaTime.Test
         [Test]
         public void LocalDateTimeProperties()
         {
-            LocalDateTime local = new LocalDateTime(2012, 6, 19, 1, 2, 3, 4, 5, CalendarSystem.Julian);
+            LocalDateTime local = new LocalDateTime(2012, 6, 19, 1, 2, 3, CalendarSystem.Julian).PlusNanoseconds(123456789);
             Offset offset = Offset.FromHours(5);
 
             OffsetDateTime odt = new OffsetDateTime(local, offset);
@@ -51,7 +51,7 @@ namespace NodaTime.Test
         [Test]
         public void LocalDateTimeProperty()
         {
-            LocalDateTime local = new LocalDateTime(2012, 6, 19, 1, 2, 3, 4, 5, CalendarSystem.Julian);
+            LocalDateTime local = new LocalDateTime(2012, 6, 19, 1, 2, 3, CalendarSystem.Julian).PlusNanoseconds(123456789);
             Offset offset = Offset.FromHours(5);
 
             OffsetDateTime odt = new OffsetDateTime(local, offset);
@@ -369,7 +369,7 @@ namespace NodaTime.Test
         public void With_TimeAdjuster()
         {
             Offset offset = Offset.FromHoursAndMinutes(2, 30);
-            OffsetDateTime start = new LocalDateTime(2014, 6, 27, 12, 15, 8, 100, 1234).WithOffset(offset);
+            OffsetDateTime start = new LocalDateTime(2014, 6, 27, 12, 15, 8).PlusNanoseconds(123456789).WithOffset(offset);
             OffsetDateTime expected = new LocalDateTime(2014, 6, 27, 12, 15, 8).WithOffset(offset);
             Assert.AreEqual(expected, start.With(TimeAdjusters.TruncateToSecond));
         }
@@ -378,8 +378,8 @@ namespace NodaTime.Test
         public void With_DateAdjuster()
         {
             Offset offset = Offset.FromHoursAndMinutes(2, 30);
-            OffsetDateTime start = new LocalDateTime(2014, 6, 27, 12, 5, 8, 100, 1234).WithOffset(offset);
-            OffsetDateTime expected = new LocalDateTime(2014, 6, 30, 12, 5, 8, 100, 1234).WithOffset(offset);
+            OffsetDateTime start = new LocalDateTime(2014, 6, 27, 12, 5, 8).PlusNanoseconds(123456789).WithOffset(offset);
+            OffsetDateTime expected = new LocalDateTime(2014, 6, 30, 12, 5, 8).PlusNanoseconds(123456789).WithOffset(offset);
             Assert.AreEqual(expected, start.With(DateAdjusters.EndOfMonth));
         }
     }

--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -785,13 +785,13 @@ namespace NodaTime.Test
         public void Between_ExtremeValues(PeriodUnits units)
         {
             // We can't use None, and Ticks/Nanoseconds will *correctly* overflow.
-            if (units == PeriodUnits.None || units == PeriodUnits.Ticks || units== PeriodUnits.Nanoseconds)
+            if (units == PeriodUnits.None || units == PeriodUnits.Ticks || units == PeriodUnits.Nanoseconds)
             {
                 return;
             }
             var iso = CalendarSystem.Iso;
             var minValue = new LocalDateTime(iso.MinYear, 1, 1, 0, 0);
-            var maxValue = new LocalDateTime(iso.MaxYear, 12, 31, 23, 59, 59, 999, (int) (NodaConstants.TicksPerMillisecond - 1));
+            var maxValue = new LocalDateTime(iso.MaxYear, 12, 31, 23, 59, 59).PlusNanoseconds(999999999);
             Period.Between(minValue, maxValue, units);
         }
 

--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -215,7 +215,7 @@ namespace NodaTime.Test
         public void BetweenLocalTimes_InvalidUnits()
         {
             LocalTime t1 = new LocalTime(10, 0);
-            LocalTime t2 = new LocalTime(15, 30, 45, 20, 5);
+            LocalTime t2 = LocalTime.FromHourMinuteSecondMillisecondTick(15, 30, 45, 20, 5);
             Assert.Throws<ArgumentException>(() => Period.Between(t1, t2, 0));
             Assert.Throws<ArgumentException>(() => Period.Between(t1, t2, (PeriodUnits)(-1)));
             Assert.Throws<ArgumentException>(() => Period.Between(t1, t2, PeriodUnits.YearMonthDay));
@@ -226,7 +226,7 @@ namespace NodaTime.Test
         public void BetweenLocalTimes_MovingForwards()
         {
             LocalTime t1 = new LocalTime(10, 0);
-            LocalTime t2 = new LocalTime(15, 30, 45, 20, 5);
+            LocalTime t2 = LocalTime.FromHourMinuteSecondMillisecondTick(15, 30, 45, 20, 5);
             Assert.AreEqual(Period.FromHours(5) + Period.FromMinutes(30) + Period.FromSeconds(45) +
                                Period.FromMilliseconds(20) + Period.FromTicks(5),
                                Period.Between(t1, t2));
@@ -235,7 +235,7 @@ namespace NodaTime.Test
         [Test]
         public void BetweenLocalTimes_MovingBackwards()
         {
-            LocalTime t1 = new LocalTime(15, 30, 45, 20, 5);
+            LocalTime t1 = LocalTime.FromHourMinuteSecondMillisecondTick(15, 30, 45, 20, 5);
             LocalTime t2 = new LocalTime(10, 0);
             Assert.AreEqual(Period.FromHours(-5) + Period.FromMinutes(-30) + Period.FromSeconds(-45) +
                                Period.FromMilliseconds(-20) + Period.FromTicks(-5),

--- a/src/NodaTime.Test/Text/LocalTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalTimePatternTest.cs
@@ -16,7 +16,7 @@ namespace NodaTime.Test.Text
     public partial class LocalTimePatternTest : PatternTestBase<LocalTime>
     {
         private static readonly DateTime SampleDateTime = new DateTime(2000, 1, 1, 21, 13, 34, 123, DateTimeKind.Unspecified).AddTicks(4567);
-        private static readonly LocalTime SampleLocalTime = new LocalTime(21, 13, 34, 123, 4567);
+        private static readonly LocalTime SampleLocalTime = LocalTime.FromHourMinuteSecondMillisecondTick(21, 13, 34, 123, 4567);
 
         // Characters we expect to work the same in Noda Time as in the BCL.
         private const string ExpectedCharacters = "hHms.:fFtT ";
@@ -159,12 +159,12 @@ namespace NodaTime.Test.Text
 
         internal static readonly Data[] TemplateValueData = {
             // Pattern specifies nothing - template value is passed through
-            new Data(new LocalTime(1, 2, 3, 4, 5)) { Culture = Cultures.EnUs, Text = "X", Pattern = "'X'", Template = new LocalTime(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5)) { Culture = Cultures.EnUs, Text = "X", Pattern = "'X'", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
             // Tests for each individual field being propagated
-            new Data(new LocalTime(1, 6, 7, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "mm:ss.FFFFFFF", Template = new LocalTime(1, 2, 3, 4, 5) },
-            new Data(new LocalTime(6, 2, 7, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:ss.FFFFFFF", Template = new LocalTime(1, 2, 3, 4, 5) },
-            new Data(new LocalTime(6, 7, 3, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:mm.FFFFFFF", Template = new LocalTime(1, 2, 3, 4, 5) },
-            new Data(new LocalTime(6, 7, 8, 4, 5)) { Culture = Cultures.EnUs, Text = "06:07:08", Pattern = "HH:mm:ss", Template = new LocalTime(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(1, 6, 7, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "mm:ss.FFFFFFF", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(6, 2, 7, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:ss.FFFFFFF", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(6, 7, 3, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:mm.FFFFFFF", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(6, 7, 8, 4, 5)) { Culture = Cultures.EnUs, Text = "06:07:08", Pattern = "HH:mm:ss", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
 
             // Hours are tricky because of the ways they can be specified
             new Data(new LocalTime(6, 2, 3)) { Culture = Cultures.EnUs, Text = "6", Pattern = "%h", Template = new LocalTime(1, 2, 3) },
@@ -256,13 +256,13 @@ namespace NodaTime.Test.Text
             new Data(12, 0, 0) { Culture = Cultures.EnUs, Text = "PM", Pattern = "tt" },
 
             // Pattern specifies nothing - template value is passed through
-            new Data(new LocalTime(1, 2, 3, 4, 5)) { Culture = Cultures.EnUs, Text = "*", Pattern = "%*", Template = new LocalTime(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5)) { Culture = Cultures.EnUs, Text = "*", Pattern = "%*", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
             // Tests for each individual field being propagated
-            new Data(new LocalTime(1, 6, 7, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "mm:ss.FFFFFFF", Template = new LocalTime(1, 2, 3, 4, 5) },
-            new Data(new LocalTime(6, 2, 7, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:ss.FFFFFFF", Template = new LocalTime(1, 2, 3, 4, 5) },
-            new Data(new LocalTime(6, 7, 3, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:mm.FFFFFFF", Template = new LocalTime(1, 2, 3, 4, 5) },
-            new Data(new LocalTime(6, 7, 3, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:mm.FFFFFFF", Template = new LocalTime(1, 2, 3, 4, 5) },
-            new Data(new LocalTime(6, 7, 8, 4, 5)) { Culture = Cultures.EnUs, Text = "06:07:08", Pattern = "HH:mm:ss", Template = new LocalTime(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(1, 6, 7, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "mm:ss.FFFFFFF", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(6, 2, 7, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:ss.FFFFFFF", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(6, 7, 3, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:mm.FFFFFFF", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(6, 7, 3, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:mm.FFFFFFF", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
+            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(6, 7, 8, 4, 5)) { Culture = Cultures.EnUs, Text = "06:07:08", Pattern = "HH:mm:ss", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
 
             // Hours are tricky because of the ways they can be specified
             new Data(new LocalTime(6, 2, 3)) { Culture = Cultures.EnUs, Text = "6", Pattern = "%h", Template = new LocalTime(1, 2, 3) },
@@ -433,7 +433,7 @@ namespace NodaTime.Test.Text
             }
 
             public Data(int hours, int minutes, int seconds, int milliseconds, int ticksWithinMillisecond)
-                : this(new LocalTime(hours, minutes, seconds, milliseconds, ticksWithinMillisecond))
+                : this(LocalTime.FromHourMinuteSecondMillisecondTick(hours, minutes, seconds, milliseconds, ticksWithinMillisecond))
             {
             }
 

--- a/src/NodaTime.Test/TimeAdjustersTest.cs
+++ b/src/NodaTime.Test/TimeAdjustersTest.cs
@@ -10,7 +10,7 @@ namespace NodaTime.Test
         [Test]
         public void TruncateToSecond()
         {
-            var start = new LocalTime(7, 4, 30, 123, 4567);
+            var start = LocalTime.FromHourMinuteSecondMillisecondTick(7, 4, 30, 123, 4567);
             var end = new LocalTime(7, 4, 30);
             Assert.AreEqual(end, TimeAdjusters.TruncateToSecond(start));
         }
@@ -18,7 +18,7 @@ namespace NodaTime.Test
         [Test]
         public void TruncateToMinute()
         {
-            var start = new LocalTime(7, 4, 30, 123, 4567);
+            var start = LocalTime.FromHourMinuteSecondMillisecondTick(7, 4, 30, 123, 4567);
             var end = new LocalTime(7, 4, 0);
             Assert.AreEqual(end, TimeAdjusters.TruncateToMinute(start));
         }
@@ -26,7 +26,7 @@ namespace NodaTime.Test
         [Test]
         public void TruncateToHour()
         {
-            var start = new LocalTime(7, 4, 30, 123, 4567);
+            var start = LocalTime.FromHourMinuteSecondMillisecondTick(7, 4, 30, 123, 4567);
             var end = new LocalTime(7, 0, 0);
             Assert.AreEqual(end, TimeAdjusters.TruncateToHour(start));
         }

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -30,9 +30,9 @@ namespace NodaTime.Test
         [Test]
         public void SimpleProperties()
         {
-            var value = SampleZone.AtStrictly(new LocalDateTime(2012, 2, 10, 8, 9, 10, 11, 12));
+            var value = SampleZone.AtStrictly(new LocalDateTime(2012, 2, 10, 8, 9, 10).PlusNanoseconds(123456789));
             Assert.AreEqual(new LocalDate(2012, 2, 10), value.Date);
-            Assert.AreEqual(LocalTime.FromHourMinuteSecondMillisecondTick(8, 9, 10, 11, 12), value.TimeOfDay);
+            Assert.AreEqual(LocalTime.FromHourMinuteSecondNanosecond(8, 9, 10, 123456789), value.TimeOfDay);
             Assert.AreEqual(Era.Common, value.Era);
             Assert.AreEqual(2012, value.Year);
             Assert.AreEqual(2012, value.YearOfEra);
@@ -44,14 +44,18 @@ namespace NodaTime.Test
             Assert.AreEqual(8, value.Hour);
             Assert.AreEqual(9, value.Minute);
             Assert.AreEqual(10, value.Second);
-            Assert.AreEqual(11, value.Millisecond);
-            Assert.AreEqual(11 * 10000 + 12, value.TickOfSecond);
+            Assert.AreEqual(123, value.Millisecond);
+            Assert.AreEqual(1234567, value.TickOfSecond);
             Assert.AreEqual(8 * NodaConstants.TicksPerHour +
                             9 * NodaConstants.TicksPerMinute +
                             10 * NodaConstants.TicksPerSecond +
-                            11 * NodaConstants.TicksPerMillisecond +
-                            12,
+                            1234567,
                             value.TickOfDay);
+            Assert.AreEqual(8 * NodaConstants.NanosecondsPerHour +
+                            9 * NodaConstants.NanosecondsPerMinute +
+                            10 * NodaConstants.NanosecondsPerSecond +
+                            123456789,
+                            value.NanosecondOfDay);
         }
 
         [Test]

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -32,7 +32,7 @@ namespace NodaTime.Test
         {
             var value = SampleZone.AtStrictly(new LocalDateTime(2012, 2, 10, 8, 9, 10, 11, 12));
             Assert.AreEqual(new LocalDate(2012, 2, 10), value.Date);
-            Assert.AreEqual(new LocalTime(8, 9, 10, 11, 12), value.TimeOfDay);
+            Assert.AreEqual(LocalTime.FromHourMinuteSecondMillisecondTick(8, 9, 10, 11, 12), value.TimeOfDay);
             Assert.AreEqual(Era.Common, value.Era);
             Assert.AreEqual(2012, value.Year);
             Assert.AreEqual(2012, value.YearOfEra);

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -224,10 +224,19 @@ namespace NodaTime
         /// <summary>
         /// Returns a new value of this instant with the given number of ticks added to it.
         /// </summary>
-        /// <param name="ticksToAdd">The ticks to add to this instant to create the return value.</param>
+        /// <param name="ticks">The ticks to add to this instant to create the return value.</param>
         /// <returns>The result of adding the given number of ticks to this instant.</returns>
         [Pure]
-        public Instant PlusTicks(long ticksToAdd) => FromUntrustedDuration(duration + Duration.FromTicks(ticksToAdd));
+        public Instant PlusTicks(long ticks) => FromUntrustedDuration(duration + Duration.FromTicks(ticks));
+
+        /// <summary>
+        /// Returns a new value of this instant with the given number of nanoseconds added to it.
+        /// </summary>
+        /// <param name="nanoseconds">The nanoseconds to add to this instant to create the return value.</param>
+        /// <returns>The result of adding the given number of ticks to this instant.</returns>
+        [Pure]
+        public Instant PlusNanoseconds(long nanoseconds) => FromUntrustedDuration(duration + Duration.FromNanoseconds(nanoseconds));
+
         #region Operators
         /// <summary>
         /// Implements the operator + (addition) for <see cref="Instant" /> + <see cref="Duration" />.

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -166,50 +166,8 @@ namespace NodaTime
         /// <returns>The resulting date/time.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The parameters do not form a valid date/time.</exception>
         public LocalDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, [NotNull] CalendarSystem calendar)
-            : this(year, month, day, hour, minute, second, millisecond, 0, calendar)
-        {
-        }
-
-        // TODO(2.0): Remove this constructor? It's a pretty odd one at this point.
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LocalDateTime"/> struct.
-        /// </summary>
-        /// <param name="year">The year. This is the "absolute year",
-        /// so a value of 0 means 1 BC, for example.</param>
-        /// <param name="month">The month of year.</param>
-        /// <param name="day">The day of month.</param>
-        /// <param name="hour">The hour.</param>
-        /// <param name="minute">The minute.</param>
-        /// <param name="second">The second.</param>
-        /// <param name="millisecond">The millisecond.</param>
-        /// <param name="tickWithinMillisecond">The tick within millisecond.</param>
-        /// <returns>The resulting date/time.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">The parameters do not form a valid date/time.</exception>
-        public LocalDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int tickWithinMillisecond)
-            : this(new LocalDate(year, month, day),
-                   LocalTime.FromHourMinuteSecondMillisecondTick(hour, minute, second, millisecond, tickWithinMillisecond))
-        {
-        }
-
-        // TODO(2.0): Remove this constructor? It's a pretty odd one at this point.
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LocalDateTime"/> struct.
-        /// </summary>
-        /// <param name="year">The year. This is the "absolute year", so, for
-        /// the ISO calendar, a value of 0 means 1 BC, for example.</param>
-        /// <param name="month">The month of year.</param>
-        /// <param name="day">The day of month.</param>
-        /// <param name="hour">The hour.</param>
-        /// <param name="minute">The minute.</param>
-        /// <param name="second">The second.</param>
-        /// <param name="millisecond">The millisecond.</param>
-        /// <param name="tickWithinMillisecond">The tick within millisecond.</param>
-        /// <param name="calendar">The calendar.</param>
-        /// <returns>The resulting date/time.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">The parameters do not form a valid date/time.</exception>
-        public LocalDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int tickWithinMillisecond, [NotNull] CalendarSystem calendar)
             : this(new LocalDate(year, month, day, calendar),
-                   LocalTime.FromHourMinuteSecondMillisecondTick(hour, minute, second, millisecond, tickWithinMillisecond))
+                   new LocalTime(hour, minute, second, millisecond))
         {
         }
 

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -187,7 +187,7 @@ namespace NodaTime
         /// <exception cref="ArgumentOutOfRangeException">The parameters do not form a valid date/time.</exception>
         public LocalDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int tickWithinMillisecond)
             : this(new LocalDate(year, month, day),
-                   new LocalTime(hour, minute, second, millisecond, tickWithinMillisecond))
+                   LocalTime.FromHourMinuteSecondMillisecondTick(hour, minute, second, millisecond, tickWithinMillisecond))
         {
         }
 
@@ -209,7 +209,7 @@ namespace NodaTime
         /// <exception cref="ArgumentOutOfRangeException">The parameters do not form a valid date/time.</exception>
         public LocalDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int tickWithinMillisecond, [NotNull] CalendarSystem calendar)
             : this(new LocalDate(year, month, day, calendar),
-                   new LocalTime(hour, minute, second, millisecond, tickWithinMillisecond))
+                   LocalTime.FromHourMinuteSecondMillisecondTick(hour, minute, second, millisecond, tickWithinMillisecond))
         {
         }
 

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -138,7 +138,7 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// Creates a local time at the given hour, minute, second, millisecond and tick within millisecond.
+        /// Factory method to create a local time at the given hour, minute, second, millisecond and tick within millisecond.
         /// </summary>
         /// <param name="hour">The hour of day.</param>
         /// <param name="minute">The minute of the hour.</param>
@@ -147,7 +147,7 @@ namespace NodaTime
         /// <param name="tickWithinMillisecond">The tick within the millisecond.</param>
         /// <exception cref="ArgumentOutOfRangeException">The parameters do not form a valid time.</exception>
         /// <returns>The resulting time.</returns>
-        public LocalTime(int hour, int minute, int second, int millisecond, int tickWithinMillisecond)
+        public static LocalTime FromHourMinuteSecondMillisecondTick(int hour, int minute, int second, int millisecond, int tickWithinMillisecond)
         {
             // Avoid the method calls which give a decent exception unless we're actually going to fail.
             if (hour < 0 || hour > HoursPerDay - 1 ||
@@ -162,12 +162,13 @@ namespace NodaTime
                 Preconditions.CheckArgumentRange(nameof(millisecond), millisecond, 0, MillisecondsPerSecond - 1);
                 Preconditions.CheckArgumentRange(nameof(tickWithinMillisecond), tickWithinMillisecond, 0, TicksPerMillisecond - 1);
             }
-            nanoseconds = unchecked(
+            long nanoseconds = unchecked(
                 hour * NanosecondsPerHour +
                 minute * NanosecondsPerMinute +
                 second * NanosecondsPerSecond +
                 millisecond * NanosecondsPerMillisecond +
                 tickWithinMillisecond * NanosecondsPerTick);
+            return new LocalTime(nanoseconds);
         }
 
         /// <summary>

--- a/www/unstable/userguide/migration-to-2.md
+++ b/www/unstable/userguide/migration-to-2.md
@@ -89,6 +89,9 @@ and `ZonedDateTime` are now just called `DayOfWeek`. The previous numeric `DayOf
 have been removed, but in all cases if you were actually calling them, you can just cast the `IsoDayOfWeek`
 to `int` and always get the same result, as all calendar systems use ISO days of the week.
 
+The `LocalTime` constructors accepting tick values (tick-of-second and tick-of-millisecond)
+have been converted to static factory methods (`FromHourMinuteSecondTick` and `FromHourMinuteSecondMillisecondTick`).
+
 Period
 ====
 

--- a/www/unstable/userguide/migration-to-2.md
+++ b/www/unstable/userguide/migration-to-2.md
@@ -92,6 +92,11 @@ to `int` and always get the same result, as all calendar systems use ISO days of
 The `LocalTime` constructors accepting tick values (tick-of-second and tick-of-millisecond)
 have been converted to static factory methods (`FromHourMinuteSecondTick` and `FromHourMinuteSecondMillisecondTick`).
 
+The `LocalDateTime` constructors accepting tick values have been removed. To construct a `LocalDateTime`
+value with a value more fine-grained than milliseconds, either construct separate `LocalDate` and `LocalTime`
+values and add them together, or construct a `LocalDateTime` to the nearest second (or millisecond) and use
+`PlusTicks` or `PlusNanoseconds` to construct the final one.
+
 Period
 ====
 

--- a/www/unstable/userguide/versions.md
+++ b/www/unstable/userguide/versions.md
@@ -15,6 +15,7 @@ Breaking changes:
 
 See the [Noda Time 1.x to 2.0 migration guide](migration-to-2.html) for full details.
 
+- Removed `LocalDateTime` constructors accepting tick values
 - Changed `LocalTime` constructors accepting tick values (tick-of-second and tick-of-millisecond)
   to be static factory methods.
 - Renamed all static pattern properties to remove the `Pattern` suffix

--- a/www/unstable/userguide/versions.md
+++ b/www/unstable/userguide/versions.md
@@ -15,6 +15,8 @@ Breaking changes:
 
 See the [Noda Time 1.x to 2.0 migration guide](migration-to-2.html) for full details.
 
+- Changed `LocalTime` constructors accepting tick values (tick-of-second and tick-of-millisecond)
+  to be static factory methods.
 - Renamed all static pattern properties to remove the `Pattern` suffix
 - Renamed the `IsoDayOfWeek` properties in `LocalDate`, `LocalDateTime`, `OffsetDateTime`
   and `ZonedDateTime` to just `DayOfWeek`, and removed the previous numeric `DayOfWeek` properties.


### PR DESCRIPTION
- Convert LocalTime constructors accepting ticks to factory methods
- Remove LocalDateTime constructors accepting ticks
- Add Instant.PlusNanos to match Instant.PlusTicks. (Both are probably still useful.)

Fixes #617, although we should probably look over all core APIs at some point before 2.0.