### PR TITLE
Add compatibility test for Noda Time 1.1 reading NZD files

### DIFF
--- a/build/updatetzdb.bat
+++ b/build/updatetzdb.bat
@@ -13,7 +13,7 @@ set WWWDIR=..\www
 call dotnet restore -v Error %SRCDIR%
 IF ERRORLEVEL 1 EXIT /B 1
 
-call dotnet build %SRCDIR%\NodaTime.TzdbCompiler %SRCDIR%\NodaTime.TzValidate.NodaDump
+call dotnet build %SRCDIR%\NodaTime.TzdbCompiler %SRCDIR%\NodaTime.TzValidate.NodaDump %SRCDIR%\NodaTime.TzValidate.NzdCompatibility
 IF ERRORLEVEL 1 EXIT /B 1
 
 dotnet run -p %SRCDIR%\NodaTime.TzdbCompiler -- -o %SRCDIR%\NodaTime\TimeZones\Tzdb.nzd -s http://www.iana.org/time-zones/repository/releases/tzdata%1.tar.gz -w %DATADIR%\cldr
@@ -28,5 +28,9 @@ echo Hash on github pages:
 wget -q -O - http://nodatime.github.io/tzvalidate/tzdata%1%-sha256.txt 2> NUL
 echo Hash from new file:
 dotnet run -p %SRCDIR%\NodaTime.TzValidate.NodaDump -- -s %WWWDIR%\tzdb\tzdb%1.nzd --hash
+echo Hash from new file without abbreviations:
+dotnet run -p %SRCDIR%\NodaTime.TzValidate.NodaDump -- -s %WWWDIR%\tzdb\tzdb%1.nzd --hash --noabbr
+echo Hash from new file without abbreviations, using Noda Time 1.1:
+dotnet run -p %SRCDIR%\NodaTime.TzValidate.NzdCompatibility -- -s %WWWDIR%\tzdb\tzdb%1.nzd --hash --noabbr
 
 :end

--- a/src/NodaTime-All.sln
+++ b/src/NodaTime-All.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NodaTime", "NodaTime\NodaTime.xproj", "{29F470FA-C1CB-408B-A0B6-C1A9216C4B7B}"
 EndProject
