### PR TITLE
Handle truncation and range issues for BCL conversions.

### DIFF
--- a/src/NodaTime.Test/InstantTest.cs
+++ b/src/NodaTime.Test/InstantTest.cs
@@ -239,6 +239,31 @@ namespace NodaTime.Test
             Assert.AreEqual(DateTimeKind.Utc, actual.Kind);
         }
 
+        // See issue 269, but now we throw a nicer exception.
+        [Test]
+        public void ToBclTypes_DateOutOfRange()
+        {
+            var instant = Instant.FromUtc(1, 1, 1, 0, 0).PlusNanoseconds(-1);
+            Assert.Throws<InvalidOperationException>(() => instant.ToDateTimeUtc());
+            Assert.Throws<InvalidOperationException>(() => instant.ToDateTimeOffset());
+        }
+
+        [Test]
+        [TestCase(100)]
+        [TestCase(1900)]
+        [TestCase(2900)]
+        public void ToBclTypes_TruncateNanosTowardStartOfTime(int year)
+        {
+            var instant = Instant.FromUtc(year, 1, 1, 13, 15, 55).PlusNanoseconds(NodaConstants.NanosecondsPerSecond - 1);
+            var expectedDateTimeUtc = new DateTime(year, 1, 1, 13, 15, 55, DateTimeKind.Unspecified)
+                .AddTicks(NodaConstants.TicksPerSecond - 1);
+            var actualDateTimeUtc = instant.ToDateTimeUtc();
+            Assert.AreEqual(expectedDateTimeUtc, actualDateTimeUtc);
+            var expectedDateTimeOffset = new DateTimeOffset(expectedDateTimeUtc, TimeSpan.Zero);
+            var actualDateTimeOffset = instant.ToDateTimeOffset();
+            Assert.AreEqual(expectedDateTimeOffset, actualDateTimeOffset);
+        }
+
         [Test]
         public void ToDateTimeOffset()
         {
@@ -391,19 +416,6 @@ namespace NodaTime.Test
             TestHelper.AssertOutOfRange(Instant.FromUnixTimeTicks, smallestValid - 1);
             TestHelper.AssertValid(Instant.FromUnixTimeTicks, largestValid);
             TestHelper.AssertOutOfRange(Instant.FromUnixTimeTicks, largestValid + 1);
-        }
-
-        // See issue 269.
-        [Test]
-        public void ToDateTimeUtc_WithOverflow()
-        {
-            TestHelper.AssertOverflow(() => Instant.MinValue.ToDateTimeUtc());
-        }
-
-        [Test]
-        public void ToDateTimeOffset_WithOverflow()
-        {
-            TestHelper.AssertOverflow(() => Instant.MinValue.ToDateTimeOffset());
         }
     }
 }

--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -33,6 +33,26 @@ namespace NodaTime.Test
         }
 
         [Test]
