### PR TITLE
Rename DateInterval.Inclusive to EndInclusive

### DIFF
--- a/src/NodaTime.Test/DateIntervalTest.cs
+++ b/src/NodaTime.Test/DateIntervalTest.cs
@@ -43,12 +43,12 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void Construction_DefaultToInclusive()
+        public void Construction_DefaultToEndInclusive()
         {
             LocalDate start = new LocalDate(2000, 1, 1);
             LocalDate end = new LocalDate(2001, 6, 19);
             var interval = new DateInterval(start, end);
-            Assert.IsTrue(interval.Inclusive);
+            Assert.IsTrue(interval.EndInclusive);
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace NodaTime.Test
             var interval = new DateInterval(start, end, false);
             Assert.AreEqual(start, interval.Start);
             Assert.AreEqual(end, interval.End);
-            Assert.IsFalse(interval.Inclusive);
+            Assert.IsFalse(interval.EndInclusive);
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void Equals_DifferentInclusivity()
+        public void Equals_DifferentEndInclusivity()
         {
             LocalDate start = new LocalDate(2000, 1, 1);
             LocalDate end = new LocalDate(2001, 6, 19);
@@ -254,7 +254,7 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void Equals_Extremes_Equal_BothInclusive()
+        public void Equals_Extremes_Equal_BothEndInclusive()
         {
             // An extreme range where both intervals are inclusive.
             var interval1 = new DateInterval(MinIsoDate, MaxIsoDate, true);
@@ -411,7 +411,7 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void ToString_Inclusive()
+        public void ToString_EndInclusive()
         {
             LocalDate start = new LocalDate(2000, 1, 1);
             LocalDate end = new LocalDate(2001, 6, 19);
@@ -420,7 +420,7 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void ToString_Exclusive()
+        public void ToString_EndExclusive()
         {
             LocalDate start = new LocalDate(2000, 1, 1);
             LocalDate end = new LocalDate(2001, 6, 19);
@@ -429,7 +429,7 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void Length_Inclusive()
+        public void Length_EndInclusive()
         {
             LocalDate start = new LocalDate(2000, 1, 1);
             LocalDate end = new LocalDate(2000, 2, 10);
@@ -438,7 +438,7 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void Length_Exclusive()
+        public void Length_EndExclusive()
         {
             LocalDate start = new LocalDate(2000, 1, 1);
             LocalDate end = new LocalDate(2000, 2, 10);

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -26,7 +26,7 @@ namespace NodaTime
     /// next month as the exclusive end.
     /// </para>
     /// <para>
-    /// Values can be compared for equality, but note that inclusive intervals and exclusive intervals are always
+    /// Values can be compared for equality, but note that end-inclusive intervals and end-exclusive intervals are always
     /// considered to differ, even if they cover the same range of dates.
     /// </para>
     /// </remarks>
@@ -42,7 +42,7 @@ namespace NodaTime
         /// This comparer considers date intervals to be equal if they have the same start and end dates when considered
         /// as exclusive intervals.  Alternatively: this comparer is identical to the built-in equality for
         /// <c>DateInterval</c>, except that it also considers an exclusive date interval of [2001-01-01, 2001-02-01) as
-        /// equal to an inclusive date interval of [2001-01-01, 2001-01-31].
+        /// equal to an end-inclusive date interval of [2001-01-01, 2001-01-31].
         /// </para>
         /// <para>
         /// Note that intervals with different start dates are still considered unequal by this comparer (even empty
@@ -61,7 +61,7 @@ namespace NodaTime
         /// <para>
         /// This comparer considers date intervals to be equal if they would contain the same dates.  Alternatively:
         /// this comparer is identical to the built-in equality for <c>DateInterval</c>, except that it also considers
-        /// an exclusive date interval of [2001-01-01, 2001-02-01) as equal to an inclusive date interval of
+        /// an exclusive date interval of [2001-01-01, 2001-02-01) as equal to an end-inclusive date interval of
         /// [2001-01-01, 2001-01-31] and considers all empty intervals — e.g. [2001-01-01, 2001-01-01) or [1900-01-01,
         /// 1900-01-01) — to be equal to each other (as every empty interval contains the same set of dates).
         /// </para>
@@ -84,7 +84,7 @@ namespace NodaTime
         /// Gets the end date of the interval.
         /// </summary>
         /// <remarks>
-        /// Use the <see cref="Inclusive"/> property to determine whether or not the end
+        /// Use the <see cref="EndInclusive"/> property to determine whether or not the end
         /// date is considered part of the interval.
         /// </remarks>
         /// <value>The end date of the interval.</value>
@@ -94,7 +94,7 @@ namespace NodaTime
         /// Indicates whether or not this interval includes its end date.
         /// </summary>
         /// <value>Whether or not this interval includes its end date.</value>
-        public bool Inclusive { get; }
+        public bool EndInclusive { get; }
 
         /// <summary>
         /// Constructs a date interval from a start date and an end date, and an indication
@@ -102,21 +102,21 @@ namespace NodaTime
         /// </summary>
         /// <param name="start">Start date of the interval</param>
         /// <param name="end">End date of the interval</param>
-        /// <param name="inclusive"><c>true</c> to include the end date in the interval;
+        /// <param name="endInclusive"><c>true</c> to include the end date in the interval;
         /// <c>false</c> to exclude it.
         /// </param>
         /// <exception cref="ArgumentException"><paramref name="end"/> is earlier than <paramref name="start"/>
         /// or the two dates are in different calendars.
         /// </exception>
         /// <returns>A date interval between the specified dates, with the specified inclusivity.</returns>
-        public DateInterval(LocalDate start, LocalDate end, bool inclusive)
+        public DateInterval(LocalDate start, LocalDate end, bool endInclusive)
         {
             Preconditions.CheckArgument(start.Calendar.Equals(end.Calendar), nameof(end),
                 "Calendars of start and end dates must be the same.");
             Preconditions.CheckArgument(!(end < start), nameof(end), "End date must not be earlier than the start date");
             this.Start = start;
             this.End = end;
-            this.Inclusive = inclusive;
+            this.EndInclusive = endInclusive;
         }
 
         /// <summary>
@@ -127,7 +127,7 @@ namespace NodaTime
         /// <exception cref="ArgumentException"><paramref name="end"/> is earlier than <paramref name="start"/>
         /// or the two dates are in different calendars.
         /// </exception>
-        /// <returns>An inclusive date interval between the specified dates.</returns>
+        /// <returns>An end-inclusive date interval between the specified dates.</returns>
         public DateInterval(LocalDate start, LocalDate end)
             : this(start, end, true)
         {
@@ -141,15 +141,15 @@ namespace NodaTime
             HashCodeHelper.Initialize()
                 .Hash(Start)
                 .Hash(End)
-                .Hash(Inclusive)
+                .Hash(EndInclusive)
                 .Value;
 
         /// <summary>
         /// Compares two <see cref="DateInterval" /> values for equality.
         /// </summary>
         /// <remarks>
-        /// Date intervals are equal if they have the same start and end dates and are both inclusive or both exclusive:
-        /// an exclusive date interval of [2001-01-01, 2001-02-01) is not equal to the inclusive date interval of
+        /// Date intervals are equal if they have the same start and end dates and are both end-inclusive or both end-exclusive:
+        /// an end-exclusive date interval of [2001-01-01, 2001-02-01) is not equal to the end-inclusive date interval of
         /// [2001-01-01, 2001-01-31], even though both contain the same range of dates.
         /// </remarks>
         /// <param name="lhs">The first value to compare</param>
@@ -165,15 +165,15 @@ namespace NodaTime
             {
                 return false;
             }
-            return lhs.Start == rhs.Start && lhs.End == rhs.End && lhs.Inclusive == rhs.Inclusive;
+            return lhs.Start == rhs.Start && lhs.End == rhs.End && lhs.EndInclusive == rhs.EndInclusive;
         }
 
         /// <summary>
         /// Compares two <see cref="DateInterval" /> values for inequality.
         /// </summary>
         /// <remarks>
-        /// Date intervals are equal if they have the same start and end dates and are both inclusive or both exclusive:
-        /// an exclusive date interval of [2001-01-01, 2001-02-01) is not equal to the inclusive date interval of
+        /// Date intervals are equal if they have the same start and end dates and are both end-inclusive or both exclusive:
+        /// an end-exclusive date interval of [2001-01-01, 2001-02-01) is not equal to the end-inclusive date interval of
         /// [2001-01-01, 2001-01-31], even though both contain the same range of dates.
         /// </remarks>
         /// <param name="lhs">The first value to compare</param>
@@ -185,8 +185,8 @@ namespace NodaTime
         /// Compares the given date interval for equality with this one.
         /// </summary>
         /// <remarks>
-        /// Date intervals are equal if they have the same start and end dates and are both inclusive or both exclusive:
-        /// an exclusive date interval of [2001-01-01, 2001-02-01) is not equal to the inclusive date interval of
+        /// Date intervals are equal if they have the same start and end dates and are both end-inclusive or both end-exclusive:
+        /// an end-exclusive date interval of [2001-01-01, 2001-02-01) is not equal to the end-inclusive date interval of
         /// [2001-01-01, 2001-01-31], even though both contain the same range of dates.
         /// </remarks>
         /// <param name="other">The date interval to compare this one with.</param>
@@ -204,7 +204,7 @@ namespace NodaTime
         /// Checks whether the given date is within this date interval. This requires
         /// that the date is not earlier than the start date, and not later than the end
         /// date. If the given date is exactly equal to the end date, it is considered
-        /// to be within the interval if and only if the interval is <see cref="Inclusive"/>.
+        /// to be within the interval if and only if the interval is <see cref="EndInclusive"/>.
         /// </summary>
         /// <param name="date">The date to check for containment within this interval.</param>
         /// <exception cref="ArgumentException"><paramref name="date"/> is not in the same
@@ -214,36 +214,36 @@ namespace NodaTime
         {
             Preconditions.CheckArgument(date.Calendar.Equals(Start.Calendar), nameof(date),
                 "The date to check must be in the same calendar as the start and end dates");
-            return Start <= date && (Inclusive ? date <= End : date < End);
+            return Start <= date && (EndInclusive ? date <= End : date < End);
         }
 
         /// <summary>
         /// Gets the length of this date interval in days.
         /// </summary>
         /// <remarks>
-        /// The end date is included or excluded according to the <see cref="Inclusive"/>
-        /// property. For example, an inclusive interval where the start and end date are the
+        /// The end date is included or excluded according to the <see cref="EndInclusive"/>
+        /// property. For example, an end-inclusive interval where the start and end date are the
         /// same has a length of 1, whereas an exclusive interval for the same dates has a
         /// length of 0.
         /// </remarks>
         /// <value>The length of this date interval in days.</value>
         public int Length =>
             // Period.Between will give us the exclusive result, so we need to add 1
-            // if this period is inclusive.
-            Period.Between(Start, End, PeriodUnits.Days).Days + (Inclusive ? 1 : 0);
+            // if this period is end-inclusive.
+            Period.Between(Start, End, PeriodUnits.Days).Days + (EndInclusive ? 1 : 0);
 
         /// <summary>
         /// Returns a string representation of this interval.
         /// </summary>
         /// <returns>
-        /// A string representation of this interval, as [start, end] for inclusive intervals, or [start, end) for
+        /// A string representation of this interval, as <c>[start, end]</c> for end-inclusive intervals, or <c>[start, end)</c> for
         /// exclusive intervals, where "start" and "end" are the dates formatted using an ISO-8601 compatible pattern.
         /// </returns>
         public override string ToString()
         {
             string start = LocalDatePattern.Iso.Format(Start);
             string end = LocalDatePattern.Iso.Format(End);
-            string endType = Inclusive ? "]" : ")";
+            string endType = EndInclusive ? "]" : ")";
             return $"[{start}, {end}{endType}";
         }
 
@@ -287,7 +287,7 @@ namespace NodaTime
             /// 10000-01-01), which cannot be represented as a DateInterval.
             /// </para>
             /// <para>
-            /// Instead, this method maps all non-empty intervals to inclusive intervals, and retains all empty
+            /// Instead, this method maps all non-empty intervals to end-inclusive intervals, and retains all empty
             /// intervals as empty intervals (which are exclusive by definition, and unequal to any non-empty interval).
             /// </para>
             /// </remarks>
@@ -295,7 +295,7 @@ namespace NodaTime
             [NotNull]
             internal static DateInterval Normalize([NotNull] DateInterval obj)
             {
-                return obj.Inclusive || obj.Length == 0 ? obj : new DateInterval(obj.Start, obj.End.PlusDays(-1), true);
+                return obj.EndInclusive || obj.Length == 0 ? obj : new DateInterval(obj.Start, obj.End.PlusDays(-1), true);
             }
         }
 
@@ -328,7 +328,7 @@ namespace NodaTime
                 Normalize(Preconditions.CheckNotNull(obj, nameof(obj))).GetHashCode();
 
             /// <summary>
-            /// Returns a normalized version of this interval, by converting non-empty exclusive intervals to inclusive
+            /// Returns a normalized version of this interval, by converting non-empty exclusive intervals to end-inclusive
             /// ones, and canonicalizing empty intervals to the same start date.
             /// </summary>
             /// <returns>The normalized interval.</returns>


### PR DESCRIPTION
This improves clarity - the property *could* still be removed
if #2 is resolved to make all date intervals inclusive.