### PR TITLE
Increase the number of bits available to months

### DIFF
--- a/src/NodaTime.Test/YearMonthDayCalendarTest.cs
+++ b/src/NodaTime.Test/YearMonthDayCalendarTest.cs
@@ -25,8 +25,8 @@ namespace NodaTime.Test
         [Test]
         public void AllMonths()
         {
-            // We'll never actually need 16 months, but we support that many...
-            for (int month = 1; month <= 16; month++)
+            // We'll never actually need 32 months, but we support that many...
+            for (int month = 1; month <= 32; month++)
             {
                 var ymdc = new YearMonthDayCalendar(-123, month, 20, CalendarOrdinal.HebrewCivil);
                 Assert.AreEqual(-123, ymdc.Year);
@@ -53,12 +53,12 @@ namespace NodaTime.Test
         [Test]
         public void AllCalendars()
         {
-            for (int ordinal = 0; ordinal < 128; ordinal++)
+            for (int ordinal = 0; ordinal < 64; ordinal++)
             {
                 CalendarOrdinal calendar = (CalendarOrdinal) ordinal;
-                var ymdc = new YearMonthDayCalendar(-123, 12, 64, calendar);
+                var ymdc = new YearMonthDayCalendar(-123, 30, 64, calendar);
                 Assert.AreEqual(-123, ymdc.Year);
-                Assert.AreEqual(12, ymdc.Month);
+                Assert.AreEqual(30, ymdc.Month);
                 Assert.AreEqual(64, ymdc.Day);
                 Assert.AreEqual(calendar, ymdc.CalendarOrdinal);
             }

--- a/src/NodaTime.Test/YearMonthDayTest.cs
+++ b/src/NodaTime.Test/YearMonthDayTest.cs
@@ -24,8 +24,8 @@ namespace NodaTime.Test
         [Test]
         public void AllMonths()
         {
-            // We'll never actually need 16 months, but we support that many...
-            for (int month = 1; month < 16; month++)
+            // We'll never actually need 32 months, but we support that many...
+            for (int month = 1; month < 32; month++)
             {
                 var ymd = new YearMonthDay(-123, month, 20);
                 Assert.AreEqual(-123, ymd.Year);
@@ -40,9 +40,9 @@ namespace NodaTime.Test
             // We'll never actually need 64 days, but we support that many...
             for (int day = 1; day < 64; day++)
             {
-                var ymd = new YearMonthDay(-123, 12, day);
+                var ymd = new YearMonthDay(-123, 30, day);
                 Assert.AreEqual(-123, ymd.Year);
-                Assert.AreEqual(12, ymd.Month);
+                Assert.AreEqual(30, ymd.Month);
                 Assert.AreEqual(day, ymd.Day);
             }
         }

--- a/src/NodaTime/YearMonthDayCalendar.cs
+++ b/src/NodaTime/YearMonthDayCalendar.cs
@@ -12,9 +12,9 @@ namespace NodaTime
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The calendar is represented in bits 0-6.
-    /// The day is represented in bits 7-12.
-    /// The month is represented in bits 13-16.
+    /// The calendar is represented in bits 0-5.
+    /// The day is represented in bits 6-11.
+    /// The month is represented in bits 12-16.
     /// The year is represented in bits 17-31. (It's convenient to put this at the top as it can be negative.)
     /// 
     /// This type does not implement IComparable[YearMonthDayCalendar] as it turns out it doesn't need to:
@@ -32,10 +32,11 @@ namespace NodaTime
     /// </remarks>
     internal struct YearMonthDayCalendar : IEquatable<YearMonthDayCalendar>
     {
-        private const int CalendarBits = 7; // Up to 128 calendars.
-        private const int DayBits = 6;   // Up to 64 days in a month.
-        private const int MonthBits = 4; // Up to 16 months per year.
-        private const int YearBits = 15; // 32K range; only need -10K to +10K.
+        // These constants are internal so they can be used in YearMonthDay
+        internal const int CalendarBits = 6; // Up to 64 calendars.
+        internal const int DayBits = 6;   // Up to 64 days in a month.
+        internal const int MonthBits = 5; // Up to 32 months per year.
+        internal const int YearBits = 15; // 32K range; only need -10K to +10K.
 
         // Just handy constants to use for shifting and masking.
         private const int CalendarDayBits = CalendarBits + DayBits;
@@ -77,6 +78,10 @@ namespace NodaTime
         internal int Month => unchecked(((value & MonthMask) >> CalendarDayBits) + 1);
         internal int Day => unchecked(((value & DayMask) >> CalendarBits) + 1);
 
+        /// <summary>
+        /// The underlying value, which can be used for serialization and hash codes,
+        /// but should not otherwise be exposed publicly.
+        /// </summary>
         public int RawValue => value;
 
         // Just for testing purposes...


### PR DESCRIPTION
We now support months in the range [1, 32]. This is
necessary for the Wondrous calendar which has 19 months.

I've taken the extra bit from the calendar range, so we can now "only"
support 64 calendars... but we've only got 18 at the moment, and the
Wondrous calendar will be the 19th. I think that's safe.

This needs to be done before 2.0 as it affects the serialization
format.

// cc @glittle