### PR TITLE
Improve formatting of text patterns in the user guide

### DIFF
--- a/src/NodaTime.Web/Markdown/1.0.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/localdate-patterns.md
@@ -26,9 +26,9 @@ For the meanings of "absolute" years and text handling, see later details.
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.0.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/localtime-patterns.md
@@ -27,9 +27,9 @@ for general notes on custom patterns, including characters used for escaping and
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.0.x/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/offset-patterns.md
@@ -32,9 +32,9 @@ for general notes on custom patterns, including characters used for escaping and
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.0.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/text.md
@@ -79,9 +79,9 @@ All custom patterns support the following characters:
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.1.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/localdate-patterns.md
@@ -26,9 +26,9 @@ For the meanings of "absolute" years and text handling, see later details.
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.1.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/localtime-patterns.md
@@ -27,9 +27,9 @@ for general notes on custom patterns, including characters used for escaping and
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>
@@ -37,7 +37,6 @@ for general notes on custom patterns, including characters used for escaping and
       <td><code>H</code> or <code>HH</code></td>
       <td>
         The hour of day in the 24-hour clock; a value 0-23.
-
         <p>Note that when parsing local date/time values, a value of <code>24</code>
         may be exceptionally permitted to allow
         <a href="localdatetime-patterns.md">specification of a following day's

--- a/src/NodaTime.Web/Markdown/1.1.x/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/offset-patterns.md
@@ -32,9 +32,9 @@ for general notes on custom patterns, including characters used for escaping and
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.1.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/text.md
@@ -79,9 +79,9 @@ All custom patterns support the following characters:
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.2.x/duration-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/duration-patterns.md
@@ -42,9 +42,9 @@ We recommend using the repeated form in most cases.
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>    

--- a/src/NodaTime.Web/Markdown/1.2.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/localdate-patterns.md
@@ -26,9 +26,9 @@ For the meanings of "absolute" years and text handling, see later details.
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.2.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/localtime-patterns.md
@@ -27,9 +27,9 @@ for general notes on custom patterns, including characters used for escaping and
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>
@@ -37,7 +37,6 @@ for general notes on custom patterns, including characters used for escaping and
       <td><code>H</code> or <code>HH</code></td>
       <td>
         The hour of day in the 24-hour clock; a value 0-23.
-
         <p>Note that when parsing local date/time values, a value of <code>24</code>
         may be exceptionally permitted to allow
         <a href="localdatetime-patterns.md">specification of a following day's

--- a/src/NodaTime.Web/Markdown/1.2.x/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/offset-patterns.md
@@ -32,9 +32,9 @@ for general notes on custom patterns, including characters used for escaping and
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.2.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/text.md
@@ -79,9 +79,9 @@ All custom patterns support the following characters:
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.3.x/duration-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/duration-patterns.md
@@ -43,9 +43,9 @@ We recommend using the repeated form in most cases.
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>    

--- a/src/NodaTime.Web/Markdown/1.3.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/localdate-patterns.md
@@ -27,9 +27,9 @@ For the meanings of "absolute" years and text handling, see later details.
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.3.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/localtime-patterns.md
@@ -27,9 +27,9 @@ for general notes on custom patterns, including characters used for escaping and
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>
@@ -37,7 +37,6 @@ for general notes on custom patterns, including characters used for escaping and
       <td><code>H</code> or <code>HH</code></td>
       <td>
         The hour of day in the 24-hour clock; a value 0-23.
-
         <p>Note that when parsing local date/time values, a value of <code>24</code>
         may be exceptionally permitted to allow
         <a href="localdatetime-patterns.md">specification of a following day's

--- a/src/NodaTime.Web/Markdown/1.3.x/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/offset-patterns.md
@@ -32,9 +32,9 @@ for general notes on custom patterns, including characters used for escaping and
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/1.3.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/text.md
@@ -79,9 +79,9 @@ All custom patterns support the following characters:
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/unstable/duration-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/duration-patterns.md
@@ -43,9 +43,9 @@ We recommend using the repeated form in most cases.
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>    

--- a/src/NodaTime.Web/Markdown/unstable/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/localdate-patterns.md
@@ -27,9 +27,9 @@ For the meanings of "absolute" years and text handling, see later details.
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>
@@ -165,7 +165,7 @@ For the meanings of "absolute" years and text handling, see later details.
         The date separator for the format provider; slash in the invariant culture.
       </td>
       <td>en-US: <code>uuuu/MM/dd</code> => <code>2011/10/09</code><br />
-          de-DE: <code>uuuu/MM/dd</code> => <code>2011.10.09</code></td>
+          de-DE: <code>uuuu/MM/dd</code> => <code>2011.10.09</code>
           de-DE: <code>uuuu/MM/dd</code> => <code>2011.10.09</code></td>
     </tr>
   </tbody>

--- a/src/NodaTime.Web/Markdown/unstable/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/localtime-patterns.md
@@ -27,9 +27,9 @@ for general notes on custom patterns, including characters used for escaping and
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>
@@ -37,7 +37,6 @@ for general notes on custom patterns, including characters used for escaping and
       <td><code>H</code> or <code>HH</code></td>
       <td>
         The hour of day in the 24-hour clock; a value 0-23.
-
         <p>Note that when parsing local date/time values, a value of <code>24</code>
         may be exceptionally permitted to allow
         <a href="localdatetime-patterns.md">specification of a following day's

--- a/src/NodaTime.Web/Markdown/unstable/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/offset-patterns.md
@@ -35,9 +35,9 @@ for general notes on custom patterns, including characters used for escaping and
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/Markdown/unstable/text.md
+++ b/src/NodaTime.Web/Markdown/unstable/text.md
@@ -79,9 +79,9 @@ All custom patterns support the following characters:
 <table>
   <thead>
     <tr>
-      <td>Character</td>
-      <td>Meaning</td>
-      <td>Example</td>
+      <td class="pattern-char">Character</td>
+      <td class="pattern-description">Meaning</td>
+      <td class="pattern-example">Example</td>
     </tr>
   </thead>
   <tbody>

--- a/src/NodaTime.Web/wwwroot/css/main.css
+++ b/src/NodaTime.Web/wwwroot/css/main.css
@@ -364,3 +364,15 @@ footer .design {
 
 @media only screen and (min-width: 1440px) {
 }
+
+td.pattern-char {
+  width: 20%
+}
+
+td.pattern-description {
+  width: 50%
+}
+
+td.pattern-example {
+  width: 30%
+}


### PR DESCRIPTION
- Remove blank line in localtime-patterns to avoid Markdown
  parsing text as code
- Use styling to boost size of example column

Fixes #646.