### PR TITLE
Change serialization format of year/month/day/calendar

### DIFF
--- a/src/NodaTime/AnnualDate.cs
+++ b/src/NodaTime/AnnualDate.cs
@@ -102,10 +102,7 @@ namespace NodaTime
         /// Returns a hash code for this annual date.
         /// </summary>
         /// <returns>A hash code for this annual date.</returns>
-        public override int GetHashCode()
-        {
-            return value.RawValue;
-        }
+        public override int GetHashCode() => value.GetHashCode();
 
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.

--- a/src/NodaTime/BinaryFormattingConstants.cs
+++ b/src/NodaTime/BinaryFormattingConstants.cs
@@ -16,7 +16,10 @@ namespace NodaTime
     {
         // LocalDate
         // Used as part of LocalDateTime, OffsetDateTime, ZonedDateTime
-        internal const string YearMonthDayCalendarSerializationName = "yearMonthDayCalendar";
+        internal const string YearSerializationName = "year";
+        internal const string MonthSerializationName = "month";
+        internal const string DaySerializationName = "day";
+        internal const string CalendarSerializationName = "calendar";
 
         // LocalTime
         // Used as part of LocalDateTime, OffsetDateTime, ZonedDateTime

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -788,18 +788,21 @@ namespace NodaTime
         internal LocalDate([NotNull] SerializationInfo info)
         {
             Preconditions.CheckNotNull(info, nameof(info));
-            yearMonthDayCalendar = new YearMonthDayCalendar(info.GetInt32(BinaryFormattingConstants.YearMonthDayCalendarSerializationName));
+            int year = info.GetInt32(BinaryFormattingConstants.YearSerializationName);
+            int month = info.GetInt32(BinaryFormattingConstants.MonthSerializationName);
+            int day = info.GetInt32(BinaryFormattingConstants.DaySerializationName);
+            CalendarOrdinal ordinal = (CalendarOrdinal) info.GetInt32(BinaryFormattingConstants.CalendarSerializationName);
             try
             {
-                var ordinal = yearMonthDayCalendar.CalendarOrdinal;
                 Preconditions.CheckArgument(ordinal >= 0 && ordinal < CalendarOrdinal.Size, nameof(ordinal), "Calendar ordinal out of range");
                 var calendar = CalendarSystem.ForOrdinal(ordinal);
-                calendar.ValidateYearMonthDay(yearMonthDayCalendar.Year, yearMonthDayCalendar.Month, yearMonthDayCalendar.Day);
+                calendar.ValidateYearMonthDay(year, month, day);
             }
             catch (Exception e)
             {
                 throw new ArgumentException("Invalid serialized data, details in InnerException", nameof(info), e);
             }
+            yearMonthDayCalendar = new YearMonthDayCalendar(year, month, day, ordinal);
         }
 
         /// <summary>
@@ -816,7 +819,10 @@ namespace NodaTime
         internal void Serialize([NotNull] SerializationInfo info)
         {
             Preconditions.CheckNotNull(info, nameof(info));
-            info.AddValue(BinaryFormattingConstants.YearMonthDayCalendarSerializationName, yearMonthDayCalendar.RawValue);
+            info.AddValue(BinaryFormattingConstants.YearSerializationName, Year);
+            info.AddValue(BinaryFormattingConstants.MonthSerializationName, Month);
+            info.AddValue(BinaryFormattingConstants.DaySerializationName, Day);
+            info.AddValue(BinaryFormattingConstants.CalendarSerializationName, yearMonthDayCalendar.CalendarOrdinal);
         }
         #endregion
 #endif

--- a/src/NodaTime/YearMonthDay.cs
+++ b/src/NodaTime/YearMonthDay.cs
@@ -52,13 +52,7 @@ namespace NodaTime
         internal int Year => unchecked((value >> (YearMonthDayCalendar.DayBits + YearMonthDayCalendar.MonthBits)) + 1);
         internal int Month => unchecked(((value & MonthMask) >> YearMonthDayCalendar.DayBits) + 1);
         internal int Day => unchecked((value & DayMask) + 1);
-
-        /// <summary>
-        /// The underlying value, which can be used for serialization and hash codes,
-        /// but should not otherwise be exposed publicly.
-        /// </summary>
-        public int RawValue => value;
-
+        
         // Just for testing purposes...
         internal static YearMonthDay Parse(string text)
         {

--- a/src/NodaTime/YearMonthDayCalendar.cs
+++ b/src/NodaTime/YearMonthDayCalendar.cs
@@ -78,12 +78,6 @@ namespace NodaTime
         internal int Month => unchecked(((value & MonthMask) >> CalendarDayBits) + 1);
         internal int Day => unchecked(((value & DayMask) >> CalendarBits) + 1);
 
-        /// <summary>
-        /// The underlying value, which can be used for serialization and hash codes,
-        /// but should not otherwise be exposed publicly.
-        /// </summary>
-        public int RawValue => value;
-
         // Just for testing purposes...
         [VisibleForTesting]
         internal static YearMonthDayCalendar Parse(string text)


### PR DESCRIPTION
This now hides the raw value format, which is nice.
Serialization will take up a bit more space, but be more flexible
to later implementation changes.

Fixes #679.