### PR TITLE
Explicitly request deterministic builds

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
+++ b/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
@@ -10,6 +10,7 @@
     <PackageId>NodaTime.Benchmarks</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">1.1.1</RuntimeFrameworkVersion>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Demo/NodaTime.Demo.csproj
+++ b/src/NodaTime.Demo/NodaTime.Demo.csproj
@@ -8,6 +8,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet</PackageTargetFallback>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.NzdPrinter/NodaTime.NzdPrinter.csproj
+++ b/src/NodaTime.NzdPrinter/NodaTime.NzdPrinter.csproj
@@ -8,6 +8,7 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>NodaTime.NzdPrinter</PackageId>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
+++ b/src/NodaTime.Serialization.JsonNet/NodaTime.Serialization.JsonNet.csproj
@@ -17,6 +17,7 @@
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/nodatime/nodatime.git</RepositoryUrl>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Serialization.Test/NodaTime.Serialization.Test.csproj
+++ b/src/NodaTime.Serialization.Test/NodaTime.Serialization.Test.csproj
@@ -11,6 +11,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet</PackageTargetFallback>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -11,6 +11,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet</PackageTargetFallback>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Testing/NodaTime.Testing.csproj
+++ b/src/NodaTime.Testing/NodaTime.Testing.csproj
@@ -14,6 +14,7 @@
     <PackageTags>nodatime;testing</PackageTags>
     <PackageProjectUrl>http://nodatime.org/</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.TzValidate.NodaDump/NodaTime.TzValidate.NodaDump.csproj
+++ b/src/NodaTime.TzValidate.NodaDump/NodaTime.TzValidate.NodaDump.csproj
@@ -7,6 +7,7 @@
     <PackageId>NodaTime.TzValidate.NodaDump</PackageId>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;netcore45</PackageTargetFallback>
     <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.TzValidate.NzdCompatibility/NodaTime.TzValidate.NzdCompatibility.csproj
+++ b/src/NodaTime.TzValidate.NzdCompatibility/NodaTime.TzValidate.NzdCompatibility.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>NodaTime.TzValidate.NzdCompatibility</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>NodaTime.TzValidate.NzdCompatibility</PackageId>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
+++ b/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
@@ -11,6 +11,7 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;netcoreapp1.0;portable-net45+win8</PackageTargetFallback>
     <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
+++ b/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
@@ -10,6 +10,7 @@
     <PackageId>NodaTime.TzdbCompiler</PackageId>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50;netcore45</PackageTargetFallback>
     <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Web/NodaTime.Web.csproj
+++ b/src/NodaTime.Web/NodaTime.Web.csproj
@@ -8,6 +8,7 @@
     <PackageId>NodaTime.Web</PackageId>
     <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -18,6 +18,7 @@
     <RepositoryUrl>https://github.com/nodatime/nodatime.git</RepositoryUrl>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
+    <Deterministic>True</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This appears to be the default now anyway, but it's possible that
it's a weaker version, or not the default everywhere. No harm in
being explicit.

Fixes #359.