@@ -22,6 +22,8 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NodaTime.TzdbCompiler.Test", "NodaTime.TzdbCompiler.Test\NodaTime.TzdbCompiler.Test.xproj", "{56D9408D-8647-4F53-A1D9-25D00CF1BE32}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NodaTime.TzValidate.NodaDump", "NodaTime.TzValidate.NodaDump\NodaTime.TzValidate.NodaDump.xproj", "{F546EDA0-6B44-4B32-A8BE-18B1FE664BFF}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "NodaTime.TzValidate.NzdCompatibility", "NodaTime.TzValidate.NzdCompatibility\NodaTime.TzValidate.NzdCompatibility.xproj", "{B64228A2-15CC-4308-8804-D2979D725CE9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +71,10 @@ Global
 		{F546EDA0-6B44-4B32-A8BE-18B1FE664BFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F546EDA0-6B44-4B32-A8BE-18B1FE664BFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F546EDA0-6B44-4B32-A8BE-18B1FE664BFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B64228A2-15CC-4308-8804-D2979D725CE9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B64228A2-15CC-4308-8804-D2979D725CE9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B64228A2-15CC-4308-8804-D2979D725CE9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B64228A2-15CC-4308-8804-D2979D725CE9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NodaTime.TzValidate.NzdCompatibility/NodaTime.TzValidate.NzdCompatibility.xproj
+++ b/src/NodaTime.TzValidate.NzdCompatibility/NodaTime.TzValidate.NzdCompatibility.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25420" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25420</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>b64228a2-15cc-4308-8804-d2979d725ce9</ProjectGuid>
+    <RootNamespace>NodaTime.TzValidate.NzdCompatibility</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/NodaTime.TzValidate.NzdCompatibility/Options.cs
+++ b/src/NodaTime.TzValidate.NzdCompatibility/Options.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using CommandLine;
+using CommandLine.Text;
+
+namespace NodaTime.TzValidate.NzdCompatibility
+{
+    /// <summary>
+    /// Options for TzValidate dumpers, typically specified on the command line.
+    /// Note that this class unfortunately mixes "pure" dumper options (from/to year, whether
+    /// or not to include abbreviations etc) with "tool" options (source to load from, output file).
+    /// This may be corrected in the future.
+    /// </summary>
+    public sealed class Options
+    {
+        [Option("f", "from-year", Required = false, HelpText = "Lower bound (inclusive) to print transitions from.")]
+        public int? FromYear { get; set; }
+
+        [Option("t", "to-year", Required = false,
+            HelpText = "Upper bound (exclusive) to print transitions until (defaults to 2035)", DefaultValue = 2035)]
+        public int ToYear { get; set; }
+
+        [Option("s", "source", Required = true, HelpText = "Data source - a single file or URL; must be an NZD file")]
+        public string Source { get; set; }
+
+        [Option("z", "zone", Required = false, HelpText = "Zone ID, to dump a single time zone")]
+        public string ZoneId { get; set; }
+
+        [Option("o", "output", Required = false, HelpText = "Output file (defaults to writing to the console")]
+        public string OutputFile { get; set; }
+
+        [Option(null, "hash", Required = false, HelpText = "Only output the SHA-256 hash")]
+        public bool HashOnly { get; set; }
+
+        [Option(null, "noabbr", Required = false, HelpText = "Disable output of abbreviations")]
+        public bool DisableAbbreviations { get; set; }
+
+        internal Instant Start => FromYear == null ? Instant.FromUtc(1, 1, 1, 0, 0) : Instant.FromUtc(FromYear.Value, 1, 1, 0, 0);
+        internal Instant End => Instant.FromUtc(ToYear, 1, 1, 0, 0);
+
+        [HelpOption(HelpText = "Display this help screen.")]
+        public string GetUsage()
+        {
+            var help = new HelpText(new HeadingInfo("NzdCompatibility"))
+            {
+                AdditionalNewLineAfterOption = true,
+                Copyright = new CopyrightInfo("The Noda Time Authors", 2017)
+            };
+            help.AddPreOptionsLine("Usage: NodaTime.TzValidate.NzdCompatibility [-s data-source] [-f from-year] [-t to-year] [-z zone id] [-o output] [-hash] [-noabbr]");
+            help.AddPreOptionsLine("The data source must be a Noda Time .nzd file (local or web)");
+            help.AddOptions(this);
+            return help;
+        }
+
+    }
+}

--- a/src/NodaTime.TzValidate.NzdCompatibility/Program.cs
+++ b/src/NodaTime.TzValidate.NzdCompatibility/Program.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using CommandLine;
+using NodaTime.TimeZones;
+using System;
+using System.IO;
+using System.Net.Http;
+
+namespace NodaTime.TzValidate.NzdCompatibility
+{
+    /// <summary>
+    /// Based on NodaTime.TzValidate.NodaDump, this checks that Noda Time 1.1 can read an
+    /// NZD file and produce the same result as the most recent version.
+    /// </summary>
+    internal class Program
+    {
+        private static int Main(string[] args)
+        {
+            Options options = new Options();
+            ICommandLineParser parser = new CommandLineParser(new CommandLineParserSettings(Console.Error) { MutuallyExclusive = true });
+            if (!parser.ParseArguments(args, options))
+            {
+                return 1;
+            }
+            var data = LoadFileOrUrl(options.Source);
+            TzdbDateTimeZoneSource source = TzdbDateTimeZoneSource.FromStream(new MemoryStream(data));
+            var dumper = new ZoneDumper(source, options);
+            try
+            {
+                using (var writer = options.OutputFile == null ? Console.Out : File.CreateText(options.OutputFile))
+                {
+                    dumper.Dump(writer);
+                }
+            }
+            catch (UserErrorException e)
+            {
+                Console.Error.WriteLine($"Error: {e.Message}");
+                return 1;
+            }
+
+            return 0;
+        }        
+        
+        private static byte[] LoadFileOrUrl(string source)
+        {
+            if (source.StartsWith("http://") || source.StartsWith("https://") || source.StartsWith("ftp://"))
+            {
+                using (var client = new HttpClient())
+                {
+                    // I know using .Result is nasty, but we're in a console app, and nothing is
+                    // going to deadlock...
+                    return client.GetAsync(source).Result.EnsureSuccessStatusCode().Content.ReadAsByteArrayAsync().Result;
+                }
+            }
+            return File.ReadAllBytes(source);
+        }
+    }
+}

--- a/src/NodaTime.TzValidate.NzdCompatibility/UserErrorException.cs
+++ b/src/NodaTime.TzValidate.NzdCompatibility/UserErrorException.cs
@@ -1,0 +1,18 @@
+﻿// Copyright 2015 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+
+namespace NodaTime.TzValidate.NzdCompatibility
+{
+    /// <summary>
+    /// An exception caused by user error, e.g. invalid options.
+    /// </summary>
+    public sealed class UserErrorException : Exception
+    {
+        public UserErrorException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/NodaTime.TzValidate.NzdCompatibility/ZoneDumper.cs
+++ b/src/NodaTime.TzValidate.NzdCompatibility/ZoneDumper.cs
@@ -1,0 +1,131 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Text;
+using NodaTime.TimeZones;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace NodaTime.TzValidate.NzdCompatibility
+{
+    /// <summary>
+    /// Class to dump time zone transitions according to the TzValidate format.
+    /// </summary>
+    public sealed class ZoneDumper
+    {
+        private static readonly IPattern<Instant> InstantPattern = NodaTime.Text.InstantPattern.CreateWithInvariantCulture("yyyy-MM-dd HH:mm:ss'Z'");
+        private static readonly IPattern<Offset> OffsetPattern = NodaTime.Text.OffsetPattern.CreateWithInvariantCulture("l");
+        private const string LineFormatWithAbbreviations = "{0} {1} {2} {3}\n";
+        private const string LineFormatWithoutAbbreviations = "{0} {1} {2}\n";
+
+        private readonly TzdbDateTimeZoneSource source;
+        private readonly Options options;
+
+        public ZoneDumper(TzdbDateTimeZoneSource source, Options options)
+        {
+            this.source = source;
+            this.options = options;
+        }
+
+        public void Dump(TextWriter writer)
+        {
+            var zones = source.GetIds()
+                .Select(source.ForId)
+                .OrderBy(zone => zone.Id, StringComparer.Ordinal)
+                .ToList();
+
+            if (options.ZoneId != null)
+            {
+                if (options.HashOnly)
+                {
+                    // TODO: Maybe allow this after all, and include the zone ID in the headers?
+                    throw new UserErrorException("Cannot use hash option with a single zone ID");
+                }
+                var zone = zones.FirstOrDefault(z => z.Id == options.ZoneId);
+                if (zone == null)
+                {
+                    throw new UserErrorException($"Unknown zone ID: {options.ZoneId}");
+                }
+                DumpZone(zone, writer);
+            }
+            else
+            {
+                var bodyWriter = new StringWriter();
+                foreach (var zone in zones)
+                {
+                    DumpZone(zone, bodyWriter);
+                }
+                var text = bodyWriter.ToString();
+                if (options.HashOnly)
+                {
+                    writer.Write(ComputeHash(text) + "\n");
+                }
+                else
+                {
+                    WriteHeaders(text, writer);
+                    writer.Write(text);
+                }
+            }
+
+        }
+
+        private void DumpZone(DateTimeZone zone, TextWriter writer)
+        {
+            string lineFormat = options.DisableAbbreviations ? LineFormatWithoutAbbreviations : LineFormatWithAbbreviations;
+            writer.Write($"{zone.Id}\n");
+            var initial = zone.GetZoneInterval(options.Start);
+            writer.Write(lineFormat,
+                "Initially:          ",
+                OffsetPattern.Format(initial.WallOffset),
+                initial.Savings != Offset.Zero ? "daylight" : "standard",
+                initial.Name);
+            foreach (var zoneInterval in zone.GetZoneIntervals(options.Start, options.End)
+                                             .Where(zi => zi.Start >= options.Start))
+            {
+                writer.Write(lineFormat,
+                    InstantPattern.Format(zoneInterval.Start),
+                    OffsetPattern.Format(zoneInterval.WallOffset),
+                    zoneInterval.Savings != Offset.Zero ? "daylight" : "standard",
+                    zoneInterval.Name);
+            }
+            writer.Write("\n");
+        }
+
+        private void WriteHeaders(string text, TextWriter writer)
+        {
+            writer.Write($"Version: {source.TzdbVersion}\n");
+            writer.Write($"Body-SHA-256: {ComputeHash(text)}\n");
+            writer.Write("Format: tzvalidate-0.1\n");
+            // TODO: Write up these options...
+            var optionsList = new List<string>();
+            if (optionsList.Count != 0)
+            {
+                writer.Write($"Options: {string.Join(", ", optionsList)}\n");
+            }
+            writer.Write($"Range: {options.FromYear ?? 1}-{options.ToYear}\n");
+            writer.Write($"Generator: {typeof(Program).GetTypeInfo().Assembly.GetName().Name}\n");
+            writer.Write($"GeneratorUrl: https://github.com/nodatime/nodatime\n");
+            writer.Write("\n");
+        }
+
+        /// <summary>
+        /// Computes the SHA-256 hash of the given text after encoding it as UTF-8,
+        /// and returns the hash in lower-case hex.
+        /// </summary>
+        private static string ComputeHash(string text)
+        {
+            using (var hashAlgorithm = SHA256.Create())
+            {
+                var bytes = Encoding.UTF8.GetBytes(text);
+                var hash = hashAlgorithm.ComputeHash(bytes);
+                return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+            }
+        }
+    }
+}

--- a/src/NodaTime.TzValidate.NzdCompatibility/project.json
+++ b/src/NodaTime.TzValidate.NzdCompatibility/project.json
@@ -1,0 +1,36 @@
+{
+  "buildOptions": {
+    "emitEntryPoint": true,
+    "compile": [
+      "*.cs",
+      "../../lib/commandline/*.cs"
+    ]
+  },
+
+  "configurations": {
+    "Debug": {
+      "buildOptions": {
+        "define": [ "DEBUG", "TRACE" ]
+      }
+    },
+    "Release": {
+      "buildOptions": {
+        "define": [ "RELEASE", "TRACE" ],
+        "optimize": true
+      }
+    }
+  },
+
+  "dependencies": {
+    "NodaTime": {
+      "version": "1.1.1",
+      "target": "package"
+    },
+    "System.Net.Http": "4.0.0"
+  },
+
+  "frameworks": {
+    "net45": {
+    }
+  }
+}


### PR DESCRIPTION
This only thoroughly checks the TZDB part of it, but that should be good enough for now.
It will already have loaded the Windows zones etc, but we don't check the data itself.

Fixes #364.