### PR TITLE
"Handle" Feb 29th rules more cleanly

### DIFF
--- a/src/NodaTime.Test/TimeZones/ZoneYearOffsetTest.cs
+++ b/src/NodaTime.Test/TimeZones/ZoneYearOffsetTest.cs
@@ -166,7 +166,9 @@ namespace NodaTime.Test.TimeZones
         public void GetOccurrenceForYear_ExactlyFeb29th_NotLeapYear()
         {
             ZoneYearOffset offset = new ZoneYearOffset(TransitionMode.Utc, 2, 29, 0, false, LocalTime.Midnight);
-            Assert.Throws<InvalidOperationException>(() => offset.GetOccurrenceForYear(2013));
+            var actual = offset.GetOccurrenceForYear(2013);
+            var expected = new LocalDateTime(2013, 2, 28, 0, 0).ToLocalInstant(); // For "exact", go to Feb 28th
+            Assert.AreEqual(expected, actual);
         }
 
         [Test]
@@ -182,7 +184,9 @@ namespace NodaTime.Test.TimeZones
         public void GetOccurrenceForYear_AtLeastFeb29th_NotLeapYear()
         {
             ZoneYearOffset offset = new ZoneYearOffset(TransitionMode.Utc, 2, 29, (int) IsoDayOfWeek.Sunday, true, LocalTime.Midnight);
-            Assert.Throws<InvalidOperationException>(() => offset.GetOccurrenceForYear(2013));
+            var actual = offset.GetOccurrenceForYear(2013);
+            var expected = new LocalDateTime(2013, 3, 3, 0, 0).ToLocalInstant(); // March 3rd is the first Sunday after the non-existent 2013-02-29
+            Assert.AreEqual(expected, actual);
         }
 
         [Test]

--- a/src/NodaTime/TimeZones/ZoneYearOffset.cs
+++ b/src/NodaTime/TimeZones/ZoneYearOffset.cs
@@ -193,11 +193,11 @@ namespace NodaTime.TimeZones
                 int actualDayOfMonth = dayOfMonth > 0 ? dayOfMonth : CalendarSystem.Iso.GetDaysInMonth(year, monthOfYear) + dayOfMonth + 1;
                 if (monthOfYear == 2 && dayOfMonth == 29 && !CalendarSystem.Iso.IsLeapYear(year))
                 {
-                    // This mirrors zic.c. It's an odd rule, but...
-                    if (dayOfWeek == 0 || AdvanceDayOfWeek)
-                    {
-                        throw new InvalidOperationException("Requested transition for a ZoneYearOffset of February 29th in a non-leap year, not moving backwards to find a day-of-week");
-                    }
+                    // In zic.c, this would result in an error if dayOfWeek is 0 or AdvanceDayOfWeek is true.
+                    // However, it's very convenient to be able to ask any rule for its occurrence in any year.
+                    // We rely on genuine rules being well-written - and before releasing an nzd file we always
+                    // check that it's in line with zic anyway. Ignoring the brokenness is simpler than fixing
+                    // rules that are only in force for a single year.
                     actualDayOfMonth = 28; // We'll now look backwards for the right day-of-week.
                 }
                 LocalDate date = new LocalDate(year, monthOfYear, actualDayOfMonth);


### PR DESCRIPTION
Previously, we were following zic: if a rule says "exactly Feb 29th"
or "at least Feb 29th" it was invalid in a non-leap year. This is
painful due to the way we ask rules for transitions; it's simpler to
ignore the rule, and just treat Feb 29th as Feb 28th in non-leap
years.

It shouldn't make any different to validly-defined rules in TZDB,
although it does make us more lenient with badly-defined fules.
Importantly, it allows us to handle some valid BCL rules.

Fixes #743.