### PR TITLE
Remove explicit dependencies where possible

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
+++ b/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
@@ -23,14 +23,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Threading.Tasks" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
     <DefineConstants>$(DefineConstants);PCL</DefineConstants>
   </PropertyGroup>

--- a/src/NodaTime.Demo/NodaTime.Demo.csproj
+++ b/src/NodaTime.Demo/NodaTime.Demo.csproj
@@ -19,20 +19,8 @@
     <PackageReference Include="NUnitLite" Version="3.6.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Threading.Tasks" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
     <DefineConstants>$(DefineConstants);PCL</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="System.Console" Version="4.0.0" />
-  </ItemGroup>
 
 </Project>

--- a/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
+++ b/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
@@ -21,23 +21,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);PCL</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-  </ItemGroup>
 
 </Project>

--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -28,10 +28,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
-    <Reference Include="System.Runtime" />
-    <Reference Include="System.Threading.Tasks" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.0.11" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
@@ -40,11 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="System.Console" Version="4.0.0" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.0.1" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.0.11" />
-    <PackageReference Include="System.Reflection.Extensions" Version="4.0.1" />
-    <PackageReference Include="System.Xml.XDocument" Version="4.0.11" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.0.11" />
   </ItemGroup>
 
 </Project>

--- a/src/NodaTime.Testing/NodaTime.Testing.csproj
+++ b/src/NodaTime.Testing/NodaTime.Testing.csproj
@@ -20,11 +20,6 @@
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <DefineConstants>$(DefineConstants);PCL</DefineConstants>
   </PropertyGroup>

--- a/src/NodaTime.TzValidate.NodaDump/NodaTime.TzValidate.NodaDump.csproj
+++ b/src/NodaTime.TzValidate.NodaDump/NodaTime.TzValidate.NodaDump.csproj
@@ -14,8 +14,4 @@
     <ProjectReference Include="..\NodaTime.TzdbCompiler\NodaTime.TzdbCompiler.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.1.1" />
-  </ItemGroup>
-
 </Project>

--- a/src/NodaTime.TzValidate.NzdCompatibility/NodaTime.TzValidate.NzdCompatibility.csproj
+++ b/src/NodaTime.TzValidate.NzdCompatibility/NodaTime.TzValidate.NzdCompatibility.csproj
@@ -16,9 +16,4 @@
     <PackageReference Include="System.Net.Http" Version="4.1.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
 </Project>

--- a/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
+++ b/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
@@ -16,12 +16,8 @@
   <ItemGroup>
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
     <ProjectReference Include="..\NodaTime.TzdbCompiler\NodaTime.TzdbCompiler.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="NUnitLite" Version="3.6.1" />
-    <PackageReference Include="System.Xml.XDocument" Version="4.0.11" />
   </ItemGroup>
 
 </Project>

--- a/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
+++ b/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
@@ -18,9 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="SharpCompress" Version="0.14.1" />
     <PackageReference Include="System.Net.Http" Version="4.1.1" />
   </ItemGroup>

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -44,15 +44,7 @@
   </PropertyGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Diagnostics.Debug" Version="4.0.11" />
-    <PackageReference Include="System.Globalization" Version="4.0.11" />
-    <PackageReference Include="System.Linq" Version="4.1.0" />
-    <PackageReference Include="System.Resources.ResourceManager" Version="4.0.1" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.Numerics" Version="4.0.1" />
     <PackageReference Include="System.Runtime.Serialization.Xml" Version="4.1.1" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
-    <PackageReference Include="System.Xml.XmlSerializer" Version="4.0.11" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We basically rely on NETStandard.Library 1.6.1 as an atomic dependency unit.
See http://stackoverflow.com/questions/42946951 for background and great answers

Fixes #695.