### PR TITLE
More Mono-specific test ignoring (missed before)

### DIFF
--- a/src/NodaTime.Test/Text/Cultures.cs
+++ b/src/NodaTime.Test/Text/Cultures.cs
@@ -95,11 +95,6 @@ namespace NodaTime.Test.Text
             .Where(culture => !MonthNamesCompareEqual(culture))
             .Select(CultureInfo.ReadOnly)
             .ToList();
-        // Some tests don't run nicely on Mono, e.g. as they have characters we don't expect in their long/short patterns.
-        // Pretend we have no real cultures, for the sake of these tests. Having no entries in this test source causes
-        // some test runners to panic though, so we have a single null value, which should cause tests to just pass. Sigh.
-        // TODO: Make the tests pass instead?
-        internal static readonly IEnumerable<CultureInfo> AllCulturesOrOneNullOnMono = TestHelper.IsRunningOnMono ? new CultureInfo[1] : Cultures.AllCultures;
 
         internal static readonly CultureInfo Invariant = CultureInfo.InvariantCulture;
         // Specify en-US patterns explicitly, as .NET Core on Linux gives a different answer. We

--- a/src/NodaTime.Test/Text/LocalTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalTimePatternTest.cs
@@ -311,9 +311,8 @@ namespace NodaTime.Test.Text
             return CultureInfo.ReadOnly(clone);
         }
 
-        // Fails on Mono: https://github.com/nodatime/nodatime/issues/98
         [Test]
-        [TestCaseSource(typeof(Cultures), nameof(Cultures.AllCulturesOrOneNullOnMono))]
+        [TestCaseSource(typeof(Cultures), nameof(Cultures.AllCultures))]
         public void BclLongTimePatternIsValidNodaPattern(CultureInfo culture)
         {
             if (culture == null)


### PR DESCRIPTION
Passes on Mono on both Linux and Windows.