+        [TestCase(100)]
+        [TestCase(1900)]
+        [TestCase(2900)]
+        public void ToDateTimeUnspecified_TruncatesTowardsStartOfTime(int year)
+        {
+            var ldt = new LocalDateTime(year, 1, 1, 13, 15, 55).PlusNanoseconds(NodaConstants.NanosecondsPerSecond - 1);
+            var expected = new DateTime(year, 1, 1, 13, 15, 55, DateTimeKind.Unspecified).AddTicks(NodaConstants.TicksPerSecond - 1);
+            var actual = ldt.ToDateTimeUnspecified();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ToDateTimeUnspecified_OutOfRange()
+        {
+            // One day before 1st January, 1AD (which is DateTime.MinValue)
+            var ldt = new LocalDate(1, 1, 1).PlusDays(-1).AtMidnight();
+            Assert.Throws<InvalidOperationException>(() => ldt.ToDateTimeUnspecified());
+        }
+
+        [Test]
         public void FromDateTime()
         {
             LocalDateTime expected = new LocalDateTime(2011, 08, 18, 20, 53);

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -522,16 +522,44 @@ namespace NodaTime
         /// Constructs a <see cref="DateTime"/> from this Instant which has a <see cref="DateTime.Kind" />
         /// of <see cref="DateTimeKind.Utc"/> and represents the same instant of time as this value.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the date and time is not on a tick boundary (the unit of granularity of DateTime) the value will be truncated
+        /// towards the start of time.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The final date/time is outside the range of <c>DateTime</c>.</exception>
         /// <returns>A <see cref="DateTime"/> representing the same instant in time as this value, with a kind of "universal".</returns>
         [Pure]
-        public DateTime ToDateTimeUtc() => new DateTime(BclTicksAtUnixEpoch + ToUnixTimeTicks(), DateTimeKind.Utc);
+        public DateTime ToDateTimeUtc()
+        {
+            if (this < BclEpoch)
+            {
+                throw new InvalidOperationException("Instant out of range for DateTime");
+            }
+            return new DateTime(BclTicksAtUnixEpoch + ToUnixTimeTicks(), DateTimeKind.Utc);
+        }
 
         /// <summary>
         /// Constructs a <see cref="DateTimeOffset"/> from this Instant which has an offset of zero.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the date and time is not on a tick boundary (the unit of granularity of DateTime) the value will be truncated
+        /// towards the start of time.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The final date/time is outside the range of <c>DateTimeOffset</c>.</exception>
         /// <returns>A <see cref="DateTimeOffset"/> representing the same instant in time as this value.</returns>
         [Pure]
-        public DateTimeOffset ToDateTimeOffset() => new DateTimeOffset(BclTicksAtUnixEpoch + ToUnixTimeTicks(), TimeSpan.Zero);
+        public DateTimeOffset ToDateTimeOffset()
+        {
+            if (this < BclEpoch)
+            {
+                throw new InvalidOperationException("Instant out of range for DateTimeOffset");
+            }
+            return new DateTimeOffset(BclTicksAtUnixEpoch + ToUnixTimeTicks(), TimeSpan.Zero);
+        }
 
         /// <summary>
         /// Converts a <see cref="DateTimeOffset"/> into a new Instant representing the same instant in time. Note that

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -290,18 +290,29 @@ namespace NodaTime
         /// of <see cref="DateTimeKind.Unspecified"/>.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// <see cref="DateTimeKind.Unspecified"/> is slightly odd - it can be treated as UTC if you use <see cref="DateTime.ToLocalTime"/>
         /// or as system local time if you use <see cref="DateTime.ToUniversalTime"/>, but it's the only kind which allows
         /// you to construct a <see cref="DateTimeOffset"/> with an arbitrary offset, which makes it as close to
         /// the Noda Time non-system-specific "local" concept as exists in .NET.
+        /// </para>
+        /// <para>
+        /// If the date and time is not on a tick boundary (the unit of granularity of DateTime) the value will be truncated
+        /// towards the start of time.
+        /// </para>
         /// </remarks>
+        /// <exception cref="InvalidOperationException">The date/time is outside the range of <c>DateTime</c>.</exception>
         /// <returns>A <see cref="DateTime"/> value for the same date and time as this value.</returns>
         [Pure]
-        public DateTime ToDateTimeUnspecified() =>
-            new DateTime(
-                TickArithmetic.DaysAndTickOfDayToTicks(date.DaysSinceEpoch, time.TickOfDay) + NodaConstants.BclTicksAtUnixEpoch,
-                DateTimeKind.Unspecified);
-            
+        public DateTime ToDateTimeUnspecified()
+        {
+            long ticks = TickArithmetic.DaysAndTickOfDayToTicks(date.DaysSinceEpoch, time.TickOfDay) + NodaConstants.BclTicksAtUnixEpoch;
+            if (ticks < 0)
+            {
+                throw new InvalidOperationException("LocalDateTime out of range of DateTime");
+            }
+            return new DateTime(ticks, DateTimeKind.Unspecified);
+        }
 
         [Pure]
         internal LocalInstant ToLocalInstant() => new LocalInstant(date.DaysSinceEpoch, time.NanosecondOfDay);

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -394,6 +394,9 @@ namespace NodaTime
         /// <summary>
         /// Gets the tick of this local time within the day, in the range 0 to 863,999,999,999 inclusive.
         /// </summary>
+        /// <remarks>
+        /// If the value does not fall on a tick boundary, it will be truncated towards zero.
+        /// </remarks>
         /// <value>The tick of this local time within the day, in the range 0 to 863,999,999,999 inclusive.</value>
         public long TickOfDay => nanoseconds / NanosecondsPerTick;
 

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -548,11 +548,24 @@ namespace NodaTime
         /// UTC as this value.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// An offset does not convey as much information as a time zone; a <see cref="DateTimeOffset"/>
         /// represents an instant in time along with an associated local time, but it doesn't allow you
         /// to find out what the local time would be for another instant.
+        /// </para>
+        /// <para>
+        /// If the date and time is not on a tick boundary (the unit of granularity of DateTime) the value will be truncated
+        /// towards the start of time.
+        /// </para>
+        /// <para>
+        /// If the offset has a non-zero second component, this is truncated as <c>DateTimeOffset</c> has an offset
+        /// granularity of minutes.
+        /// </para>
         /// </remarks>
-        /// <returns>A <see cref="DateTimeOffset"/> representation of this value.</returns>
+        /// <exception cref="InvalidOperationException">The date/time is outside the range of <c>DateTimeOffset</c>,
+        /// or the offset is outside the range of +/-14 hours (the range supported by <c>DateTimeOffset</c>).</exception>
+        /// <returns>A <c>DateTimeOffset</c> with the same local date/time and offset as this. The <see cref="DateTime"/> part of
+        /// the result always has a "kind" of Unspecified.</returns>
         [Pure]
         public DateTimeOffset ToDateTimeOffset() => offsetDateTime.ToDateTimeOffset();
 
@@ -572,6 +585,13 @@ namespace NodaTime
         /// <see cref="DateTime.Kind"/> of <see cref="DateTimeKind.Utc"/> and represents the same instant of time as
         /// this value rather than the same local time.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If the date and time is not on a tick boundary (the unit of granularity of DateTime) the value will be truncated
+        /// towards the start of time.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">The final date/time is outside the range of <c>DateTime</c>.</exception>
         /// <returns>A <see cref="DateTime"/> representation of this value with a "universal" kind, with the same
         /// instant of time as this value.</returns>
         [Pure]
@@ -583,10 +603,17 @@ namespace NodaTime
         /// this value rather than the same instant in time.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// <see cref="DateTimeKind.Unspecified"/> is slightly odd - it can be treated as UTC if you use <see cref="DateTime.ToLocalTime"/>
         /// or as system local time if you use <see cref="DateTime.ToUniversalTime"/>, but it's the only kind which allows
         /// you to construct a <see cref="DateTimeOffset"/> with an arbitrary offset.
+        /// </para>
+        /// <para>
+        /// If the date and time is not on a tick boundary (the unit of granularity of DateTime) the value will be truncated
+        /// towards the start of time.
+        /// </para>
         /// </remarks>
+        /// <exception cref="InvalidOperationException">The date/time is outside the range of <c>DateTime</c>.</exception>
         /// <returns>A <see cref="DateTime"/> representation of this value with an "unspecified" kind, with the same
         /// local date and time as this value.</returns>
         [Pure]


### PR DESCRIPTION
- Document and test that we truncate towards the start of time
- Throw an appropriate exception for date/time and offset values
  being out of range
- Round offsets towards zero if they have non-zero second values

Fixes #395.