### PR TITLE
Fix website links

### DIFF
--- a/src/NodaTime.Web/Markdown/1.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/concepts.md
@@ -197,7 +197,7 @@ but they're still available within periods. [`Period`][Period] is used for arith
 See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
-[2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
+[2]: https://blogs.msdn.microsoft.com/bclteam/2007/06/18/a-brief-history-of-datetime-anthony-moore/
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime

--- a/src/NodaTime.Web/Markdown/1.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/concepts.md
@@ -203,14 +203,14 @@ See the [arithmetic](arithmetic) page for more information.
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime
 [Instant]: noda-type://NodaTime.Instant
 [CalendarSystem]: noda-type://NodaTime.CalendarSystem
-[UTC]: http://en.wikipedia.org/wiki/Coordinated_Universal_Time
+[UTC]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
 [DateTimeZone]: noda-type://NodaTime.DateTimeZone
 [Offset]: noda-type://NodaTime.Offset
 [Period]: noda-type://NodaTime.Period
 [Duration]: noda-type://NodaTime.Duration
 [OffsetDateTime]: noda-type://NodaTime.OffsetDateTime
 [ZonedDateTime]: noda-type://NodaTime.ZonedDateTime
-[TZDB]: http://www.iana.org/time-zones
+[TZDB]: https://www.iana.org/time-zones
 [IDateTimeZoneProvider]: noda-type://NodaTime.IDateTimeZoneProvider
 [DateTimeZoneProviders]: noda-type://NodaTime.DateTimeZoneProviders
-[TimeSpan]: http://msdn.microsoft.com/en-us/library/system.timespan.aspx
+[TimeSpan]: https://msdn.microsoft.com/en-us/library/system.timespan.aspx

--- a/src/NodaTime.Web/Markdown/1.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/concepts.md
@@ -196,7 +196,7 @@ but they're still available within periods. [`Period`][Period] is used for arith
 
 See the [arithmetic](arithmetic) page for more information.
 
-[api]: ../api/NodaTime.html
+[api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/1.0.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/core-types.md
@@ -84,7 +84,7 @@ January.
 IClock
 ------
 
-An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing.html), this is defined
+An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing), this is defined
 as an interface; in a production deployment you're likely to use the [`SystemClock`][SystemClock] singleton implementation.
 
 Interval

--- a/src/NodaTime.Web/Markdown/1.0.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/core-types.md
@@ -93,7 +93,7 @@ Interval
 An [`Interval`][Interval] is simply two instants - a start and an end. The interval includes the start, and excludes the end, which means that if you have abutting intervals any instant will be in
 exactly one of those intervals.
 
-[DST]: http://en.wikipedia.org/wiki/Daylight_saving_time
+[DST]: https://en.wikipedia.org/wiki/Daylight_saving_time
 [Interval]: noda-type://NodaTime.Interval
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/1.0.x/design.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/design.md
@@ -104,5 +104,5 @@ similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
 [2]: http://semver.org/
-[3]: http://www.joda.org/joda-time
+[3]: http://www.joda.org/joda-time/
 [4]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/1.0.x/design.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/design.md
@@ -58,7 +58,7 @@ developers want. However, we do *not* default to using the system
 time zone, or using "now" as a default date/time value, or using
 the current thread's current format provider for parsing and
 formatting (except for the BCL-compatible method calls; see [text
-handling][5] for more information on this).
+handling](text) for more information on this).
   We make it easy to do all of these things, but they're just not
 appropriate as implicit defaults. It's too easy to *accidentally*
 depend on the time zone your system happens to be running in (etc)
@@ -67,7 +67,7 @@ without anything obvious in your code.
 What this means in practice
 ---------------------------
 
-- There are rather more types and [concepts][1] to learn about in
+- There are rather more types and [concepts](concepts) to learn about in
 Noda Time than in .NET. One of the *problems* with .NET's date and
 time API is that `DateTime` doesn't have a single well-defined
 meaning.
@@ -80,7 +80,7 @@ LocalDateTime()` or `default(LocalDateTime)`) is *not* a useful
 value. This is unfortunate, but hard to avoid.
 
 - All the value types and almost all the reference types are
-immutable and [thread-safe](threading.html). We expect objects like calendars, time
+immutable and [thread-safe](threading). We expect objects like calendars, time
 zones, and patterns for formatting and parsing text to be reused
 freely between many threads. Occasionally there's hidden mutability
 in terms of caches, but this should not affect you, the user. We make sure it
@@ -103,8 +103,6 @@ requirements, chances are someone else will want to do something
 similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
-[1]: concepts.html
 [2]: http://semver.org/
 [3]: http://www.joda.org/joda-time
 [4]: https://groups.google.com/group/noda-time
-[5]: text.html

--- a/src/NodaTime.Web/Markdown/1.0.x/index.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/index.md
@@ -25,5 +25,5 @@ Resources
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com/
-[so-tag]: http://stackoverflow.com/questions/tagged/nodatime
+[so]: https://stackoverflow.com/
+[so-tag]: https://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/1.0.x/index.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/index.md
@@ -20,10 +20,10 @@ Resources
 - [Blog][blog]
 - [Mailing list][group]
 
-[blog]: http://blog.nodatime.org
+[blog]: http://blog.nodatime.org/
 [group]: https://groups.google.com/group/noda-time
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com
+[so]: http://stackoverflow.com/
 [so-tag]: http://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/1.0.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/installation.md
@@ -1,10 +1,10 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org/) with
+Our primary distribution channel is [NuGet](https://www.nuget.org/) with
 two packages:
 
-- [NodaTime](http://nuget.org/packages/NodaTime)
-- [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing)
+- [NodaTime](https://www.nuget.org/packages/NodaTime)
+- [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing)
 
 Alternatively, source and binary downloads are available on the
 [project download page][downloads].

--- a/src/NodaTime.Web/Markdown/1.0.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/installation.md
@@ -12,7 +12,7 @@ Alternatively, source and binary downloads are available on the
 [downloads]: /downloads/
 
 An experimental assembly to support Json.NET is also available (in source form
-only); see the [serialization guide](serialization.html) for more information.
+only); see the [serialization guide](serialization) for more information.
 
 See the ["Building and testing"][building] section in the developer guide for
 instructions on building Noda Time from source.
@@ -23,7 +23,7 @@ System requirements
 -------------------
 
 Currently Noda Time requires .NET 3.5 (client profile). It supports
-Mono ([with some caveats](mono.html)) but does *not* support
+Mono ([with some caveats](mono)) but does *not* support
 Silverlight (or, by extension, Windows Phone 7). We'd like to
 support these in the future, but it will involve a non-trivial
 amount of work. The same goes for creating a Portable Class Library project,
@@ -33,9 +33,9 @@ Package contents and getting started
 ------------------------------------
 
 Everything you need to *use* Noda Time is contained in the NodaTime package. The NodaTime.Testing package is designed
-for testing code which uses Noda Time. See the [testing guide](testing.html) for more information. It is expected
+for testing code which uses Noda Time. See the [testing guide](testing) for more information. It is expected
 that production code will only refer to the `NodaTime.dll` assembly, and that's all that's required at execution time.
-This assembly includes the [TZDB database](tzdb.html) as an embedded resource.
+This assembly includes the [TZDB database](tzdb) as an embedded resource.
 
 Everything within the NodaTime assembly is in the NodaTime namespace or a "child" namespace. After adding a reference to
 the main assembly (either directly via the file system or with NuGet) and including an appropriate `using` directive, you should

--- a/src/NodaTime.Web/Markdown/1.0.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/installation.md
@@ -1,6 +1,6 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org) with
+Our primary distribution channel is [NuGet](http://nuget.org/) with
 two packages:
 
 - [NodaTime](http://nuget.org/packages/NodaTime)

--- a/src/NodaTime.Web/Markdown/1.0.x/instant-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/instant-patterns.md
@@ -24,6 +24,6 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns.html).
+[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns).
 The pattern allows the culture to be specified, but *always* uses the ISO-8601 calendar, and *always* uses the UTC
 time zone. The "template value" is always the unix epoch.

--- a/src/NodaTime.Web/Markdown/1.0.x/limitations.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/limitations.md
@@ -38,7 +38,7 @@ hot-fixes for cultures which we don't support as well as we might.
 More time zone information
 ==========================
 
-[CLDR](http://cldr.unicode.org) provides useful information about
+[CLDR](http://cldr.unicode.org/) provides useful information about
 time zones such as a canonical ID and user-friendly representations
 (countries and sample cities). We'd also like to make it clearer
 when one zoneinfo time zone is an alias for another.

--- a/src/NodaTime.Web/Markdown/1.0.x/limitations.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/limitations.md
@@ -52,7 +52,7 @@ highest priority is probably an adapter for the BCL calendars.
 Smarter arithmetic
 ==================
 
-As noted in the [arithmetic guide](arithmetic.html), arithmetic using
+As noted in the [arithmetic guide](arithmetic), arithmetic using
 [`Period`](noda-type://NodaTime.Period) is pretty simplistic. We may
 want something smarter, probably to go alongside the "dumb but
 predictable" existing logic. This will definitely be driven by real

--- a/src/NodaTime.Web/Markdown/1.0.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/localdate-patterns.md
@@ -18,7 +18,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom offset pattern characters are supported for local dates. See [custom pattern notes](text.html#custom-patterns)
+The following custom offset pattern characters are supported for local dates. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 For the meanings of "absolute" years and text handling, see later details.

--- a/src/NodaTime.Web/Markdown/1.0.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/localdate-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `d`: Short format pattern.  
-  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
+  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
   For example, in the invariant culture this is "MM/dd/yyyy".
 
 - `D`: Long format pattern.  
-  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
+  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
   For example, in the invariant culture this is "dddd, dd MMMM yyyy".
 
 Custom Patterns

--- a/src/NodaTime.Web/Markdown/1.0.x/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/localdatetime-patterns.md
@@ -14,17 +14,17 @@ The following standard patterns are supported:
 
 - `s`: The sortable pattern, which is always "yyyy'-'MM'-'dd'T'HH':'mm':'ss" using the invariant culture.
 
-- `f`: The culture's [long date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `f`: The culture's [long date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
+- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
   For example, in the invariant culture this is "dddd, dd MMMM yyyy HH:mm:ss".
 
-- `g`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `g`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `G`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [long time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
+- `G`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [long time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
 
 Custom Patterns
 ---------------

--- a/src/NodaTime.Web/Markdown/1.0.x/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/localdatetime-patterns.md
@@ -29,5 +29,5 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The custom format patterns for local date and time are provided by combining the [custom patterns for `LocalDate`](localdate-patterns.html) with
-the [custom patterns for `LocalTime`](localtime-patterns.html). The result is simply the combination of the date and the time.
+The custom format patterns for local date and time are provided by combining the [custom patterns for `LocalDate`](localdate-patterns) with
+the [custom patterns for `LocalTime`](localtime-patterns). The result is simply the combination of the date and the time.

--- a/src/NodaTime.Web/Markdown/1.0.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/localtime-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `t`: Short format pattern.  
-  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx) 
+  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx) 
   For example, in the invariant culture this is "HH:mm".
 
 - `T`: Long format pattern.  
-  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx) 
+  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx) 
   For example, in the invariant culture this is "HH:mm:ss".
 
 - `r`: Round-trip pattern.  

--- a/src/NodaTime.Web/Markdown/1.0.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/localtime-patterns.md
@@ -21,7 +21,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom offset pattern characters are supported for local times. See [custom pattern notes](text.html#custom-patterns)
+The following custom offset pattern characters are supported for local times. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/1.0.x/mono.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com) is an open source implementation of
+[Mono](http://mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/1.0.x/mono.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com/) is an open source implementation of
+[Mono](http://www.mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/1.0.x/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/offset-patterns.md
@@ -26,7 +26,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom offset pattern characters are supported for local times. See [custom pattern notes](text.html#custom-patterns)
+The following custom offset pattern characters are supported for local times. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/1.0.x/rationale.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/rationale.md
@@ -28,5 +28,5 @@ a new date/time API, the Noda Time team would happily go into
 retirement (other than for the sake of those forced to stick with
 earlier versions of .NET, of course).
 
-[1]: http://www.joda.org/joda-time
+[1]: http://www.joda.org/joda-time/
 [2]: http://blog.nodatime.org/2011/08/what-wrong-with-datetime-anyway.html

--- a/src/NodaTime.Web/Markdown/1.0.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/serialization.md
@@ -7,7 +7,7 @@ serialization are supported, they will be included within the main Noda Time ass
 Json.NET: NodaTime.Serialization.JsonNet
 ----------------------------------------
 
-[Json.NET](http://json.net) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
+[Json.NET](http://json.net/) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
 of the same name.
 
 An extension method of `ConfigureForNodaTime` is provided on both `JsonSerializer` and

--- a/src/NodaTime.Web/Markdown/1.0.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/serialization.md
@@ -11,10 +11,10 @@ Json.NET: NodaTime.Serialization.JsonNet
 of the same name.
 
 An extension method of `ConfigureForNodaTime` is provided on both `JsonSerializer` and
-`JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields
+`JsonSerializerSettings`. Alternatively, the `NodaConverters` type provides public static read-only fields
 for individual converters. (All converters are immutable.)
 
-Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter-1).
+Custom converters can be created easily from patterns using `NodaPatternConverter`.
 
 Supported types and default representations
 ===========================================

--- a/src/NodaTime.Web/Markdown/1.0.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/serialization.md
@@ -14,7 +14,7 @@ An extension method of `ConfigureForNodaTime` is provided on both `JsonSerialize
 `JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields
 for individual converters. (All converters are immutable.)
 
-Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter_1).
+Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter-1).
 
 Supported types and default representations
 ===========================================

--- a/src/NodaTime.Web/Markdown/1.0.x/testing.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/testing.md
@@ -6,7 +6,7 @@ which *uses* Noda Time.
 NodaTime.Testing
 ----------------
 
-Firstly, get hold of the [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
+Firstly, get hold of the [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
 small, but it will no doubt grow - and it will make your life much easier. The purpose of the assembly is to provide
 easy-to-use test doubles which can be used instead of the real implementations.
 

--- a/src/NodaTime.Web/Markdown/1.0.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/text.md
@@ -34,10 +34,10 @@ information or other options.
 Each core Noda type has its own pattern type such as
 [`OffsetPattern`](noda-type://NodaTime.Text.OffsetPattern). All
 these patterns implement the
-[`IPattern<T>`](noda-type://NodaTime.Text.IPattern_1) interface,
+[`IPattern<T>`](noda-type://NodaTime.Text.IPattern-1) interface,
 which has simple `Format` and `Parse` methods taking just the value
 and text respectively. The result of `Parse` is a
-[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult_1) which
+[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult-1) which
 encapsulates both success and failure results.
 
 The BCL-based API

--- a/src/NodaTime.Web/Markdown/1.0.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/text.md
@@ -129,7 +129,7 @@ recommend** that you quote any text literals, to avoid nasty
 surprises if extra characters take on special meanings in later
 versions.
 
-  [2]: http://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
+  [2]: https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
   [3]: noda-ns://NodaTime.Text
   [4]: noda-type://NodaTime.LocalDateTime
   [5]: noda-type://NodaTime.Instant

--- a/src/NodaTime.Web/Markdown/1.0.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/text.md
@@ -61,12 +61,12 @@ available patterns are as consistent as possible within reason, but
 documenting each separately avoids confusion with some field
 specifiers being available for some types but not others.
 
-- [Offset patterns](offset-patterns.html)
-- [Instant patterns](instant-patterns.html)
-- [LocalTime patterns](localtime-patterns.html)
-- [LocalDate patterns](localdate-patterns.html)
-- [LocalDateTime patterns](localdatetime-patterns.html)
-- [Period patterns](period-patterns.html)
+- [Offset patterns](offset-patterns)
+- [Instant patterns](instant-patterns)
+- [LocalTime patterns](localtime-patterns)
+- [LocalDate patterns](localdate-patterns)
+- [LocalDateTime patterns](localdatetime-patterns)
+- [Period patterns](period-patterns)
 
 Note that at present, `ZonedDateTime`, `OffsetDateTime` and `Duration` do not support
 any form of parsing or user-specified formatting.

--- a/src/NodaTime.Web/Markdown/1.0.x/threading.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/threading.md
@@ -62,6 +62,6 @@ Enums
 Enums should generally be treated as immutable value types. Accessing the enum values directly can *never* have any nasty effects,
 but be careful around using a writable field of an enum type, for the same reasons as given in the earlier discussion.
 
-[lippert]: http://blogs.msdn.com/b/ericlippert/archive/2009/10/19/what-is-this-thing-you-call-thread-safe.aspx
-[immutability]: http://blogs.msdn.com/b/ericlippert/archive/tags/immutability/
+[lippert]: https://blogs.msdn.microsoft.com/ericlippert/2009/10/19/what-is-this-thing-you-call-thread-safe/
+[immutability]: https://blogs.msdn.microsoft.com/ericlippert/tag/immutability/
 [mailing list]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/1.0.x/type-choices.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/type-choices.md
@@ -1,7 +1,7 @@
 @Title="Choosing (and convering) between types"
 
 This is a companion page to the
-["core concepts quick reference"](concepts.html), and ["core types"](core-types.html)
+["core concepts quick reference"](concepts), and ["core types"](core-types)
 pages, describing when it's appropriate to use which type, and how to convert between them.
 
 Ultimately, you should be thinking about what data you really have,
@@ -155,5 +155,5 @@ as they're generally very straightforward.)
 Most of these are pretty simple, but a few are worth calling out
 specifically. The biggest "gotcha" is converting `LocalDateTime` to
 `ZonedDateTime` - it has some corner cases you need to consider. See the ["times zones" section of
-the core concepts guide](concepts.html#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
+the core concepts guide](concepts#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
 for more information.

--- a/src/NodaTime.Web/Markdown/1.0.x/tzdb.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/tzdb.md
@@ -29,7 +29,7 @@ Steps
 3. Ideally, rename the directory to match the version number, e.g. "2012c". The directory name will be used in the version ID
    reported by the time zone provider later.
 4. Find the Windows mapping file you want to use. Currently, I'd recommend using the version supplied with the Noda Time source
-   in ZoneInfoCompiler\Data\winmap in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org).
+   in ZoneInfoCompiler\Data\winmap in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org/).
 5. Run ZoneInfoCompiler. I'd suggest leaving it in its build directory and running it like this:
 
 ```bat

--- a/src/NodaTime.Web/Markdown/1.0.x/tzdb.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/tzdb.md
@@ -1,6 +1,6 @@
 @Title="Updating the time zone database"
 
-Noda Time comes with a version of the [tzdb](http://www.iana.org/time-zones) (aka zoneinfo) database, which is
+Noda Time comes with a version of the [tzdb](https://www.iana.org/time-zones) (aka zoneinfo) database, which is
 now hosted by IANA. This database changes over time, as countries decide to change their time zone rules.
 As new versions of Noda Time are released, the version of tzdb will be updated. However, you may wish to use
 a new version of tzdb *without* changing which version of Noda Time you're using. This documentation tells you how
@@ -22,7 +22,7 @@ number) and building the whole solution. You'll end up with binaries in ZoneInfo
 Steps
 =====
 
-1. Download the [latest tzdb release](http://www.iana.org/time-zones)
+1. Download the [latest tzdb release](https://www.iana.org/time-zones)
 2. Unpack the tar.gz file - you may need to download extra tools for this; [7-Zip](http://www.7-zip.org/) can cope with .tar.gz
    files for example, and I'd expect other zip tools to do so too. You should end up with a directory containing files such
    as "america", "africa", "etcetera".
@@ -52,7 +52,7 @@ Typically you'll want to use the newly-created resource file as the default time
 While it's possible to have multiple time zone providers in play at a time, that's a very rare scenario. Using a resource
 file is relatively straightforward:
 
-- Create a [`ResourceSet`](http://msdn.microsoft.com/en-us/library/t15hy0dt.aspx) from the file
+- Create a [`ResourceSet`](https://msdn.microsoft.com/en-us/library/t15hy0dt.aspx) from the file
 - Create a [`TzdbDateTimeZoneSource`][TzdbDateTimeZoneSource] with the `ResourceSet`
 - Create [`DateTimeZoneCache`][DateTimeZoneCache] with the source 
 - Use that cache (usually by way of dependency injection as an `IDateTimeZoneProvider`) wherever you need time zone information

--- a/src/NodaTime.Web/Markdown/1.1.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/concepts.md
@@ -1,7 +1,7 @@
 @Title="Core concepts"
 
 This is a companion page to the
-["core types quick reference"](core-types.html), and ["choosing between types"](type-choices.html)
+["core types quick reference"](core-types), and ["choosing between types"](type-choices)
 pages, describing the fundamental concepts in Noda Time.
 
 One of the benefits of Noda Time over the Base Class Library (BCL)
@@ -20,7 +20,7 @@ date and time data for your whole project.
 This document introduces the core concepts, but in order to avoid it
 being too overwhelming, we won't go into the fine details. See
 individual pages (particularly the ["choosing between
-types"](type-choices.html) page) and the [API documentation][api]
+types"](type-choices) page) and the [API documentation][api]
 for more information.
 
 "Local" and "global" (or "absolute") types
@@ -168,7 +168,7 @@ There are various different sources of time zone information available, and Noda
 handles two of them: it is able to map BCL `TimeZoneInfo` objects using `BclDateTimeZone`,
 and the [TZDB][TZDB] (aka Olson) database. A version of TZDB is embedded within the Noda Time
 distribution, and if you need a more recent one, there are [instructions on how to download and
-use new data](tzdb.html). We generally recommend that you isolate yourself from the provider you're
+use new data](tzdb). We generally recommend that you isolate yourself from the provider you're
 using by only depending on [`IDateTimeZoneProvider`][IDateTimeZoneProvider], and injecting the appropriate
 provider in the normal way. "Stock" providers are available via the [`DateTimeZoneProviders`][DateTimeZoneProviders]
 class.
@@ -194,7 +194,7 @@ year or not. Periods based on smaller units (hours, minutes and so on) will alwa
 but they're still available within periods. [`Period`][Period] is used for arithmetic on locally-based values (`LocalDateTime`,
 `LocalDate`, `LocalTime`).
 
-See the [arithmetic](arithmetic.html) page for more information.
+See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx

--- a/src/NodaTime.Web/Markdown/1.1.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/concepts.md
@@ -197,7 +197,7 @@ but they're still available within periods. [`Period`][Period] is used for arith
 See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
-[2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
+[2]: https://blogs.msdn.microsoft.com/bclteam/2007/06/18/a-brief-history-of-datetime-anthony-moore/
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime

--- a/src/NodaTime.Web/Markdown/1.1.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/concepts.md
@@ -203,14 +203,14 @@ See the [arithmetic](arithmetic) page for more information.
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime
 [Instant]: noda-type://NodaTime.Instant
 [CalendarSystem]: noda-type://NodaTime.CalendarSystem
-[UTC]: http://en.wikipedia.org/wiki/Coordinated_Universal_Time
+[UTC]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
 [DateTimeZone]: noda-type://NodaTime.DateTimeZone
 [Offset]: noda-type://NodaTime.Offset
 [Period]: noda-type://NodaTime.Period
 [Duration]: noda-type://NodaTime.Duration
 [OffsetDateTime]: noda-type://NodaTime.OffsetDateTime
 [ZonedDateTime]: noda-type://NodaTime.ZonedDateTime
-[TZDB]: http://www.iana.org/time-zones
+[TZDB]: https://www.iana.org/time-zones
 [IDateTimeZoneProvider]: noda-type://NodaTime.IDateTimeZoneProvider
 [DateTimeZoneProviders]: noda-type://NodaTime.DateTimeZoneProviders
-[TimeSpan]: http://msdn.microsoft.com/en-us/library/system.timespan.aspx
+[TimeSpan]: https://msdn.microsoft.com/en-us/library/system.timespan.aspx

--- a/src/NodaTime.Web/Markdown/1.1.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/concepts.md
@@ -196,7 +196,7 @@ but they're still available within periods. [`Period`][Period] is used for arith
 
 See the [arithmetic](arithmetic.html) page for more information.
 
-[api]: ../api/Index.html
+[api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/1.1.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/core-types.md
@@ -93,7 +93,7 @@ Interval
 An [`Interval`][Interval] is simply two instants - a start and an end. The interval includes the start, and excludes the end, which means that if you have abutting intervals any instant will be in
 exactly one of those intervals.
 
-[DST]: http://en.wikipedia.org/wiki/Daylight_saving_time
+[DST]: https://en.wikipedia.org/wiki/Daylight_saving_time
 [Interval]: noda-type://NodaTime.Interval
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/1.1.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/core-types.md
@@ -1,7 +1,7 @@
 @Title="Core types quick reference"
 
 This is a companion page to the
-["core concepts"](concepts.html), and ["choosing between types"](type-choices.html)
+["core concepts"](concepts), and ["choosing between types"](type-choices)
 pages, describing the fundamental types in Noda Time very briefly, primarily for reference.
 If you're not familiar with the core concepts, read that page first.
 
@@ -84,7 +84,7 @@ January.
 IClock
 ------
 
-An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing.html), this is defined
+An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing), this is defined
 as an interface; in a production deployment you're likely to use the [`SystemClock`][SystemClock] singleton implementation.
 
 Interval

--- a/src/NodaTime.Web/Markdown/1.1.x/design.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/design.md
@@ -104,5 +104,5 @@ similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
 [2]: http://semver.org/
-[3]: http://www.joda.org/joda-time
+[3]: http://www.joda.org/joda-time/
 [4]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/1.1.x/design.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/design.md
@@ -58,7 +58,7 @@ developers want. However, we do *not* default to using the system
 time zone, or using "now" as a default date/time value, or using
 the current thread's current format provider for parsing and
 formatting (except for the BCL-compatible method calls; see [text
-handling][5] for more information on this).
+handling](text) for more information on this).
   We make it easy to do all of these things, but they're just not
 appropriate as implicit defaults. It's too easy to *accidentally*
 depend on the time zone your system happens to be running in (etc)
@@ -67,7 +67,7 @@ without anything obvious in your code.
 What this means in practice
 ---------------------------
 
-- There are rather more types and [concepts][1] to learn about in
+- There are rather more types and [concepts](concepts) to learn about in
 Noda Time than in .NET. One of the *problems* with .NET's date and
 time API is that `DateTime` doesn't have a single well-defined
 meaning.
@@ -80,7 +80,7 @@ LocalDateTime()` or `default(LocalDateTime)`) is *not* a useful
 value. This is unfortunate, but hard to avoid.
 
 - All the value types and almost all the reference types are
-immutable and [thread-safe](threading.html). We expect objects like calendars, time
+immutable and [thread-safe](threading). We expect objects like calendars, time
 zones, and patterns for formatting and parsing text to be reused
 freely between many threads. Occasionally there's hidden mutability
 in terms of caches, but this should not affect you, the user. We make sure it
@@ -103,8 +103,6 @@ requirements, chances are someone else will want to do something
 similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
-[1]: concepts.html
 [2]: http://semver.org/
 [3]: http://www.joda.org/joda-time
 [4]: https://groups.google.com/group/noda-time
-[5]: text.html

--- a/src/NodaTime.Web/Markdown/1.1.x/index.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/index.md
@@ -25,5 +25,5 @@ Resources
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com/
-[so-tag]: http://stackoverflow.com/questions/tagged/nodatime
+[so]: https://stackoverflow.com/
+[so-tag]: https://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/1.1.x/index.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/index.md
@@ -20,10 +20,10 @@ Resources
 - [Blog][blog]
 - [Mailing list][group]
 
-[blog]: http://blog.nodatime.org
+[blog]: http://blog.nodatime.org/
 [group]: https://groups.google.com/group/noda-time
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com
+[so]: http://stackoverflow.com/
 [so-tag]: http://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/1.1.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/installation.md
@@ -1,10 +1,10 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org/) with
+Our primary distribution channel is [NuGet](https://www.nuget.org/) with
 two packages:
 
-- [NodaTime](http://nuget.org/packages/NodaTime)
-- [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing)
+- [NodaTime](https://www.nuget.org/packages/NodaTime)
+- [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing)
 
 Alternatively, source and binary downloads are available on the
 [project download page][downloads].
@@ -52,9 +52,9 @@ be able to start using Noda Time immediately, with no further effort.
 Debugging
 ---------
 
-As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org/). You can configure
+As of version 1.1, the source code of Noda Time is published to [SymbolSource](https://www.symbolsource.org/). You can configure
 Visual Studio to automatically fetch the source code if you need to step into it when debugging your application. It takes a little
-bit of setup, but there are [full instructions](http://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
+bit of setup, but there are [full instructions](https://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
 (The instructions aren't specific to Noda Time, so if you're
 already using SymbolSource as one of your symbol servers, you just need to make sure you're not excluding Noda Time from the list of
 modules to fetch.)

--- a/src/NodaTime.Web/Markdown/1.1.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/installation.md
@@ -12,7 +12,7 @@ Alternatively, source and binary downloads are available on the
 [downloads]: /downloads/
 
 An experimental assembly to support Json.NET is also available (in source form
-only); see the [serialization guide](serialization.html) for more information.
+only); see the [serialization guide](serialization) for more information.
 
 See the ["Building and testing"][building] section in the developer guide for
 instructions on building Noda Time from source.
@@ -24,7 +24,7 @@ System requirements
 
 As of release 1.1, there are two builds of Noda Time: the desktop version and the Portable Class Library version.
 
-The desktop version requires .NET 3.5 (client profile). This build also supports Mono, [with some caveats](mono.html).
+The desktop version requires .NET 3.5 (client profile). This build also supports Mono, [with some caveats](mono).
 
 The PCL build is configured to support:
 
@@ -35,15 +35,15 @@ The PCL build is configured to support:
 
 Noda Time does *not* support XBox 360 or Silverlight 3, and it's unlikely that we'd ever want to introduce support
 for these. (It's more likely that over time, we'll drop support for Silverlight - but not imminently, of course.)
-See the [limitations](limitations.html) page for differences between the PCL build and the desktop build.
+See the [limitations](limitations) page for differences between the PCL build and the desktop build.
 
 Package contents and getting started
 ------------------------------------
 
 Everything you need to *use* Noda Time is contained in the NodaTime package. The NodaTime.Testing package is designed
-for testing code which uses Noda Time. See the [testing guide](testing.html) for more information. It is expected
+for testing code which uses Noda Time. See the [testing guide](testing) for more information. It is expected
 that production code will only refer to the `NodaTime.dll` assembly, and that's all that's required at execution time.
-This assembly includes the [TZDB database](tzdb.html) as an embedded resource.
+This assembly includes the [TZDB database](tzdb) as an embedded resource.
 
 Everything within the NodaTime assembly is in the NodaTime namespace or a "child" namespace. After adding a reference to
 the main assembly (either directly via the file system or with NuGet) and including an appropriate `using` directive, you should

--- a/src/NodaTime.Web/Markdown/1.1.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/installation.md
@@ -1,6 +1,6 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org) with
+Our primary distribution channel is [NuGet](http://nuget.org/) with
 two packages:
 
 - [NodaTime](http://nuget.org/packages/NodaTime)
@@ -52,7 +52,7 @@ be able to start using Noda Time immediately, with no further effort.
 Debugging
 ---------
 
-As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org). You can configure
+As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org/). You can configure
 Visual Studio to automatically fetch the source code if you need to step into it when debugging your application. It takes a little
 bit of setup, but there are [full instructions](http://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
 (The instructions aren't specific to Noda Time, so if you're

--- a/src/NodaTime.Web/Markdown/1.1.x/instant-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/instant-patterns.md
@@ -24,6 +24,6 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns.html).
+[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns).
 The pattern allows the culture to be specified, but *always* uses the ISO-8601 calendar, and *always* uses the UTC
 time zone. The "template value" is always the unix epoch.

--- a/src/NodaTime.Web/Markdown/1.1.x/limitations.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/limitations.md
@@ -6,7 +6,7 @@ aspects we'd like to improve; see the
 [issues list](https://github.com/nodatime/nodatime/issues) for
 others.
 
-We also have a [roadmap](roadmap.html) of intended releases. This is
+We also have a [roadmap](roadmap) of intended releases. This is
 always tentative, of course, but it helps to give some clarity to our
 decisions in terms of what to work on next.
 
@@ -33,7 +33,7 @@ Additionally, the PCL doesn't support .NET resource files as fully as the deskto
 framework; in particular, it doesn't allow you to retrieve non-string resources. This
 has provoked a change from the previous resource-based format used for TZDB, to a
 stream-based format, which is now the default. For most users this will be a no-op
-change, but it does affect how you [build and use a custom version of TZDB](tzdb.html).
+change, but it does affect how you [build and use a custom version of TZDB](tzdb).
 
 Fuller text support
 ===================
@@ -73,7 +73,7 @@ highest priority is probably an adapter for the BCL calendars.
 Smarter arithmetic
 ==================
 
-As noted in the [arithmetic guide](arithmetic.html), arithmetic using
+As noted in the [arithmetic guide](arithmetic), arithmetic using
 [`Period`](noda-type://NodaTime.Period) is pretty simplistic. We may
 want something smarter, probably to go alongside the "dumb but
 predictable" existing logic. This will definitely be driven by real

--- a/src/NodaTime.Web/Markdown/1.1.x/limitations.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/limitations.md
@@ -59,7 +59,7 @@ hot-fixes for cultures which we don't support as well as we might.
 More time zone information
 ==========================
 
-[CLDR](http://cldr.unicode.org) provides useful information about
+[CLDR](http://cldr.unicode.org/) provides useful information about
 time zones such as a canonical ID and user-friendly representations
 (countries and sample cities). We'd also like to make it clearer
 when one zoneinfo time zone is an alias for another.

--- a/src/NodaTime.Web/Markdown/1.1.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/localdate-patterns.md
@@ -18,7 +18,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom offset pattern characters are supported for local dates. See [custom pattern notes](text.html#custom-patterns)
+The following custom offset pattern characters are supported for local dates. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 For the meanings of "absolute" years and text handling, see later details.

--- a/src/NodaTime.Web/Markdown/1.1.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/localdate-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `d`: Short format pattern.  
-  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
+  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
   For example, in the invariant culture this is "MM/dd/yyyy".
 
 - `D`: Long format pattern.  
-  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
+  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
   For example, in the invariant culture this is "dddd, dd MMMM yyyy".
 
 Custom Patterns

--- a/src/NodaTime.Web/Markdown/1.1.x/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/localdatetime-patterns.md
@@ -29,8 +29,8 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The custom format patterns for local date and time values are provided by combining the [custom patterns for `LocalDate`](localdate-patterns.html) with
-the [custom patterns for `LocalTime`](localtime-patterns.html). The result is simply the combination of the date and the time.
+The custom format patterns for local date and time values are provided by combining the [custom patterns for `LocalDate`](localdate-patterns) with
+the [custom patterns for `LocalTime`](localtime-patterns). The result is simply the combination of the date and the time.
 
 There is one exception to this: when parsing a `LocalDateTime`, an 24-hour (`HH`) specifier is allowed to have the value 24,
 instead of being limited to the range 00-23. This is only permitted if the resulting time of day is midnight, and it indicates

--- a/src/NodaTime.Web/Markdown/1.1.x/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/localdatetime-patterns.md
@@ -14,17 +14,17 @@ The following standard patterns are supported:
 
 - `s`: The sortable pattern, which is always "yyyy'-'MM'-'dd'T'HH':'mm':'ss" using the invariant culture.
 
-- `f`: The culture's [long date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `f`: The culture's [long date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
+- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
   For example, in the invariant culture this is "dddd, dd MMMM yyyy HH:mm:ss".
 
-- `g`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `g`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `G`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [long time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
+- `G`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [long time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
 
 Custom Patterns
 ---------------

--- a/src/NodaTime.Web/Markdown/1.1.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/localtime-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `t`: Short format pattern.  
-  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx) 
+  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx) 
   For example, in the invariant culture this is "HH:mm".
 
 - `T`: Long format pattern.  
-  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx) 
+  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx) 
   For example, in the invariant culture this is "HH:mm:ss".
 
 - `r`: Round-trip pattern.  

--- a/src/NodaTime.Web/Markdown/1.1.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/localtime-patterns.md
@@ -39,7 +39,7 @@ for general notes on custom patterns, including characters used for escaping and
         The hour of day in the 24-hour clock; a value 0-23.
         <p>Note that when parsing local date/time values, a value of <code>24</code>
         may be exceptionally permitted to allow
-        <a href="localdatetime-patterns.md">specification of a following day's
+        <a href="localdatetime-patterns">specification of a following day's
         midnight</a>.
       </td>
       <td>

--- a/src/NodaTime.Web/Markdown/1.1.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/localtime-patterns.md
@@ -21,7 +21,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom offset pattern characters are supported for local times. See [custom pattern notes](text.html#custom-patterns)
+The following custom offset pattern characters are supported for local times. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/1.1.x/mono.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com) is an open source implementation of
+[Mono](http://mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/1.1.x/mono.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com/) is an open source implementation of
+[Mono](http://www.mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/1.1.x/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/offset-patterns.md
@@ -26,7 +26,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom offset pattern characters are supported for local times. See [custom pattern notes](text.html#custom-patterns)
+The following custom offset pattern characters are supported for local times. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/1.1.x/rationale.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/rationale.md
@@ -28,5 +28,5 @@ a new date/time API, the Noda Time team would happily go into
 retirement (other than for the sake of those forced to stick with
 earlier versions of .NET, of course).
 
-[1]: http://www.joda.org/joda-time
+[1]: http://www.joda.org/joda-time/
 [2]: http://blog.nodatime.org/2011/08/what-wrong-with-datetime-anyway.html

--- a/src/NodaTime.Web/Markdown/1.1.x/roadmap.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/roadmap.md
@@ -2,7 +2,7 @@
 
 Our online Developer Guide contains [an _approximate_ roadmap][roadmap] for the
 major features that we hope to support in Noda Time, some of which are inspired
-by Noda Time's [current limitations](limitations.html).
+by Noda Time's [current limitations](limitations).
 
 [roadmap]: /developer/roadmap
 

--- a/src/NodaTime.Web/Markdown/1.1.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/serialization.md
@@ -7,7 +7,7 @@ serialization are supported, they will be included within the main Noda Time ass
 Json.NET: NodaTime.Serialization.JsonNet
 ----------------------------------------
 
-[Json.NET](http://json.net) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
+[Json.NET](http://json.net/) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
 of the same name.
 
 An extension method of `ConfigureForNodaTime` is provided on both `JsonSerializer` and

--- a/src/NodaTime.Web/Markdown/1.1.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/serialization.md
@@ -11,10 +11,10 @@ Json.NET: NodaTime.Serialization.JsonNet
 of the same name.
 
 An extension method of `ConfigureForNodaTime` is provided on both `JsonSerializer` and
-`JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields
+`JsonSerializerSettings`. Alternatively, the `NodaConverters` type provides public static read-only fields
 for individual converters. (All converters are immutable.)
 
-Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter-1).
+Custom converters can be created easily from patterns using `NodaPatternConverter`.
 
 Supported types and default representations
 ===========================================

--- a/src/NodaTime.Web/Markdown/1.1.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/serialization.md
@@ -14,7 +14,7 @@ An extension method of `ConfigureForNodaTime` is provided on both `JsonSerialize
 `JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields
 for individual converters. (All converters are immutable.)
 
-Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter_1).
+Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter-1).
 
 Supported types and default representations
 ===========================================

--- a/src/NodaTime.Web/Markdown/1.1.x/testing.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/testing.md
@@ -6,7 +6,7 @@ which *uses* Noda Time.
 NodaTime.Testing
 ----------------
 
-Firstly, get hold of the [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
+Firstly, get hold of the [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
 small, but it will no doubt grow - and it will make your life much easier. The purpose of the assembly is to provide
 easy-to-use test doubles which can be used instead of the real implementations.
 

--- a/src/NodaTime.Web/Markdown/1.1.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/text.md
@@ -34,10 +34,10 @@ information or other options.
 Each core Noda type has its own pattern type such as
 [`OffsetPattern`](noda-type://NodaTime.Text.OffsetPattern). All
 these patterns implement the
-[`IPattern<T>`](noda-type://NodaTime.Text.IPattern_1) interface,
+[`IPattern<T>`](noda-type://NodaTime.Text.IPattern-1) interface,
 which has simple `Format` and `Parse` methods taking just the value
 and text respectively. The result of `Parse` is a
-[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult_1) which
+[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult-1) which
 encapsulates both success and failure results.
 
 The BCL-based API

--- a/src/NodaTime.Web/Markdown/1.1.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/text.md
@@ -129,7 +129,7 @@ recommend** that you quote any text literals, to avoid nasty
 surprises if extra characters take on special meanings in later
 versions.
 
-  [2]: http://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
+  [2]: https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
   [3]: noda-ns://NodaTime.Text
   [4]: noda-type://NodaTime.LocalDateTime
   [5]: noda-type://NodaTime.Instant

--- a/src/NodaTime.Web/Markdown/1.1.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/text.md
@@ -61,12 +61,12 @@ available patterns are as consistent as possible within reason, but
 documenting each separately avoids confusion with some field
 specifiers being available for some types but not others.
 
-- [Offset patterns](offset-patterns.html)
-- [Instant patterns](instant-patterns.html)
-- [LocalTime patterns](localtime-patterns.html)
-- [LocalDate patterns](localdate-patterns.html)
-- [LocalDateTime patterns](localdatetime-patterns.html)
-- [Period patterns](period-patterns.html)
+- [Offset patterns](offset-patterns)
+- [Instant patterns](instant-patterns)
+- [LocalTime patterns](localtime-patterns)
+- [LocalDate patterns](localdate-patterns)
+- [LocalDateTime patterns](localdatetime-patterns)
+- [Period patterns](period-patterns)
 
 Note that at present, `ZonedDateTime`, `OffsetDateTime` and `Duration` do not support
 any form of parsing or user-specified formatting.

--- a/src/NodaTime.Web/Markdown/1.1.x/threading.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/threading.md
@@ -62,6 +62,6 @@ Enums
 Enums should generally be treated as immutable value types. Accessing the enum values directly can *never* have any nasty effects,
 but be careful around using a writable field of an enum type, for the same reasons as given in the earlier discussion.
 
-[lippert]: http://blogs.msdn.com/b/ericlippert/archive/2009/10/19/what-is-this-thing-you-call-thread-safe.aspx
-[immutability]: http://blogs.msdn.com/b/ericlippert/archive/tags/immutability/
+[lippert]: https://blogs.msdn.microsoft.com/ericlippert/2009/10/19/what-is-this-thing-you-call-thread-safe/
+[immutability]: https://blogs.msdn.microsoft.com/ericlippert/tag/immutability/
 [mailing list]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/1.1.x/type-choices.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/type-choices.md
@@ -1,7 +1,7 @@
 @Title="Choosing (and converting) between types"
 
 This is a companion page to the
-["core concepts quick reference"](concepts.html), and ["core types"](core-types.html)
+["core concepts quick reference"](concepts), and ["core types"](core-types)
 pages, describing when it's appropriate to use which type, and how to convert between them.
 
 Ultimately, you should be thinking about what data you really have,
@@ -155,5 +155,5 @@ as they're generally very straightforward.)
 Most of these are pretty simple, but a few are worth calling out
 specifically. The biggest "gotcha" is converting `LocalDateTime` to
 `ZonedDateTime` - it has some corner cases you need to consider. See the ["times zones" section of
-the core concepts guide](concepts.html#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
+the core concepts guide](concepts#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
 for more information.

--- a/src/NodaTime.Web/Markdown/1.1.x/tzdb.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/tzdb.md
@@ -1,6 +1,6 @@
 @Title="Updating the time zone database"
 
-Noda Time comes with a version of the [tzdb](http://www.iana.org/time-zones) (aka zoneinfo) database, which is
+Noda Time comes with a version of the [tzdb](https://www.iana.org/time-zones) (aka zoneinfo) database, which is
 now hosted by IANA. This database changes over time, as countries decide to change their time zone rules.
 As new versions of Noda Time are released, the version of tzdb will be updated. However, you may wish to use
 a new version of tzdb *without* changing which version of Noda Time you're using. This documentation tells you how
@@ -24,7 +24,7 @@ Creating and using a "NodaZoneData" file (1.1+ format)
 Building a NodaZoneData file
 ----------------------------
 
-1. Download the [latest tzdb release](http://www.iana.org/time-zones)
+1. Download the [latest tzdb release](https://www.iana.org/time-zones)
 2. Unpack the tar.gz file - you may need to download extra tools for this; [7-Zip](http://www.7-zip.org/) can cope with .tar.gz
    files for example, and I'd expect other zip tools to do so too. You should end up with a directory containing files such
    as "america", "africa", "etcetera".
@@ -97,7 +97,7 @@ Creating and using a resource file (legacy format)
 Building the resource file
 --------------------------
 
-1. Download the [latest tzdb release](http://www.iana.org/time-zones)
+1. Download the [latest tzdb release](https://www.iana.org/time-zones)
 2. Unpack the tar.gz file - you may need to download extra tools for this; [7-Zip](http://www.7-zip.org/) can cope with .tar.gz
    files for example, and I'd expect other zip tools to do so too. You should end up with a directory containing files such
    as "america", "africa", "etcetera".
@@ -127,7 +127,7 @@ Typically you'll want to use the newly-created resource file as the default time
 While it's possible to have multiple time zone providers in play at a time, that's a very rare scenario. Using a resource
 file is relatively straightforward:
 
-- Create a [`ResourceSet`](http://msdn.microsoft.com/en-us/library/t15hy0dt.aspx) from the file
+- Create a [`ResourceSet`](https://msdn.microsoft.com/en-us/library/t15hy0dt.aspx) from the file
 - Create a [`TzdbDateTimeZoneSource`][TzdbDateTimeZoneSource] with the `ResourceSet`
 - Create [`DateTimeZoneCache`][DateTimeZoneCache] with the source 
 - Use that cache (usually by way of dependency injection as an `IDateTimeZoneProvider`) wherever you need time zone information

--- a/src/NodaTime.Web/Markdown/1.1.x/tzdb.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/tzdb.md
@@ -31,7 +31,7 @@ Building a NodaZoneData file
 3. Ideally, rename the directory to match the version number, e.g. "2012j". The directory name will be used in the version ID
    reported by the time zone provider later.
 4. Find the Windows mapping file you want to use. Currently, I'd recommend using the version supplied with the Noda Time source
-   in ZoneInfoCompiler\Data\winmap in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org).
+   in ZoneInfoCompiler\Data\winmap in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org/).
 5. Run ZoneInfoCompiler. I'd suggest leaving it in its build directory and running it like this:
 
 ```bat
@@ -104,7 +104,7 @@ Building the resource file
 3. Ideally, rename the directory to match the version number, e.g. "2012j". The directory name will be used in the version ID
    reported by the time zone provider later.
 4. Find the Windows mapping file you want to use. Currently, I'd recommend using the version supplied with the Noda Time source
-   in ZoneInfoCompiler\Data\winmap in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org).
+   in ZoneInfoCompiler\Data\winmap in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org/).
 5. Run ZoneInfoCompiler. I'd suggest leaving it in its build directory and running it like this:
 
 ```bat

--- a/src/NodaTime.Web/Markdown/1.2.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/concepts.md
@@ -205,14 +205,14 @@ See the [arithmetic](arithmetic) page for more information.
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime
 [Instant]: noda-type://NodaTime.Instant
 [CalendarSystem]: noda-type://NodaTime.CalendarSystem
-[UTC]: http://en.wikipedia.org/wiki/Coordinated_Universal_Time
+[UTC]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
 [DateTimeZone]: noda-type://NodaTime.DateTimeZone
 [Offset]: noda-type://NodaTime.Offset
 [Period]: noda-type://NodaTime.Period
 [Duration]: noda-type://NodaTime.Duration
 [OffsetDateTime]: noda-type://NodaTime.OffsetDateTime
 [ZonedDateTime]: noda-type://NodaTime.ZonedDateTime
-[TZDB]: http://www.iana.org/time-zones
+[TZDB]: https://www.iana.org/time-zones
 [IDateTimeZoneProvider]: noda-type://NodaTime.IDateTimeZoneProvider
 [DateTimeZoneProviders]: noda-type://NodaTime.DateTimeZoneProviders
-[TimeSpan]: http://msdn.microsoft.com/en-us/library/system.timespan.aspx
+[TimeSpan]: https://msdn.microsoft.com/en-us/library/system.timespan.aspx

--- a/src/NodaTime.Web/Markdown/1.2.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/concepts.md
@@ -199,7 +199,7 @@ but they're still available within periods. [`Period`][Period] is used for arith
 See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
-[2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
+[2]: https://blogs.msdn.microsoft.com/bclteam/2007/06/18/a-brief-history-of-datetime-anthony-moore/
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime

--- a/src/NodaTime.Web/Markdown/1.2.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/concepts.md
@@ -1,7 +1,7 @@
 @Title="Core concepts"
 
 This is a companion page to the
-["core types quick reference"](core-types.html), and ["choosing between types"](type-choices.html)
+["core types quick reference"](core-types), and ["choosing between types"](type-choices)
 pages, describing the fundamental concepts in Noda Time.
 
 One of the benefits of Noda Time over the Base Class Library (BCL)
@@ -20,7 +20,7 @@ date and time data for your whole project.
 This document introduces the core concepts, but in order to avoid it
 being too overwhelming, we won't go into the fine details. See
 individual pages (particularly the ["choosing between
-types"](type-choices.html) page) and the [API documentation][api]
+types"](type-choices) page) and the [API documentation][api]
 for more information.
 
 "Local" and "global" (or "absolute") types
@@ -169,7 +169,7 @@ Noda Time handles two of them: it is able to map BCL `TimeZoneInfo` objects
 using `BclDateTimeZone`, or it can use the [tz database][TZDB] (also known as
 the IANA Time Zone database, or zoneinfo or Olson database). A version of TZDB
 is embedded within the Noda Time distribution, and if you need a more recent
-one, there are [instructions on how to download and use new data](tzdb.html).
+one, there are [instructions on how to download and use new data](tzdb).
 We generally recommend that you isolate yourself from the provider you're using
 by only depending on [`IDateTimeZoneProvider`][IDateTimeZoneProvider], and
 injecting the appropriate provider in the normal way. "Stock" providers are
@@ -196,7 +196,7 @@ year or not. Periods based on smaller units (hours, minutes and so on) will alwa
 but they're still available within periods. [`Period`][Period] is used for arithmetic on locally-based values (`LocalDateTime`,
 `LocalDate`, `LocalTime`).
 
-See the [arithmetic](arithmetic.html) page for more information.
+See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx

--- a/src/NodaTime.Web/Markdown/1.2.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/concepts.md
@@ -198,7 +198,7 @@ but they're still available within periods. [`Period`][Period] is used for arith
 
 See the [arithmetic](arithmetic.html) page for more information.
 
-[api]: ../api/Index.html
+[api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/1.2.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/core-types.md
@@ -100,7 +100,7 @@ Interval
 An [`Interval`][Interval] is simply two instants - a start and an end. The interval includes the start, and excludes the end, which means that if you have abutting intervals any instant will be in
 exactly one of those intervals.
 
-[DST]: http://en.wikipedia.org/wiki/Daylight_saving_time
+[DST]: https://en.wikipedia.org/wiki/Daylight_saving_time
 [Interval]: noda-type://NodaTime.Interval
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/1.2.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/core-types.md
@@ -1,7 +1,7 @@
 @Title="Core types quick reference"
 
 This is a companion page to the
-["core concepts"](concepts.html), and ["choosing between types"](type-choices.html)
+["core concepts"](concepts), and ["choosing between types"](type-choices)
 pages, describing the fundamental types in Noda Time very briefly, primarily for reference.
 If you're not familiar with the core concepts, read that page first.
 
@@ -91,7 +91,7 @@ January.
 IClock
 ------
 
-An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing.html), this is defined
+An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing), this is defined
 as an interface; in a production deployment you're likely to use the [`SystemClock`][SystemClock] singleton implementation.
 
 Interval

--- a/src/NodaTime.Web/Markdown/1.2.x/design.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/design.md
@@ -104,5 +104,5 @@ similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
 [2]: http://semver.org/
-[3]: http://www.joda.org/joda-time
+[3]: http://www.joda.org/joda-time/
 [4]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/1.2.x/design.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/design.md
@@ -58,7 +58,7 @@ developers want. However, we do *not* default to using the system
 time zone, or using "now" as a default date/time value, or using
 the current thread's current format provider for parsing and
 formatting (except for the BCL-compatible method calls; see [text
-handling][5] for more information on this).
+handling](text) for more information on this).
   We make it easy to do all of these things, but they're just not
 appropriate as implicit defaults. It's too easy to *accidentally*
 depend on the time zone your system happens to be running in (etc)
@@ -67,7 +67,7 @@ without anything obvious in your code.
 What this means in practice
 ---------------------------
 
-- There are rather more types and [concepts][1] to learn about in
+- There are rather more types and [concepts](concepts) to learn about in
 Noda Time than in .NET. One of the *problems* with .NET's date and
 time API is that `DateTime` doesn't have a single well-defined
 meaning.
@@ -80,7 +80,7 @@ LocalDateTime()` or `default(LocalDateTime)`) is *not* a useful
 value. This is unfortunate, but hard to avoid.
 
 - All the value types and almost all the reference types are
-immutable and [thread-safe](threading.html). We expect objects like calendars, time
+immutable and [thread-safe](threading). We expect objects like calendars, time
 zones, and patterns for formatting and parsing text to be reused
 freely between many threads. Occasionally there's hidden mutability
 in terms of caches, but this should not affect you, the user. We make sure it
@@ -103,8 +103,6 @@ requirements, chances are someone else will want to do something
 similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
-[1]: concepts.html
 [2]: http://semver.org/
 [3]: http://www.joda.org/joda-time
 [4]: https://groups.google.com/group/noda-time
-[5]: text.html

--- a/src/NodaTime.Web/Markdown/1.2.x/duration-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/duration-patterns.md
@@ -12,7 +12,7 @@ The following standard pattern is supported:
 Custom Patterns
 ---------------
 
-The following custom pattern characters are supported for durations. See [custom pattern notes](text.html#custom-patterns)
+The following custom pattern characters are supported for durations. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 The pattern letters basically split into two categories:

--- a/src/NodaTime.Web/Markdown/1.2.x/index.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/index.md
@@ -25,5 +25,5 @@ Resources
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com/
-[so-tag]: http://stackoverflow.com/questions/tagged/nodatime
+[so]: https://stackoverflow.com/
+[so-tag]: https://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/1.2.x/index.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/index.md
@@ -20,10 +20,10 @@ Resources
 - [Blog][blog]
 - [Mailing list][group]
 
-[blog]: http://blog.nodatime.org
+[blog]: http://blog.nodatime.org/
 [group]: https://groups.google.com/group/noda-time
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com
+[so]: http://stackoverflow.com/
 [so-tag]: http://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/1.2.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/installation.md
@@ -1,11 +1,11 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org/) with
+Our primary distribution channel is [NuGet](https://www.nuget.org/) with
 three packages:
 
-- [NodaTime](http://nuget.org/packages/NodaTime)
-- [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing)
-- [NodaTime.Serialization.JsonNet](http://nuget.org/packages/NodaTime.Serialization.JsonNet)
+- [NodaTime](https://www.nuget.org/packages/NodaTime)
+- [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing)
+- [NodaTime.Serialization.JsonNet](https://www.nuget.org/packages/NodaTime.Serialization.JsonNet)
 
 Alternatively, source and binary downloads are available on the
 [project download page][downloads].
@@ -64,9 +64,9 @@ be able to start using Noda Time immediately, with no further effort.
 Debugging
 ---------
 
-As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org/). You can configure
+As of version 1.1, the source code of Noda Time is published to [SymbolSource](https://www.symbolsource.org/). You can configure
 Visual Studio to automatically fetch the source code if you need to step into it when debugging your application. It takes a little
-bit of setup, but there are [full instructions](http://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
+bit of setup, but there are [full instructions](https://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
 (The instructions aren't specific to Noda Time, so if you're
 already using SymbolSource as one of your symbol servers, you just need to make sure you're not excluding Noda Time from the list of
 modules to fetch.)

--- a/src/NodaTime.Web/Markdown/1.2.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/installation.md
@@ -22,7 +22,7 @@ System requirements
 
 From release 1.1 onwards, there are two builds of Noda Time: the desktop version and the Portable Class Library version.
 
-The desktop version requires .NET 3.5 (client profile). This build also supports Mono, [with some caveats](mono.html).
+The desktop version requires .NET 3.5 (client profile). This build also supports Mono, [with some caveats](mono).
 
 The PCL build is configured to support:
 
@@ -35,7 +35,7 @@ The PCL build also appears to work with Xamarin.iOS and Xamarin.Android apps, bu
 
 Noda Time does *not* support XBox 360 or Silverlight 3, and it's unlikely that we'd ever want to introduce support
 for these. (It's more likely that over time, we'll drop support for Silverlight - but not imminently, of course.)
-See the [limitations](limitations.html) page for differences between the PCL build and the desktop build.
+See the [limitations](limitations) page for differences between the PCL build and the desktop build.
 
 The NodaTime.Serialization.JsonNet assembly is built and tested against Json.NET version 4.5.11. It's likely that any version
 of Json.NET from 4.5.0 onwards will work with Noda Time, but we'd recommend using at least 4.5.11. As far as we know, there
@@ -47,14 +47,14 @@ Package contents and getting started
 ------------------------------------
 
 Everything you need to *use* Noda Time is contained in the NodaTime package. The NodaTime.Testing package is designed
-for testing code which uses Noda Time. See the [testing guide](testing.html) for more information. It is expected
+for testing code which uses Noda Time. See the [testing guide](testing) for more information. It is expected
 that production code will only refer to the `NodaTime.dll` assembly, and that's all that's required at execution time.
-This assembly includes the [TZDB database](tzdb.html) as an embedded resource.
+This assembly includes the [TZDB database](tzdb) as an embedded resource.
 
 For Json.NET serialization, the NodaTime.Serialization.JsonNet package (containing a single assembly of the same name) is 
 required, as well as an appropriate version of Json.NET itself. There is a NuGet dependency from NodaTime.Serialization.JsonNet
 to the newtonsoft.json package, so if you're using NuGet you just need to refer to NodaTime.Serialization.JsonNet and an 
-appropriate version of Json.NET will be installed automatically. See the [serialization guide](serialization.html) for more
+appropriate version of Json.NET will be installed automatically. See the [serialization guide](serialization) for more
 information on using Noda Time with Json.NET.
 
 Everything within the NodaTime assembly is in the NodaTime namespace or a "child" namespace. After adding a reference to

--- a/src/NodaTime.Web/Markdown/1.2.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/installation.md
@@ -1,6 +1,6 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org) with
+Our primary distribution channel is [NuGet](http://nuget.org/) with
 three packages:
 
 - [NodaTime](http://nuget.org/packages/NodaTime)
@@ -64,7 +64,7 @@ be able to start using Noda Time immediately, with no further effort.
 Debugging
 ---------
 
-As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org). You can configure
+As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org/). You can configure
 Visual Studio to automatically fetch the source code if you need to step into it when debugging your application. It takes a little
 bit of setup, but there are [full instructions](http://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
 (The instructions aren't specific to Noda Time, so if you're

--- a/src/NodaTime.Web/Markdown/1.2.x/instant-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/instant-patterns.md
@@ -25,7 +25,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns.html).
+[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns).
 The pattern allows the culture to be specified, but *always* uses the ISO-8601 calendar, and *always* uses the UTC
 time zone. The "template value" is always the unix epoch.
 

--- a/src/NodaTime.Web/Markdown/1.2.x/instant-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/instant-patterns.md
@@ -33,5 +33,6 @@ All instant patterns (other than the standard *numeric* ones) handle [`Instant.M
 and [`Instant.MaxValue`](noda-property://NodaTime.Instant.MaxValue) separately. The default formatting of the values
 are simply "MinInstant" and "MaxInstant" respectively, but a new
 [`InstantPattern`](noda-type://NodaTime.Text.InstantPattern) with different min/max labels 
-can be created using the [`WithMinMaxLabels`](noda-type://NodaTime.Text.InstantPattern.WithMinMaxLabels#NodaTime_Text_InstantPattern_WithMinMaxLabels_System_String_System_String_) method.
+can be created using the
+[`WithMinMaxLabels`](noda-type://NodaTime.Text.InstantPattern#NodaTime_Text_InstantPattern_WithMinMaxLabels_System_String_System_String_) method.
 The labels must be non-empty strings which differ from each other.

--- a/src/NodaTime.Web/Markdown/1.2.x/limitations.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/limitations.md
@@ -6,7 +6,7 @@ aspects we'd like to improve; see the
 [issues list](https://github.com/nodatime/nodatime/issues) for
 others.
 
-We also have a [roadmap](roadmap.html) of intended releases. This is
+We also have a [roadmap](roadmap) of intended releases. This is
 always tentative, of course, but it helps to give some clarity to our
 decisions in terms of what to work on next.
 
@@ -33,7 +33,7 @@ Additionally, the PCL doesn't support .NET resource files as fully as the deskto
 framework; in particular, it doesn't allow you to retrieve non-string resources. This
 has provoked a change from the previous resource-based format used for TZDB, to a
 stream-based format, which is now the default. For most users this will be a no-op
-change, but it does affect how you [build and use a custom version of TZDB](tzdb.html).
+change, but it does affect how you [build and use a custom version of TZDB](tzdb).
 
 Fuller text support
 ===================
@@ -77,7 +77,7 @@ highest priority is probably an adapter for the BCL calendars.
 Smarter arithmetic
 ==================
 
-As noted in the [arithmetic guide](arithmetic.html), arithmetic using
+As noted in the [arithmetic guide](arithmetic), arithmetic using
 [`Period`](noda-type://NodaTime.Period) is pretty simplistic. We may
 want something smarter, probably to go alongside the "dumb but
 predictable" existing logic. This will definitely be driven by real

--- a/src/NodaTime.Web/Markdown/1.2.x/limitations.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/limitations.md
@@ -46,7 +46,7 @@ we may want to optimize further at some point too.
 
 Additionally, all our text localization resources (day and month names) come from the .NET
 framework itself. That has some significant limitations, and makes Noda Time more reliant
-on `CultureInfo` than is ideal. [CLDR](http://cldr.unicode.org) contains more information,
+on `CultureInfo` than is ideal. [CLDR](http://cldr.unicode.org/) contains more information,
 which should allow for features such as ordinal day numbers ("1st", "2nd", "3rd") and
 a broader set of supported calendar/culture combinations.
 
@@ -63,7 +63,7 @@ hot-fixes for cultures which we don't support as well as we might.
 More time zone information
 ==========================
 
-[CLDR](http://cldr.unicode.org) provides useful information about
+[CLDR](http://cldr.unicode.org/) provides useful information about
 time zones such as a canonical ID and user-friendly representations
 (countries and sample cities). We'd also like to make it clearer
 when one zoneinfo time zone is an alias for another.

--- a/src/NodaTime.Web/Markdown/1.2.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/localdate-patterns.md
@@ -18,7 +18,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom format pattern characters are supported for local dates. See [custom pattern notes](text.html#custom-patterns)
+The following custom format pattern characters are supported for local dates. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 For the meanings of "absolute" years and text handling, see later details.

--- a/src/NodaTime.Web/Markdown/1.2.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/localdate-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `d`: Short format pattern.  
-  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
+  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
   For example, in the invariant culture this is "MM/dd/yyyy".
 
 - `D`: Long format pattern.  
-  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
+  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
   For example, in the invariant culture this is "dddd, dd MMMM yyyy".
 
 Custom Patterns

--- a/src/NodaTime.Web/Markdown/1.2.x/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/localdatetime-patterns.md
@@ -29,8 +29,8 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The custom format patterns for local date and time values are provided by combining the [custom patterns for `LocalDate`](localdate-patterns.html) with
-the [custom patterns for `LocalTime`](localtime-patterns.html). The result is simply the combination of the date and the time.
+The custom format patterns for local date and time values are provided by combining the [custom patterns for `LocalDate`](localdate-patterns) with
+the [custom patterns for `LocalTime`](localtime-patterns). The result is simply the combination of the date and the time.
 
 There is one exception to this: when parsing a `LocalDateTime`, an 24-hour (`HH`) specifier is allowed to have the value 24,
 instead of being limited to the range 00-23. This is only permitted if the resulting time of day is midnight, and it indicates

--- a/src/NodaTime.Web/Markdown/1.2.x/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/localdatetime-patterns.md
@@ -14,17 +14,17 @@ The following standard patterns are supported:
 
 - `s`: The sortable pattern, which is always "yyyy'-'MM'-'dd'T'HH':'mm':'ss" using the invariant culture. (Note: this is only truly sortable for years within the range \[0-9999\].)
 
-- `f`: The culture's [long date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `f`: The culture's [long date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
+- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
   For example, in the invariant culture this is "dddd, dd MMMM yyyy HH:mm:ss".
 
-- `g`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `g`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `G`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [long time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
+- `G`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [long time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
 
 Custom Patterns
 ---------------

--- a/src/NodaTime.Web/Markdown/1.2.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/localtime-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `t`: Short format pattern.  
-  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx) 
+  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx) 
   For example, in the invariant culture this is "HH:mm".
 
 - `T`: Long format pattern.  
-  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx) 
+  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx) 
   For example, in the invariant culture this is "HH:mm:ss".
 
 - `r`: Round-trip pattern.  

--- a/src/NodaTime.Web/Markdown/1.2.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/localtime-patterns.md
@@ -39,7 +39,7 @@ for general notes on custom patterns, including characters used for escaping and
         The hour of day in the 24-hour clock; a value 0-23.
         <p>Note that when parsing local date/time values, a value of <code>24</code>
         may be exceptionally permitted to allow
-        <a href="localdatetime-patterns.md">specification of a following day's
+        <a href="localdatetime-patterns">specification of a following day's
         midnight</a>.
       </td>
       <td>

--- a/src/NodaTime.Web/Markdown/1.2.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/localtime-patterns.md
@@ -21,7 +21,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom format pattern characters are supported for local times. See [custom pattern notes](text.html#custom-patterns)
+The following custom format pattern characters are supported for local times. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/1.2.x/mono.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com) is an open source implementation of
+[Mono](http://mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/1.2.x/mono.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com/) is an open source implementation of
+[Mono](http://www.mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/1.2.x/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/offset-patterns.md
@@ -26,7 +26,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom pattern characters are supported for offsets. See [custom pattern notes](text.html#custom-patterns)
+The following custom pattern characters are supported for offsets. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/1.2.x/offsetdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/offsetdatetime-patterns.md
@@ -12,6 +12,6 @@ Standard Patterns
 Custom Patterns
 ---------------
 
-The custom format patterns for the local date and time parts of the value are the same as the [custom patterns for `LocalDateTime`](localdatetime-patterns.html). There is an additional specifier for the offset.
+The custom format patterns for the local date and time parts of the value are the same as the [custom patterns for `LocalDateTime`](localdatetime-patterns). There is an additional specifier for the offset.
 
-The "o" specifier must always be followed by a [pattern for `Offset`](offset-patterns.html) within angle brackets. The pattern may be a standard pattern or a custom pattern. For example, a pattern of "yyyy-MM-dd HH:mm:ss o&lt;G&gt;" might produce output of "2013-07-17 06:20:35 Z" or "2013-07-17 07:20:35 +01:00".
+The "o" specifier must always be followed by a [pattern for `Offset`](offset-patterns) within angle brackets. The pattern may be a standard pattern or a custom pattern. For example, a pattern of "yyyy-MM-dd HH:mm:ss o&lt;G&gt;" might produce output of "2013-07-17 06:20:35 Z" or "2013-07-17 07:20:35 +01:00".

--- a/src/NodaTime.Web/Markdown/1.2.x/rationale.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/rationale.md
@@ -28,5 +28,5 @@ a new date/time API, the Noda Time team would happily go into
 retirement (other than for the sake of those forced to stick with
 earlier versions of .NET, of course).
 
-[1]: http://www.joda.org/joda-time
+[1]: http://www.joda.org/joda-time/
 [2]: http://blog.nodatime.org/2011/08/what-wrong-with-datetime-anyway.html

--- a/src/NodaTime.Web/Markdown/1.2.x/roadmap.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/roadmap.md
@@ -2,7 +2,7 @@
 
 Our online Developer Guide contains [an _approximate_ roadmap][roadmap] for the
 major features that we hope to support in Noda Time, some of which are inspired
-by Noda Time's [current limitations](limitations.html).
+by Noda Time's [current limitations](limitations).
 
 [roadmap]: /developer/roadmap
 

--- a/src/NodaTime.Web/Markdown/1.2.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/serialization.md
@@ -173,7 +173,7 @@ Json.NET: NodaTime.Serialization.JsonNet
 
 [Json.NET](http://json.net) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
 of the same name. This assembly is built against Json.NET 4.5.11, and is available in both portable and desktop flavours. It can be installed using NuGet, again with a package name of `NodaTime.Serialization.JsonNet`. See the
-[installation guide](installation.html) for more details.
+[installation guide](installation) for more details.
 
 An extension method of `ConfigureForNodaTime` is provided on both `JsonSerializer` and
 `JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields

--- a/src/NodaTime.Web/Markdown/1.2.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/serialization.md
@@ -179,7 +179,7 @@ An extension method of `ConfigureForNodaTime` is provided on both `JsonSerialize
 `JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields
 for individual converters. (All converters are immutable.)
 
-Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter_1).
+Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter-1).
 
 ### Disabling automatic date parsing ###
 

--- a/src/NodaTime.Web/Markdown/1.2.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/serialization.md
@@ -166,12 +166,12 @@ The serialized form is not documented here as it is not expected to be consumed 
 Third-party serialization
 -------------------------
 
-The Noda Time project itself has support for [Json.NET](http://json.net). Additionally, there is a separate project for [ServiceStack.Text](https://github.com/ServiceStack/ServiceStack.Text/) support. Details of both are given below.
+The Noda Time project itself has support for [Json.NET](http://json.net/). Additionally, there is a separate project for [ServiceStack.Text](https://github.com/ServiceStack/ServiceStack.Text/) support. Details of both are given below.
 
 Json.NET: NodaTime.Serialization.JsonNet
 ----------------------------------------
 
-[Json.NET](http://json.net) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
+[Json.NET](http://json.net/) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
 of the same name. This assembly is built against Json.NET 4.5.11, and is available in both portable and desktop flavours. It can be installed using NuGet, again with a package name of `NodaTime.Serialization.JsonNet`. See the
 [installation guide](installation) for more details.
 

--- a/src/NodaTime.Web/Markdown/1.2.x/testing.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/testing.md
@@ -6,7 +6,7 @@ which *uses* Noda Time.
 NodaTime.Testing
 ----------------
 
-Firstly, get hold of the [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
+Firstly, get hold of the [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
 small, but it will no doubt grow - and it will make your life much easier. The purpose of the assembly is to provide
 easy-to-use test doubles which can be used instead of the real implementations.
 

--- a/src/NodaTime.Web/Markdown/1.2.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/text.md
@@ -61,15 +61,15 @@ available patterns are as consistent as possible within reason, but
 documenting each separately avoids confusion with some field
 specifiers being available for some types but not others.
 
-- [Duration patterns](duration-patterns.html)
-- [Offset patterns](offset-patterns.html)
-- [Instant patterns](instant-patterns.html)
-- [LocalTime patterns](localtime-patterns.html)
-- [LocalDate patterns](localdate-patterns.html)
-- [LocalDateTime patterns](localdatetime-patterns.html)
-- [OffsetDateTime patterns](offsetdatetime-patterns.html)
-- [ZonedDateTime patterns](zoneddatetime-patterns.html)
-- [Period patterns](period-patterns.html)
+- [Duration patterns](duration-patterns)
+- [Offset patterns](offset-patterns)
+- [Instant patterns](instant-patterns)
+- [LocalTime patterns](localtime-patterns)
+- [LocalDate patterns](localdate-patterns)
+- [LocalDateTime patterns](localdatetime-patterns)
+- [OffsetDateTime patterns](offsetdatetime-patterns)
+- [ZonedDateTime patterns](zoneddatetime-patterns)
+- [Period patterns](period-patterns)
 
 <a name="custom-patterns"></a>Custom patterns
 ---------------

--- a/src/NodaTime.Web/Markdown/1.2.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/text.md
@@ -34,10 +34,10 @@ information or other options.
 Each core Noda type has its own pattern type such as
 [`OffsetPattern`](noda-type://NodaTime.Text.OffsetPattern). All
 these patterns implement the
-[`IPattern<T>`](noda-type://NodaTime.Text.IPattern_1) interface,
+[`IPattern<T>`](noda-type://NodaTime.Text.IPattern-1) interface,
 which has simple `Format` and `Parse` methods taking just the value
 and text respectively. The result of `Parse` is a
-[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult_1) which
+[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult-1) which
 encapsulates both success and failure results.
 
 The BCL-based API

--- a/src/NodaTime.Web/Markdown/1.2.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/text.md
@@ -160,7 +160,7 @@ Often you don't have much choice about how to parse or format text: if you're in
   - Try to use a pattern which is ISO-friendly where possible; it'll make it easier to interoperate with other systems in the future.
   - Quote all non-field values other than spaces.
 
-  [2]: http://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
+  [2]: https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
   [3]: noda-ns://NodaTime.Text
   [4]: noda-type://NodaTime.LocalDateTime
   [5]: noda-type://NodaTime.Instant

--- a/src/NodaTime.Web/Markdown/1.2.x/threading.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/threading.md
@@ -62,6 +62,6 @@ Enums
 Enums should generally be treated as immutable value types. Accessing the enum values directly can *never* have any nasty effects,
 but be careful around using a writable field of an enum type, for the same reasons as given in the earlier discussion.
 
-[lippert]: http://blogs.msdn.com/b/ericlippert/archive/2009/10/19/what-is-this-thing-you-call-thread-safe.aspx
-[immutability]: http://blogs.msdn.com/b/ericlippert/archive/tags/immutability/
+[lippert]: https://blogs.msdn.microsoft.com/ericlippert/2009/10/19/what-is-this-thing-you-call-thread-safe/
+[immutability]: https://blogs.msdn.microsoft.com/ericlippert/tag/immutability/
 [mailing list]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/1.2.x/type-choices.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/type-choices.md
@@ -1,7 +1,7 @@
 @Title="Choosing (and converting) between types"
 
 This is a companion page to the
-["core concepts"](concepts.html), and ["core types quick reference"](core-types.html)
+["core concepts"](concepts), and ["core types quick reference"](core-types)
 pages, describing when it's appropriate to use which type, and how to convert between them.
 
 Ultimately, you should be thinking about what data you really have,
@@ -155,5 +155,5 @@ as they're generally very straightforward.)
 Most of these are pretty simple, but a few are worth calling out
 specifically. The biggest "gotcha" is converting `LocalDateTime` to
 `ZonedDateTime` - it has some corner cases you need to consider. See the ["times zones" section of
-the core concepts guide](concepts.html#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
+the core concepts guide](concepts#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
 for more information.

--- a/src/NodaTime.Web/Markdown/1.2.x/tzdb.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/tzdb.md
@@ -1,7 +1,7 @@
 @Title="Updating the time zone database"
 
 Noda Time comes with a version of the
-[tz database](http://www.iana.org/time-zones) (also known as the IANA Time Zone
+[tz database](https://www.iana.org/time-zones) (also known as the IANA Time Zone
 database, or zoneinfo or Olson database), which is now hosted by IANA. This
 database changes over time, as countries decide to change their time zone
 rules.  As new versions of Noda Time are released, the version of tzdb will be
@@ -40,7 +40,7 @@ latest version. This may be used for automation.
 Building a NodaZoneData file
 ----------------------------
 
-1. Download the [latest tzdb release](http://www.iana.org/time-zones)
+1. Download the [latest tzdb release](https://www.iana.org/time-zones)
 2. Unpack the tar.gz file - you may need to download extra tools for this; [7-Zip](http://www.7-zip.org/) can cope with .tar.gz
    files for example, and I'd expect other zip tools to do so too. You should end up with a directory containing files such
    as "america", "africa", "etcetera".
@@ -110,7 +110,7 @@ Creating and using a resource file (legacy format)
 Building the resource file
 --------------------------
 
-1. Download the [latest tzdb release](http://www.iana.org/time-zones)
+1. Download the [latest tzdb release](https://www.iana.org/time-zones)
 2. Unpack the tar.gz file - you may need to download extra tools for this; [7-Zip](http://www.7-zip.org/) can cope with .tar.gz
    files for example, and I'd expect other zip tools to do so too. You should end up with a directory containing files such
    as "america", "africa", "etcetera".
@@ -140,7 +140,7 @@ Typically you'll want to use the newly-created resource file as the default time
 While it's possible to have multiple time zone providers in play at a time, that's a very rare scenario. Using a resource
 file is relatively straightforward:
 
-- Create a [`ResourceSet`](http://msdn.microsoft.com/en-us/library/t15hy0dt.aspx) from the file
+- Create a [`ResourceSet`](https://msdn.microsoft.com/en-us/library/t15hy0dt.aspx) from the file
 - Create a [`TzdbDateTimeZoneSource`][TzdbDateTimeZoneSource] with the `ResourceSet`
 - Create [`DateTimeZoneCache`][DateTimeZoneCache] with the source 
 - Use that cache (usually by way of dependency injection as an `IDateTimeZoneProvider`) wherever you need time zone information

--- a/src/NodaTime.Web/Markdown/1.2.x/tzdb.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/tzdb.md
@@ -47,7 +47,7 @@ Building a NodaZoneData file
 3. Ideally, rename the directory to match the version number, e.g. "2013h". The directory name will be used in the version ID
    reported by the time zone provider later.
 4. Find the Windows mapping file you want to use. Currently, I'd recommend using the version supplied with the Noda Time source
-   in NodaTime.TzdbCompiler\Data\winmap in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org).
+   in NodaTime.TzdbCompiler\Data\winmap in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org/).
 5. Run NodaTime.TzdbCompiler. I'd suggest leaving it in its build directory and running it like this:
 
 ```bat
@@ -117,7 +117,7 @@ Building the resource file
 3. Ideally, rename the directory to match the version number, e.g. "2013h". The directory name will be used in the version ID
    reported by the time zone provider later.
 4. Find the Windows mapping file you want to use. Currently, I'd recommend using the version supplied with the Noda Time source
-   in NodaTime.TzdbCompiler\Data\winmap in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org).
+   in NodaTime.TzdbCompiler\Data\winmap in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org/).
 5. Run NodaTime.TzdbCompiler. I'd suggest leaving it in its build directory and running it like this:
 
 ```bat

--- a/src/NodaTime.Web/Markdown/1.2.x/zoneddatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.2.x/zoneddatetime-patterns.md
@@ -14,7 +14,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The custom format patterns for a zoned date and time are provided by combining the [custom patterns for `OffsetDateTime`](offsetdatetime-patterns.html) with
+The custom format patterns for a zoned date and time are provided by combining the [custom patterns for `OffsetDateTime`](offsetdatetime-patterns) with
 the addition of two extra custom format specifiers: `z` and `x`.
 
 `z` is used to parse or format that time zone identifier. When parsing, an [`IDateTimeZoneProvider`](noda-type://NodaTime.IDateTimeZoneProvider) is used to extract candidate identifiers and fetch time zones for them. The UTC+/-xx:xx format for fixed offset time zones is always valid, regardless of provider. The provider is part of the `ZonedDateTimePattern`, and a new pattern with a different provider can be created using the `WithZoneProvider` method. The provider is not used when formatting: the time zone identifier is simply used directly. Note that if you format a `ZonedDateTime` which uses a time zone from a different provider than the one in the pattern, you may not be able to parse it again with the same pattern. A null provider can be specified, in which case

--- a/src/NodaTime.Web/Markdown/1.3.x/arithmetic.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/arithmetic.md
@@ -209,7 +209,7 @@ Arithmetic with the Hebrew calendar
 One exception to the rules given above is the Hebrew calendar system. For a start,
 the Hebrew calendar has a *leap month* - in a leap year, the single month of
 Adar becomes Adar I and Adar II ([with Adar I being considered the leap
-month](http://judaism.stackexchange.com/questions/37308)).
+month](https://judaism.stackexchange.com/questions/37308)).
 When an arithmetic operation requires that a date in Adar is mapped to a leap year, we use
 the same day-of-month but within Adar II. When an arithmetic operation requires that a date in
 Adar I or Adar II is mapped to a non-leap year, we use the same day-of-month in Adar. (This can
@@ -225,7 +225,7 @@ not the month *number*. So for example, bearing in mind that 5402 is a leap year
 
 Additionally, the "truncate the day-of-month if necessary" rule does not apply to the Hebrew
 calendar system, in the rules implemented in Noda Time 1.3.0. Instead,
-[following Hebrew scriptural rules](http://judaism.stackexchange.com/questions/39053), if changing
+[following Hebrew scriptural rules](https://judaism.stackexchange.com/questions/39053), if changing
 year makes a day-of-month invalid (which can happen if the original month is Adar I, Kislev or Heshvan),
 the result is instead the first day of the subsequent month. So for example, adding one year to the 30th of Kislev
 will result in the 1st of Tevet, if Kislev only has 29 days in the "target" year.

--- a/src/NodaTime.Web/Markdown/1.3.x/calendars.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/calendars.md
@@ -23,7 +23,7 @@ First supported in v1.0.0
 API access: [`CalendarSystem.Iso`](noda-property://NodaTime.CalendarSystem.Iso)
 
 This is the default calendar system when constructing values without explicitly specifying a calendar.
-It is designed to correspond to the calendar described in [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601),
+It is designed to correspond to the calendar described in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601),
 and is equivalent to the Gregorian calendar in all respects other than the century and year-of-century values.
 (In the ISO calendar, 1985 is year number 85 in century 19, and 1900 is year number 0 in century 19. In the
 Gregorian calendar, the same years would be year 85 in century 20 and year 100 in century 19 respectively.)
@@ -39,7 +39,7 @@ Gregorian
 First supported in v1.0.0  
 API access: [`CalendarSystem.GetGregorianCalendar()`](noda-type://NodaTime.CalendarSystem##NodaTime_CalendarSystem_GetGregorianCalendar_System_Int32_)
 
-The [Gregorian calendar](http://en.wikipedia.org/wiki/Gregorian_calendar) was a refinement to the Julian calendar,
+The [Gregorian calendar](https://en.wikipedia.org/wiki/Gregorian_calendar) was a refinement to the Julian calendar,
 changing the formula for which years are leap years from "whenever the year is divisible by 4" to
 "whenever the year is divisible by 4, except when it's also divisible by 100 and *not* divisible by 400". This keeps
 the calendar in closer sync with the observed rotation of the earth around the sun.
@@ -58,7 +58,7 @@ Julian
 First supported in v1.0.0  
 API access: [`CalendarSystem.GetJulianCalendar()`](noda-type://NodaTime.CalendarSystem##NodaTime_CalendarSystem_GetJulianCalendar_System_Int32_)
 
-The [Julian calendar](http://en.wikipedia.org/wiki/Julian_calendar) was introduced by Julius Caesar in 46BC, and took
+The [Julian calendar](https://en.wikipedia.org/wiki/Julian_calendar) was introduced by Julius Caesar in 46BC, and took
 effect in 45BC. It was like the Gregorian calendar, but with a simpler leap year rule - every year number divisible by
 4 was a leap year.
 
@@ -89,7 +89,7 @@ Islamic (Hijri)
 First supported in v1.0.0  
 API access: [`CalendarSystem.GetIslamicCalendar()`](noda-type://NodaTime.CalendarSystem#NodaTime_CalendarSystem_GetIslamicCalendar_NodaTime_Calendars_IslamicLeapYearPattern_NodaTime_Calendars_IslamicEpoch_)
 
-The [Islamic (or Hijri) calendar](http://en.wikipedia.org/wiki/Islamic_calendar) is a lunar calendar with years of 12
+The [Islamic (or Hijri) calendar](https://en.wikipedia.org/wiki/Islamic_calendar) is a lunar calendar with years of 12
 months, totalling either 355 or 354 days depending on whether or not it's a leap year. There are various schemes
 for determining which years are leap years, all based on a 30 year cycle. Noda Time supports four options here,
 specified in the [`IslamicLeapYearPattern`](noda-type://NodaTime.Calendars.IslamicLeapYearPattern) enumeration.
@@ -114,11 +114,11 @@ Persian (or Solar Hijri)
 First supported in v1.3.0  
 API access: [`CalendarSystem.GetPersianCalendar()`](noda-type://NodaTime.CalendarSystem#NodaTime_CalendarSystem_GetPersianCalendar)
 
-The [Persian (or Solar Hijri) calendar](http://en.wikipedia.org/wiki/Solar_Hijri_calendar) is the official calendar of
+The [Persian (or Solar Hijri) calendar](https://en.wikipedia.org/wiki/Solar_Hijri_calendar) is the official calendar of
 Iran and Pakistan. The first day of the Persian calendar is March 18th 622CE (Julian).
 
 This is properly an observational calendar, but the implementation in Noda Time is equivalent to that of
-the BCL [`PersianCalendar`](http://msdn.microsoft.com/en-us/library/system.globalization.persiancalendar.aspx) class,
+the BCL [`PersianCalendar`](https://msdn.microsoft.com/en-us/library/system.globalization.persiancalendar.aspx) class,
 which has a simple leap cycle of 33 years, where years 1, 5, 9, 13, 17, 22, 26, and 30 in each cycle are leap years.
 There is a more complicated algorithmic version proposed by Ahmad Birashk, but this has not been implemented in Noda Time.
 
@@ -128,7 +128,7 @@ Hebrew
 First supported in v1.3.0  
 API access: [`CalendarSystem.GetHebrewCalendar()`](noda-type://NodaTime.CalendarSystem##NodaTime_CalendarSystem_GetHebrewCalendar_NodaTime_Calendars_HebrewMonthNumbering_)
 
-The [Hebrew calendar](http://en.wikipedia.org/wiki/Hebrew_calendar) is a lunisolar calendar used primarily for determination
+The [Hebrew calendar](https://en.wikipedia.org/wiki/Hebrew_calendar) is a lunisolar calendar used primarily for determination
 of religious holidays within Judaism. It was originally observational, but a computed version is now commonly used. Even
 this is very complicated, however: most years have 12 months, but 7 in every 19 years are leap years, with 13 months. Two
 of the months in the regular calendar have variable numbers of days depending on other aspects of the calendar, in order

--- a/src/NodaTime.Web/Markdown/1.3.x/calendars.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/calendars.md
@@ -1,6 +1,6 @@
 @Title="Calendars"
 
-As described in the [core concepts documentation](concepts.html), a calendar system is a scheme
+As described in the [core concepts documentation](concepts), a calendar system is a scheme
 for dividing time into eras, years, months and days and so on. As a matter of simplification,
 Noda Time treats every day as starting and ending at midnight, despite some calendars (such as
 the Islamic and Hebrew calendars) traditionally having days stretching from sunset to sunset.

--- a/src/NodaTime.Web/Markdown/1.3.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/concepts.md
@@ -205,7 +205,7 @@ periods. [`Period`][Period] is used for arithmetic on locally-based values (`Loc
 See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
-[2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
+[2]: https://blogs.msdn.microsoft.com/bclteam/2007/06/18/a-brief-history-of-datetime-anthony-moore/
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime

--- a/src/NodaTime.Web/Markdown/1.3.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/concepts.md
@@ -1,7 +1,7 @@
 @Title="Core concepts"
 
 This is a companion page to the
-["core types quick reference"](core-types.html), and ["choosing between types"](type-choices.html)
+["core types quick reference"](core-types), and ["choosing between types"](type-choices)
 pages, describing the fundamental concepts in Noda Time.
 
 One of the benefits of Noda Time over the Base Class Library (BCL)
@@ -20,7 +20,7 @@ date and time data for your whole project.
 This document introduces the core concepts, but in order to avoid it
 being too overwhelming, we won't go into the fine details. See
 individual pages (particularly the ["choosing between
-types"](type-choices.html) page) and the [API documentation][api]
+types"](type-choices) page) and the [API documentation][api]
 for more information.
 
 "Local" and "global" (or "absolute") types
@@ -118,7 +118,7 @@ although a few useful methods are exposed. Most of the time even if you
 an appropriate object, and then pass it to other constructors etc as a
 little bundle of magic which simply does the right thing for you.
 
-See the [calendars documentation](calendars.html) for more details about
+See the [calendars documentation](calendars) for more details about
 which calendar systems are supported.
 
 <a name="time-zones"></a>Time zones
@@ -172,7 +172,7 @@ Noda Time handles two of them: it is able to map BCL `TimeZoneInfo` objects
 using `BclDateTimeZone`, or it can use the [tz database][TZDB] (also known as
 the IANA Time Zone database, or zoneinfo or Olson database). A version of TZDB
 is embedded within the Noda Time distribution, and if you need a more recent
-one, there are [instructions on how to download and use new data](tzdb.html).
+one, there are [instructions on how to download and use new data](tzdb).
 We generally recommend that you isolate yourself from the provider you're using
 by only depending on [`IDateTimeZoneProvider`][IDateTimeZoneProvider], and
 injecting the appropriate provider in the normal way. "Stock" providers are
@@ -202,7 +202,7 @@ so on) will always represent the same length of time, but they're still availabl
 periods. [`Period`][Period] is used for arithmetic on locally-based values (`LocalDateTime`,
 `LocalDate`, `LocalTime`).
 
-See the [arithmetic](arithmetic.html) page for more information.
+See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx

--- a/src/NodaTime.Web/Markdown/1.3.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/concepts.md
@@ -204,7 +204,7 @@ periods. [`Period`][Period] is used for arithmetic on locally-based values (`Loc
 
 See the [arithmetic](arithmetic.html) page for more information.
 
-[api]: ../api/Index.html
+[api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/1.3.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/concepts.md
@@ -211,14 +211,14 @@ See the [arithmetic](arithmetic) page for more information.
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime
 [Instant]: noda-type://NodaTime.Instant
 [CalendarSystem]: noda-type://NodaTime.CalendarSystem
-[UTC]: http://en.wikipedia.org/wiki/Coordinated_Universal_Time
+[UTC]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
 [DateTimeZone]: noda-type://NodaTime.DateTimeZone
 [Offset]: noda-type://NodaTime.Offset
 [Period]: noda-type://NodaTime.Period
 [Duration]: noda-type://NodaTime.Duration
 [OffsetDateTime]: noda-type://NodaTime.OffsetDateTime
 [ZonedDateTime]: noda-type://NodaTime.ZonedDateTime
-[TZDB]: http://www.iana.org/time-zones
+[TZDB]: https://www.iana.org/time-zones
 [IDateTimeZoneProvider]: noda-type://NodaTime.IDateTimeZoneProvider
 [DateTimeZoneProviders]: noda-type://NodaTime.DateTimeZoneProviders
-[TimeSpan]: http://msdn.microsoft.com/en-us/library/system.timespan.aspx
+[TimeSpan]: https://msdn.microsoft.com/en-us/library/system.timespan.aspx

--- a/src/NodaTime.Web/Markdown/1.3.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/core-types.md
@@ -100,7 +100,7 @@ Interval
 An [`Interval`][Interval] is simply two instants - a start and an end. The interval includes the start, and excludes the end, which means that if you have abutting intervals any instant will be in
 exactly one of those intervals.
 
-[DST]: http://en.wikipedia.org/wiki/Daylight_saving_time
+[DST]: https://en.wikipedia.org/wiki/Daylight_saving_time
 [Interval]: noda-type://NodaTime.Interval
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/1.3.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/core-types.md
@@ -1,7 +1,7 @@
 @Title="Core types quick reference"
 
 This is a companion page to the
-["core concepts"](concepts.html), and ["choosing between types"](type-choices.html)
+["core concepts"](concepts), and ["choosing between types"](type-choices)
 pages, describing the fundamental types in Noda Time very briefly, primarily for reference.
 If you're not familiar with the core concepts, read that page first.
 
@@ -91,7 +91,7 @@ January.
 IClock
 ------
 
-An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing.html), this is defined
+An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing), this is defined
 as an interface; in a production deployment you're likely to use the [`SystemClock`][SystemClock] singleton implementation.
 
 Interval

--- a/src/NodaTime.Web/Markdown/1.3.x/design.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/design.md
@@ -104,5 +104,5 @@ similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
 [2]: http://semver.org/
-[3]: http://www.joda.org/joda-time
+[3]: http://www.joda.org/joda-time/
 [4]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/1.3.x/design.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/design.md
@@ -58,7 +58,7 @@ developers want. However, we do *not* default to using the system
 time zone, or using "now" as a default date/time value, or using
 the current thread's current format provider for parsing and
 formatting (except for the BCL-compatible method calls; see [text
-handling][5] for more information on this).
+handling](text) for more information on this).
   We make it easy to do all of these things, but they're just not
 appropriate as implicit defaults. It's too easy to *accidentally*
 depend on the time zone your system happens to be running in (etc)
@@ -67,7 +67,7 @@ without anything obvious in your code.
 What this means in practice
 ---------------------------
 
-- There are rather more types and [concepts][1] to learn about in
+- There are rather more types and [concepts](concepts) to learn about in
 Noda Time than in .NET. One of the *problems* with .NET's date and
 time API is that `DateTime` doesn't have a single well-defined
 meaning.
@@ -80,7 +80,7 @@ LocalDateTime()` or `default(LocalDateTime)`) is *not* a useful
 value. This is unfortunate, but hard to avoid.
 
 - All the value types and almost all the reference types are
-immutable and [thread-safe](threading.html). We expect objects like calendars, time
+immutable and [thread-safe](threading). We expect objects like calendars, time
 zones, and patterns for formatting and parsing text to be reused
 freely between many threads. Occasionally there's hidden mutability
 in terms of caches, but this should not affect you, the user. We make sure it
@@ -103,8 +103,6 @@ requirements, chances are someone else will want to do something
 similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
-[1]: concepts.html
 [2]: http://semver.org/
 [3]: http://www.joda.org/joda-time
 [4]: https://groups.google.com/group/noda-time
-[5]: text.html

--- a/src/NodaTime.Web/Markdown/1.3.x/duration-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/duration-patterns.md
@@ -13,7 +13,7 @@ The following standard pattern is supported:
 Custom Patterns
 ---------------
 
-The following custom pattern characters are supported for durations. See [custom pattern notes](text.html#custom-patterns)
+The following custom pattern characters are supported for durations. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 The pattern letters basically split into two categories:

--- a/src/NodaTime.Web/Markdown/1.3.x/index.json
+++ b/src/NodaTime.Web/Markdown/1.3.x/index.json
@@ -21,5 +21,6 @@
       "title": "Library",
       "pageIds": [ "testing", "tzdb", "mono", "limitations", "roadmap", "versions" ]
     }
-  ]
+  ],
+  "resources": [ "conversions.png" ]
 }

--- a/src/NodaTime.Web/Markdown/1.3.x/index.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/index.md
@@ -25,5 +25,5 @@ Resources
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com/
-[so-tag]: http://stackoverflow.com/questions/tagged/nodatime
+[so]: https://stackoverflow.com/
+[so-tag]: https://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/1.3.x/index.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/index.md
@@ -20,10 +20,10 @@ Resources
 - [Blog][blog]
 - [Mailing list][group]
 
-[blog]: http://blog.nodatime.org
+[blog]: http://blog.nodatime.org/
 [group]: https://groups.google.com/group/noda-time
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com
+[so]: http://stackoverflow.com/
 [so-tag]: http://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/1.3.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/installation.md
@@ -1,11 +1,11 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org/) with
+Our primary distribution channel is [NuGet](https://www.nuget.org/) with
 three packages:
 
-- [NodaTime](http://nuget.org/packages/NodaTime)
-- [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing)
-- [NodaTime.Serialization.JsonNet](http://nuget.org/packages/NodaTime.Serialization.JsonNet)
+- [NodaTime](https://www.nuget.org/packages/NodaTime)
+- [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing)
+- [NodaTime.Serialization.JsonNet](https://www.nuget.org/packages/NodaTime.Serialization.JsonNet)
 
 Alternatively, source and binary downloads are available on the
 [project download page][downloads].
@@ -64,9 +64,9 @@ be able to start using Noda Time immediately, with no further effort.
 Debugging
 ---------
 
-As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org/). You can configure
+As of version 1.1, the source code of Noda Time is published to [SymbolSource](https://www.symbolsource.org/). You can configure
 Visual Studio to automatically fetch the source code if you need to step into it when debugging your application. It takes a little
-bit of setup, but there are [full instructions](http://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
+bit of setup, but there are [full instructions](https://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
 (The instructions aren't specific to Noda Time, so if you're
 already using SymbolSource as one of your symbol servers, you just need to make sure you're not excluding Noda Time from the list of
 modules to fetch.)

--- a/src/NodaTime.Web/Markdown/1.3.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/installation.md
@@ -22,7 +22,7 @@ System requirements
 
 From release 1.1 onwards, there are two builds of Noda Time: the desktop version and the Portable Class Library version.
 
-The desktop version requires .NET 3.5 (client profile). This build also supports Mono, [with some caveats](mono.html).
+The desktop version requires .NET 3.5 (client profile). This build also supports Mono, [with some caveats](mono).
 
 The PCL build is configured to support:
 
@@ -35,7 +35,7 @@ The PCL build also appears to work with Xamarin.iOS and Xamarin.Android apps, bu
 
 Noda Time does *not* support XBox 360 or Silverlight 3, and it's unlikely that we'd ever want to introduce support
 for these. (It's more likely that over time, we'll drop support for Silverlight - but not imminently, of course.)
-See the [limitations](limitations.html) page for differences between the PCL build and the desktop build.
+See the [limitations](limitations) page for differences between the PCL build and the desktop build.
 
 The NodaTime.Serialization.JsonNet assembly is built and tested against Json.NET version 4.5.11. It's likely that any version
 of Json.NET from 4.5.0 onwards will work with Noda Time, but we'd recommend using at least 4.5.11. As far as we know, there
@@ -47,14 +47,14 @@ Package contents and getting started
 ------------------------------------
 
 Everything you need to *use* Noda Time is contained in the NodaTime package. The NodaTime.Testing package is designed
-for testing code which uses Noda Time. See the [testing guide](testing.html) for more information. It is expected
+for testing code which uses Noda Time. See the [testing guide](testing) for more information. It is expected
 that production code will only refer to the `NodaTime.dll` assembly, and that's all that's required at execution time.
-This assembly includes the [TZDB database](tzdb.html) as an embedded resource.
+This assembly includes the [TZDB database](tzdb) as an embedded resource.
 
 For Json.NET serialization, the NodaTime.Serialization.JsonNet package (containing a single assembly of the same name) is 
 required, as well as an appropriate version of Json.NET itself. There is a NuGet dependency from NodaTime.Serialization.JsonNet
 to the newtonsoft.json package, so if you're using NuGet you just need to refer to NodaTime.Serialization.JsonNet and an 
-appropriate version of Json.NET will be installed automatically. See the [serialization guide](serialization.html) for more
+appropriate version of Json.NET will be installed automatically. See the [serialization guide](serialization) for more
 information on using Noda Time with Json.NET.
 
 Everything within the NodaTime assembly is in the NodaTime namespace or a "child" namespace. After adding a reference to

--- a/src/NodaTime.Web/Markdown/1.3.x/installation.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/installation.md
@@ -1,6 +1,6 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org) with
+Our primary distribution channel is [NuGet](http://nuget.org/) with
 three packages:
 
 - [NodaTime](http://nuget.org/packages/NodaTime)
@@ -64,7 +64,7 @@ be able to start using Noda Time immediately, with no further effort.
 Debugging
 ---------
 
-As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org). You can configure
+As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org/). You can configure
 Visual Studio to automatically fetch the source code if you need to step into it when debugging your application. It takes a little
 bit of setup, but there are [full instructions](http://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
 (The instructions aren't specific to Noda Time, so if you're

--- a/src/NodaTime.Web/Markdown/1.3.x/instant-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/instant-patterns.md
@@ -34,5 +34,6 @@ All instant patterns (other than the standard *numeric* ones) handle [`Instant.M
 and [`Instant.MaxValue`](noda-property://NodaTime.Instant.MaxValue) separately. The default formatting of the values
 are simply "MinInstant" and "MaxInstant" respectively, but a new
 [`InstantPattern`](noda-type://NodaTime.Text.InstantPattern) with different min/max labels 
-can be created using the [`WithMinMaxLabels`](noda-type://NodaTime.Text.InstantPattern.WithMinMaxLabels#NodaTime_Text_InstantPattern_WithMinMaxLabels_System_String_System_String_) method.
+can be created using the
+[`WithMinMaxLabels`](noda-type://NodaTime.Text.InstantPattern#NodaTime_Text_InstantPattern_WithMinMaxLabels_System_String_System_String_) method.
 The labels must be non-empty strings which differ from each other.

--- a/src/NodaTime.Web/Markdown/1.3.x/instant-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/instant-patterns.md
@@ -26,7 +26,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns.html).
+[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns).
 The pattern allows the culture to be specified, but *always* uses the ISO-8601 calendar, and *always* uses the UTC
 time zone. The "template value" is always the unix epoch.
 

--- a/src/NodaTime.Web/Markdown/1.3.x/limitations.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/limitations.md
@@ -46,7 +46,7 @@ we may want to optimize further at some point too.
 
 Additionally, all our text localization resources (day and month names) come from the .NET
 framework itself. That has some significant limitations, and makes Noda Time more reliant
-on `CultureInfo` than is ideal. [CLDR](http://cldr.unicode.org) contains more information,
+on `CultureInfo` than is ideal. [CLDR](http://cldr.unicode.org/) contains more information,
 which should allow for features such as ordinal day numbers ("1st", "2nd", "3rd") and
 a broader set of supported calendar/culture combinations (such as English names for the
 Hebrew calendar months).
@@ -67,7 +67,7 @@ hot-fixes for cultures which we don't support as well as we might.
 More time zone information
 ==========================
 
-[CLDR](http://cldr.unicode.org) provides useful information about
+[CLDR](http://cldr.unicode.org/) provides useful information about
 time zones such as a canonical ID and user-friendly representations
 (countries and sample cities). We'd also like to make it clearer
 when one zoneinfo time zone is an alias for another.

--- a/src/NodaTime.Web/Markdown/1.3.x/limitations.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/limitations.md
@@ -6,7 +6,7 @@ aspects we'd like to improve; see the
 [issues list](https://github.com/nodatime/nodatime/issues) for
 others.
 
-We also have a [roadmap](roadmap.html) of intended releases. This is
+We also have a [roadmap](roadmap) of intended releases. This is
 always tentative, of course, but it helps to give some clarity to our
 decisions in terms of what to work on next.
 
@@ -33,7 +33,7 @@ Additionally, the PCL doesn't support .NET resource files as fully as the deskto
 framework; in particular, it doesn't allow you to retrieve non-string resources. This
 has provoked a change from the previous resource-based format used for TZDB, to a
 stream-based format, which is now the default. For most users this will be a no-op
-change, but it does affect how you [build and use a custom version of TZDB](tzdb.html).
+change, but it does affect how you [build and use a custom version of TZDB](tzdb).
 
 Fuller text support
 ===================
@@ -52,7 +52,7 @@ a broader set of supported calendar/culture combinations (such as English names 
 Hebrew calendar months).
 
 Speaking of the Hebrew calendar, initial support for the calendar has been introduced
-in 1.3.0, but month names are *not* properly supported currently. See [local date formatting](localdate-patterns.html) for more details of this limitation.
+in 1.3.0, but month names are *not* properly supported currently. See [local date formatting](localdate-patterns) for more details of this limitation.
 
 Better resource handling
 ========================
@@ -81,7 +81,7 @@ highest priority is probably an adapter for the BCL calendars.
 Smarter arithmetic
 ==================
 
-As noted in the [arithmetic guide](arithmetic.html), arithmetic using
+As noted in the [arithmetic guide](arithmetic), arithmetic using
 [`Period`](noda-type://NodaTime.Period) is pretty simplistic. We may
 want something smarter, probably to go alongside the "dumb but
 predictable" existing logic. This will definitely be driven by real

--- a/src/NodaTime.Web/Markdown/1.3.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/localdate-patterns.md
@@ -19,7 +19,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom format pattern characters are supported for local dates. See [custom pattern notes](text.html#custom-patterns)
+The following custom format pattern characters are supported for local dates. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 For the meanings of "absolute" years and text handling, see later details.

--- a/src/NodaTime.Web/Markdown/1.3.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/localdate-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `d`: Short format pattern.  
-  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
+  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
   For example, in the invariant culture this is "MM/dd/yyyy".
 
 - `D`: Long format pattern.  
-  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
+  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
   For example, in the invariant culture this is "dddd, dd MMMM yyyy".
   This is the default format pattern.
 

--- a/src/NodaTime.Web/Markdown/1.3.x/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/localdatetime-patterns.md
@@ -30,8 +30,8 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The custom format patterns for local date and time values are provided by combining the [custom patterns for `LocalDate`](localdate-patterns.html) with
-the [custom patterns for `LocalTime`](localtime-patterns.html). The result is simply the combination of the date and the time.
+The custom format patterns for local date and time values are provided by combining the [custom patterns for `LocalDate`](localdate-patterns) with
+the [custom patterns for `LocalTime`](localtime-patterns). The result is simply the combination of the date and the time.
 
 There is one exception to this: when parsing a `LocalDateTime`, an 24-hour (`HH`) specifier is allowed to have the value 24,
 instead of being limited to the range 00-23. This is only permitted if the resulting time of day is midnight, and it indicates

--- a/src/NodaTime.Web/Markdown/1.3.x/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/localdatetime-patterns.md
@@ -14,17 +14,17 @@ The following standard patterns are supported:
 
 - `s`: The sortable pattern, which is always "yyyy'-'MM'-'dd'T'HH':'mm':'ss" using the invariant culture. (Note: this is only truly sortable for years within the range \[0-9999\].)
 
-- `f`: The culture's [long date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `f`: The culture's [long date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
+- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
   For example, in the invariant culture this is "dddd, dd MMMM yyyy HH:mm:ss".
 
-- `g`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `g`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `G`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [long time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
+- `G`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [long time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
   This is the default format pattern.
 
 Custom Patterns

--- a/src/NodaTime.Web/Markdown/1.3.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/localtime-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `t`: Short format pattern.  
-  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx). 
+  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx). 
   For example, in the invariant culture this is "HH:mm".
 
 - `T`: Long format pattern.  
-  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx). 
+  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx). 
   For example, in the invariant culture this is "HH:mm:ss". This is the default format pattern.
 
 - `r`: Round-trip pattern.  

--- a/src/NodaTime.Web/Markdown/1.3.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/localtime-patterns.md
@@ -39,7 +39,7 @@ for general notes on custom patterns, including characters used for escaping and
         The hour of day in the 24-hour clock; a value 0-23.
         <p>Note that when parsing local date/time values, a value of <code>24</code>
         may be exceptionally permitted to allow
-        <a href="localdatetime-patterns.md">specification of a following day's
+        <a href="localdatetime-patterns">specification of a following day's
         midnight</a>.
       </td>
       <td>

--- a/src/NodaTime.Web/Markdown/1.3.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/localtime-patterns.md
@@ -21,7 +21,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom format pattern characters are supported for local times. See [custom pattern notes](text.html#custom-patterns)
+The following custom format pattern characters are supported for local times. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/1.3.x/mono.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com) is an open source implementation of
+[Mono](http://mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/1.3.x/mono.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com/) is an open source implementation of
+[Mono](http://www.mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/1.3.x/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/offset-patterns.md
@@ -26,7 +26,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom pattern characters are supported for offsets. See [custom pattern notes](text.html#custom-patterns)
+The following custom pattern characters are supported for offsets. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/1.3.x/offsetdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/offsetdatetime-patterns.md
@@ -12,6 +12,6 @@ Standard Patterns
 Custom Patterns
 ---------------
 
-The custom format patterns for the local date and time parts of the value are the same as the [custom patterns for `LocalDateTime`](localdatetime-patterns.html). There is an additional specifier for the offset.
+The custom format patterns for the local date and time parts of the value are the same as the [custom patterns for `LocalDateTime`](localdatetime-patterns). There is an additional specifier for the offset.
 
-The "o" specifier must always be followed by a [pattern for `Offset`](offset-patterns.html) within angle brackets. The pattern may be a standard pattern or a custom pattern. For example, a pattern of "yyyy-MM-dd HH:mm:ss o&lt;G&gt;" might produce output of "2013-07-17 06:20:35 Z" or "2013-07-17 07:20:35 +01:00".
+The "o" specifier must always be followed by a [pattern for `Offset`](offset-patterns) within angle brackets. The pattern may be a standard pattern or a custom pattern. For example, a pattern of "yyyy-MM-dd HH:mm:ss o&lt;G&gt;" might produce output of "2013-07-17 06:20:35 Z" or "2013-07-17 07:20:35 +01:00".

--- a/src/NodaTime.Web/Markdown/1.3.x/rationale.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/rationale.md
@@ -28,5 +28,5 @@ a new date/time API, the Noda Time team would happily go into
 retirement (other than for the sake of those forced to stick with
 earlier versions of .NET, of course).
 
-[1]: http://www.joda.org/joda-time
+[1]: http://www.joda.org/joda-time/
 [2]: http://blog.nodatime.org/2011/08/what-wrong-with-datetime-anyway.html

--- a/src/NodaTime.Web/Markdown/1.3.x/roadmap.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/roadmap.md
@@ -2,7 +2,7 @@
 
 Our online Developer Guide contains [an _approximate_ roadmap][roadmap] for the
 major features that we hope to support in Noda Time, some of which are inspired
-by Noda Time's [current limitations](limitations.html).
+by Noda Time's [current limitations](limitations).
 
 [roadmap]: /developer/roadmap
 

--- a/src/NodaTime.Web/Markdown/1.3.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/serialization.md
@@ -173,12 +173,12 @@ The serialized form is not documented here as it is not expected to be consumed 
 Third-party serialization
 -------------------------
 
-The Noda Time project itself has support for [Json.NET](http://json.net). Additionally, there is a separate project for [ServiceStack.Text](https://github.com/ServiceStack/ServiceStack.Text/) support. Details of both are given below.
+The Noda Time project itself has support for [Json.NET](http://json.net/). Additionally, there is a separate project for [ServiceStack.Text](https://github.com/ServiceStack/ServiceStack.Text/) support. Details of both are given below.
 
 Json.NET: NodaTime.Serialization.JsonNet
 ----------------------------------------
 
-[Json.NET](http://json.net) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
+[Json.NET](http://json.net/) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
 of the same name. This assembly is built against Json.NET 4.5.11, and is available in both portable and desktop flavours. It can be installed using NuGet, again with a package name of `NodaTime.Serialization.JsonNet`. See the
 [installation guide](installation) for more details.
 

--- a/src/NodaTime.Web/Markdown/1.3.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/serialization.md
@@ -180,7 +180,7 @@ Json.NET: NodaTime.Serialization.JsonNet
 
 [Json.NET](http://json.net) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
 of the same name. This assembly is built against Json.NET 4.5.11, and is available in both portable and desktop flavours. It can be installed using NuGet, again with a package name of `NodaTime.Serialization.JsonNet`. See the
-[installation guide](installation.html) for more details.
+[installation guide](installation) for more details.
 
 An extension method of `ConfigureForNodaTime` is provided on both `JsonSerializer` and
 `JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields

--- a/src/NodaTime.Web/Markdown/1.3.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/serialization.md
@@ -186,7 +186,7 @@ An extension method of `ConfigureForNodaTime` is provided on both `JsonSerialize
 `JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields
 for individual converters. (All converters are immutable.)
 
-Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter_1).
+Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter-1).
 
 ### Disabling automatic date parsing ###
 

--- a/src/NodaTime.Web/Markdown/1.3.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/serialization.md
@@ -67,9 +67,9 @@ properties, which would entirely defeat the point of the exercise.
 
 It's also worth noting that the XML serialization in .NET doesn't allow any user-defined types to be
 serialized via attributes. So while it would make perfect sense to be able to apply
-[`[XmlAttribute]`](http://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlattributeattribute)
+[`[XmlAttribute]`](https://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlattributeattribute)
 to a particular property and have it serialized as an attribute, in reality you need to use
-[`[XmlElement]`](http://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlelementattribute.aspx)
+[`[XmlElement]`](https://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlelementattribute.aspx)
 instead. There's nothing Noda Time can do here; it's just a [limitation of .NET XML serialization](http://connect.microsoft.com/VisualStudio/feedback/details/277641/xmlattribute-xmltext-cannot-be-used-to-encode-types-implementing-ixmlserializable).
 
 Finally, serialization of `ZonedDateTime` comes with the tricky question of which `IDateTimeZoneProvider` to use in order to convert a time zone ID specified in the XML into a `DateTimeZone`.

--- a/src/NodaTime.Web/Markdown/1.3.x/testing.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/testing.md
@@ -6,7 +6,7 @@ which *uses* Noda Time.
 NodaTime.Testing
 ----------------
 
-Firstly, get hold of the [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
+Firstly, get hold of the [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
 small, but it will no doubt grow - and it will make your life much easier. The purpose of the assembly is to provide
 easy-to-use test doubles which can be used instead of the real implementations.
 

--- a/src/NodaTime.Web/Markdown/1.3.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/text.md
@@ -61,15 +61,15 @@ available patterns are as consistent as possible within reason, but
 documenting each separately avoids confusion with some field
 specifiers being available for some types but not others.
 
-- [Duration patterns](duration-patterns.html)
-- [Offset patterns](offset-patterns.html)
-- [Instant patterns](instant-patterns.html)
-- [LocalTime patterns](localtime-patterns.html)
-- [LocalDate patterns](localdate-patterns.html)
-- [LocalDateTime patterns](localdatetime-patterns.html)
-- [OffsetDateTime patterns](offsetdatetime-patterns.html)
-- [ZonedDateTime patterns](zoneddatetime-patterns.html)
-- [Period patterns](period-patterns.html)
+- [Duration patterns](duration-patterns)
+- [Offset patterns](offset-patterns)
+- [Instant patterns](instant-patterns)
+- [LocalTime patterns](localtime-patterns)
+- [LocalDate patterns](localdate-patterns)
+- [LocalDateTime patterns](localdatetime-patterns)
+- [OffsetDateTime patterns](offsetdatetime-patterns)
+- [ZonedDateTime patterns](zoneddatetime-patterns)
+- [Period patterns](period-patterns)
 
 <a name="custom-patterns"></a>Custom patterns
 ---------------

--- a/src/NodaTime.Web/Markdown/1.3.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/text.md
@@ -34,10 +34,10 @@ information or other options.
 Each core Noda type has its own pattern type such as
 [`OffsetPattern`](noda-type://NodaTime.Text.OffsetPattern). All
 these patterns implement the
-[`IPattern<T>`](noda-type://NodaTime.Text.IPattern_1) interface,
+[`IPattern<T>`](noda-type://NodaTime.Text.IPattern-1) interface,
 which has simple `Format` and `Parse` methods taking just the value
 and text respectively. The result of `Parse` is a
-[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult_1) which
+[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult-1) which
 encapsulates both success and failure results.
 
 The BCL-based API

--- a/src/NodaTime.Web/Markdown/1.3.x/text.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/text.md
@@ -160,7 +160,7 @@ Often you don't have much choice about how to parse or format text: if you're in
   - Try to use a pattern which is ISO-friendly where possible; it'll make it easier to interoperate with other systems in the future.
   - Quote all non-field values other than spaces.
 
-  [2]: http://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
+  [2]: https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
   [3]: noda-ns://NodaTime.Text
   [4]: noda-type://NodaTime.LocalDateTime
   [5]: noda-type://NodaTime.Instant

--- a/src/NodaTime.Web/Markdown/1.3.x/threading.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/threading.md
@@ -62,6 +62,6 @@ Enums
 Enums should generally be treated as immutable value types. Accessing the enum values directly can *never* have any nasty effects,
 but be careful around using a writable field of an enum type, for the same reasons as given in the earlier discussion.
 
-[lippert]: http://blogs.msdn.com/b/ericlippert/archive/2009/10/19/what-is-this-thing-you-call-thread-safe.aspx
-[immutability]: http://blogs.msdn.com/b/ericlippert/archive/tags/immutability/
+[lippert]: https://blogs.msdn.microsoft.com/ericlippert/2009/10/19/what-is-this-thing-you-call-thread-safe/
+[immutability]: https://blogs.msdn.microsoft.com/ericlippert/tag/immutability/
 [mailing list]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/1.3.x/trivia.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/trivia.md
@@ -88,12 +88,12 @@ year), they'd be somewhere in between for about 40 years.
 While this almost sounds like a reasonable plan (almost like the way that
 [Google "smears" a leap second across a whole minute rather than simply
 adding a
-second](http://googleblog.blogspot.com/2011/09/time-technology-and-leaping-seconds.html)),
+second](https://googleblog.blogspot.com/2011/09/time-technology-and-leaping-seconds.html)),
 it went horribly wrong. In February 1700, Sweden skipped the leap year,
 according to plan. That meant that they were one day ahead of the countries
 still following the Julian calendar. Unfortunately, in the  same year -
 although ironically *before* February 28th - the [Great Northern
-War](http://en.wikipedia.org/wiki/Great_Northern_War) broke out. This
+War](https://en.wikipedia.org/wiki/Great_Northern_War) broke out. This
 distracted Sweden from their calendrical machinations, and they *did* have a
 leap year in 1704 and 1708.
 
@@ -115,7 +115,7 @@ alone in such an odd way.
 
 **Read more:**
 
-- [Wikipedia](http://en.wikipedia.org/wiki/February_30)
+- [Wikipedia](https://en.wikipedia.org/wiki/February_30)
 
 The time in Greenwich at the Unix epoch
 ---
@@ -154,7 +154,7 @@ offset. The transition from summer time to standard time on October 27th
 
 - [BBC News](http://www.bbc.co.uk/news/uk-scotland-11643098)
 - [History of Legal Time in
-  Britain](http://www.polyomino.org.uk/british-time/)
+  Britain](https://www.polyomino.org.uk/british-time/)
 
 <sup>1</sup> I'm studiously avoiding the differentiation between, UTC, UT,
 UT0, TAI and the like. They make my head hurt, and in common usage time zone
@@ -223,7 +223,7 @@ careful before you compare it with another date. To avoid *too* much
 confusion, many historical dates are given using the Julian calendar, which
 was being observed at the time (depending on the place, of course), while
 using the "New Style" of year numbering. For example, [Henry
-VIII](http://en.wikipedia.org/wiki/Henry_VIII_of_England) died on January
+VIII](https://en.wikipedia.org/wiki/Henry_VIII_of_England) died on January
 28th 1547 (New Style) or January 28th 1546 (Old Style). In my experience,
 some web pages explicitly call out which numbering style they're using,
 others record it as "January 28th 1546/1547" and hope that readers
@@ -241,11 +241,11 @@ anyway.
 
 - [Wikipedia: Calender (New Style) act][wikipedia-newstyle-act]
 - [Wikipedia: Old and New Style
-  dates](http://en.wikipedia.org/wiki/Old_Style_and_New_Style_dates)
+  dates](https://en.wikipedia.org/wiki/Old_Style_and_New_Style_dates)
 - [Malcolm Rowe's write-up in
   Google+](https://plus.google.com/+MalcolmRowe/posts/Bf5swesMPUV)
 
-[wikipedia-newstyle-act]: http://en.wikipedia.org/wiki/Calendar_(New_Style)_Act_1750
+[wikipedia-newstyle-act]: https://en.wikipedia.org/wiki/Calendar_(New_Style)_Act_1750
 
 <sup>1</sup> When I say "we" here, I really mean "Malcolm" who did most of
 the work on understanding this issue based on Wikipedia and primary
@@ -304,9 +304,9 @@ typically deploys changes to the *Windows* time zone database...
 **Read more:**
 
 - [Argentina (announcement on 7th October 2009, due 18th
-  October)](http://www.timeanddate.com/news/time/argentina-dst-2009-2010.html)
+  October)](https://www.timeanddate.com/news/time/argentina-dst-2009-2010.html)
 - [Morocco (September
-  2013)](http://www.timeanddate.com/news/time/morocco-ends-dst-2013.html)
+  2013)](https://www.timeanddate.com/news/time/morocco-ends-dst-2013.html)
 - [Libya (October
-  2013)](http://www.timeanddate.com/news/time/libya-cancels-dst-switch-2013.html)
-- [Turkey (March 2011)](http://www.timeanddate.com/news/time/turkey-starts-dst-2011.html)
+  2013)](https://www.timeanddate.com/news/time/libya-cancels-dst-switch-2013.html)
+- [Turkey (March 2011)](https://www.timeanddate.com/news/time/turkey-starts-dst-2011.html)

--- a/src/NodaTime.Web/Markdown/1.3.x/trivia.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/trivia.md
@@ -292,7 +292,7 @@ between a change being announced and Noda Time supporting it in production:
 4. I run a script to pull the latest version from TZDB, build it as an NZD
    file and push it to the Noda Time web site
 5. The system in question pulls the latest version from the web site and
-   [starts using it](tzdb.html)
+   [starts using it](tzdb)
 
 As you can see, this depends on a lot of different people, so some delay is
 inevitable. However, if your application is configured to poll the web site

--- a/src/NodaTime.Web/Markdown/1.3.x/type-choices.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/type-choices.md
@@ -1,7 +1,7 @@
 @Title="Choosing (and converting) between types"
 
 This is a companion page to the
-["core concepts"](concepts.html), and ["core types quick reference"](core-types.html)
+["core concepts"](concepts), and ["core types quick reference"](core-types)
 pages, describing when it's appropriate to use which type, and how to convert between them.
 
 Ultimately, you should be thinking about what data you really have,
@@ -155,5 +155,5 @@ as they're generally very straightforward.)
 Most of these are pretty simple, but a few are worth calling out
 specifically. The biggest "gotcha" is converting `LocalDateTime` to
 `ZonedDateTime` - it has some corner cases you need to consider. See the ["times zones" section of
-the core concepts guide](concepts.html#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
+the core concepts guide](concepts#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
 for more information.

--- a/src/NodaTime.Web/Markdown/1.3.x/tzdb.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/tzdb.md
@@ -1,7 +1,7 @@
 @Title="Updating the time zone database"
 
 Noda Time comes with a version of the
-[tz database](http://www.iana.org/time-zones) (also known as the IANA Time Zone
+[tz database](https://www.iana.org/time-zones) (also known as the IANA Time Zone
 database, or zoneinfo or Olson database), which is now hosted by IANA. This
 database changes over time, as countries decide to change their time zone
 rules.  As new versions of Noda Time are released, the version of tzdb will be
@@ -43,7 +43,7 @@ This may be used for automation.
 Building a NodaZoneData file
 ----------------------------
 
-1. Download the [latest tzdb release](http://www.iana.org/time-zones)
+1. Download the [latest tzdb release](https://www.iana.org/time-zones)
 2. Unpack the tar.gz file - you may need to download extra tools for this; [7-Zip](http://www.7-zip.org/) can cope with .tar.gz
    files for example, and I'd expect other zip tools to do so too. You should end up with a directory containing files such
    as "america", "africa", "etcetera".
@@ -113,7 +113,7 @@ Creating and using a resource file (legacy format)
 Building the resource file
 --------------------------
 
-1. Download the [latest tzdb release](http://www.iana.org/time-zones)
+1. Download the [latest tzdb release](https://www.iana.org/time-zones)
 2. Unpack the tar.gz file - you may need to download extra tools for this; [7-Zip](http://www.7-zip.org/) can cope with .tar.gz
    files for example, and I'd expect other zip tools to do so too. You should end up with a directory containing files such
    as "america", "africa", "etcetera".
@@ -143,7 +143,7 @@ Typically you'll want to use the newly-created resource file as the default time
 While it's possible to have multiple time zone providers in play at a time, that's a very rare scenario. Using a resource
 file is relatively straightforward:
 
-- Create a [`ResourceSet`](http://msdn.microsoft.com/en-us/library/t15hy0dt.aspx) from the file
+- Create a [`ResourceSet`](https://msdn.microsoft.com/en-us/library/t15hy0dt.aspx) from the file
 - Create a [`TzdbDateTimeZoneSource`][TzdbDateTimeZoneSource] with the `ResourceSet`
 - Create [`DateTimeZoneCache`][DateTimeZoneCache] with the source 
 - Use that cache (usually by way of dependency injection as an `IDateTimeZoneProvider`) wherever you need time zone information

--- a/src/NodaTime.Web/Markdown/1.3.x/tzdb.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/tzdb.md
@@ -50,7 +50,7 @@ Building a NodaZoneData file
 3. Ideally, rename the directory to match the version number, e.g. "2013h". The directory name will be used in the version ID
    reported by the time zone provider later.
 4. Find the Windows mapping file you want to use. Currently, I'd recommend using the version supplied with the Noda Time source
-   in the `data\cldr` directory in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org).
+   in the `data\cldr` directory in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org/).
 5. Run NodaTime.TzdbCompiler. I'd suggest leaving it in its build directory and running it like this:
 
 ```bat
@@ -120,7 +120,7 @@ Building the resource file
 3. Ideally, rename the directory to match the version number, e.g. "2013h". The directory name will be used in the version ID
    reported by the time zone provider later.
 4. Find the Windows mapping file you want to use. Currently, I'd recommend using the version supplied with the Noda Time source
-   in the `data\cldr` directory, in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org).
+   in the `data\cldr` directory, in a file beginning "windowsZones". This file comes from [CLDR](http://cldr.unicode.org/).
 5. Run NodaTime.TzdbCompiler. I'd suggest leaving it in its build directory and running it like this:
 
 ```bat

--- a/src/NodaTime.Web/Markdown/1.3.x/zoneddatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/zoneddatetime-patterns.md
@@ -16,7 +16,7 @@ specified in conjunction with a time zone provider. It corresponds to the custom
 Custom Patterns
 ---------------
 
-The custom format patterns for a zoned date and time are provided by combining the [custom patterns for `OffsetDateTime`](offsetdatetime-patterns.html) with
+The custom format patterns for a zoned date and time are provided by combining the [custom patterns for `OffsetDateTime`](offsetdatetime-patterns) with
 the addition of two extra custom format specifiers: `z` and `x`.
 
 `z` is used to parse or format that time zone identifier. When parsing, an [`IDateTimeZoneProvider`](noda-type://NodaTime.IDateTimeZoneProvider) is used to extract candidate identifiers and fetch time zones for them. The UTC+/-xx:xx format for fixed offset time zones is always valid, regardless of provider. The provider is part of the `ZonedDateTimePattern`, and a new pattern with a different provider can be created using the `WithZoneProvider` method. The provider is not used when formatting: the time zone identifier is simply used directly. Note that if you format a `ZonedDateTime` which uses a time zone from a different provider than the one in the pattern, you may not be able to parse it again with the same pattern. A null provider can be specified, in which case

--- a/src/NodaTime.Web/Markdown/2.0.x/arithmetic.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/arithmetic.md
@@ -209,7 +209,7 @@ Arithmetic with the Hebrew calendar
 One exception to the rules given above is the Hebrew calendar system. For a start,
 the Hebrew calendar has a *leap month* - in a leap year, the single month of
 Adar becomes Adar I and Adar II ([with Adar I being considered the leap
-month](http://judaism.stackexchange.com/questions/37308)).
+month](https://judaism.stackexchange.com/questions/37308)).
 When an arithmetic operation requires that a date in Adar is mapped to a leap year, we use
 the same day-of-month but within Adar II. When an arithmetic operation requires that a date in
 Adar I or Adar II is mapped to a non-leap year, we use the same day-of-month in Adar. (This can
@@ -225,7 +225,7 @@ not the month *number*. So for example, bearing in mind that 5402 is a leap year
 
 Additionally, the "truncate the day-of-month if necessary" rule does not apply to the Hebrew
 calendar system, in the rules implemented in Noda Time 1.3.0. Instead,
-[following Hebrew scriptural rules](http://judaism.stackexchange.com/questions/39053), if changing
+[following Hebrew scriptural rules](https://judaism.stackexchange.com/questions/39053), if changing
 year makes a day-of-month invalid (which can happen if the original month is Adar I, Kislev or Heshvan),
 the result is instead the first day of the subsequent month. So for example, adding one year to the 30th of Kislev
 will result in the 1st of Tevet, if Kislev only has 29 days in the "target" year.

--- a/src/NodaTime.Web/Markdown/2.0.x/calendars.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/calendars.md
@@ -34,7 +34,7 @@ First supported in v1.0.0
 API access: [`CalendarSystem.Iso`](noda-property://NodaTime.CalendarSystem.Iso)
 
 This is the default calendar system when constructing values without explicitly specifying a calendar.
-It is designed to correspond to the calendar described in [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601),
+It is designed to correspond to the calendar described in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601),
 and is equivalent to the Gregorian calendar in all respects other than the century and year-of-century values.
 
 As of Noda Time 2.0, century and year-of-century properties have
@@ -51,7 +51,7 @@ API access:
 
 - [`CalendarSystem.Gregorian`](noda-property://NodaTime.CalendarSystem.Gregorian)
 
-The [Gregorian calendar](http://en.wikipedia.org/wiki/Gregorian_calendar) was a refinement to the Julian calendar,
+The [Gregorian calendar](https://en.wikipedia.org/wiki/Gregorian_calendar) was a refinement to the Julian calendar,
 changing the formula for which years are leap years from "whenever the year is divisible by 4" to
 "whenever the year is divisible by 4, except when it's also divisible by 100 and *not* divisible by 400". This keeps
 the calendar in closer sync with the observed rotation of the earth around the sun.
@@ -68,7 +68,7 @@ Julian
 First supported in v1.0.0  
 API access: [`CalendarSystem.Julian`](noda-property://NodaTime.CalendarSystem.Julian)
 
-The [Julian calendar](http://en.wikipedia.org/wiki/Julian_calendar) was introduced by Julius Caesar in 46BC, and took
+The [Julian calendar](https://en.wikipedia.org/wiki/Julian_calendar) was introduced by Julius Caesar in 46BC, and took
 effect in 45BC. It was like the Gregorian calendar, but with a simpler leap year rule - every year number divisible by
 4 was a leap year.
 
@@ -98,7 +98,7 @@ API access:
 - [`CalendarSystem.GetIslamicCalendar()`](noda-type://NodaTime.CalendarSystem#NodaTime_CalendarSystem_GetIslamicCalendar_NodaTime_Calendars_IslamicLeapYearPattern_NodaTime_Calendars_IslamicEpoch_)
 - [`CalendarSystem.IslamicBcl`](noda-property://NodaTime.CalendarSystem.IslamicBcl)
 
-The [Islamic (or Hijri) calendar](http://en.wikipedia.org/wiki/Islamic_calendar) is a lunar calendar with years of 12
+The [Islamic (or Hijri) calendar](https://en.wikipedia.org/wiki/Islamic_calendar) is a lunar calendar with years of 12
 months, totalling either 355 or 354 days depending on whether or not it's a leap year. There are various schemes
 for determining which years are leap years, all based on a 30 year cycle. Noda Time supports four options here,
 specified in the [`IslamicLeapYearPattern`](noda-type://NodaTime.Calendars.IslamicLeapYearPattern) enumeration.
@@ -129,7 +129,7 @@ API access:
 - [`CalendarSystem.PersianAstronomical`](noda-property://NodaTime.CalendarSystem.PersianAstronomical)
 - [`CalendarSystem.PersianArithmetic`](noda-property://NodaTime.CalendarSystem.PersianArithmetic)
 
-The [Persian (or Solar Hijri) calendar](http://en.wikipedia.org/wiki/Solar_Hijri_calendar) is the official calendar of
+The [Persian (or Solar Hijri) calendar](https://en.wikipedia.org/wiki/Solar_Hijri_calendar) is the official calendar of
 Iran and Pakistan. Three variants of this are supported in Noda Time:
 
 - The "simple" calendar, which was the only one supported in Noda Time 1.3, and matches the behaviour of the BCL
@@ -150,13 +150,13 @@ Um Al Qura
 First supported in v2.0.0  
 API access: [`CalendarSystem.UmAlQura`](noda-property://NodaTime.CalendarSystem.UmAlQura)
 
-The [Um Al Qura (or Umm al-Qura) calendar](http://en.wikipedia.org/wiki/Islamic_calendar#Saudi_Arabia.27s_Umm_al-Qura_calendar),
+The [Um Al Qura (or Umm al-Qura) calendar](https://en.wikipedia.org/wiki/Islamic_calendar#Saudi_Arabia.27s_Umm_al-Qura_calendar),
 primarily used in Saudi Arabia, is similar to the Islamic Hijri calendar, except that instead of being algorithmic it relies on
 tabular data. Each month has 29 or 30 days, and each year has 354 or 355 days, but the month lengths cannot be determined
 algorithmically.
 
 The Noda Time implementation uses data from the BCL
-[`UmAlQuraCalendar`](http://msdn.microsoft.com/en-us/library/system.globalization.umalquracalendar.aspx) to obtain the required
+[`UmAlQuraCalendar`](https://msdn.microsoft.com/en-us/library/system.globalization.umalquracalendar.aspx) to obtain the required
 information, but the data is baked into Noda Time so it is available
 on all platforms.
 
@@ -170,7 +170,7 @@ API access:
 - [`CalendarSystem.HebrewCivil`](noda-property://NodaTime.CalendarSystem.HebrewCivil)
 - [`CalendarSystem.HebrewScriptural`](noda-property://NodaTime.CalendarSystem.HebrewScriptural)
 
-The [Hebrew calendar](http://en.wikipedia.org/wiki/Hebrew_calendar) is a lunisolar calendar used primarily for determination
+The [Hebrew calendar](https://en.wikipedia.org/wiki/Hebrew_calendar) is a lunisolar calendar used primarily for determination
 of religious holidays within Judaism. It was originally observational, but a computed version is now commonly used. Even
 this is very complicated, however: most years have 12 months, but 7 in every 19 years are leap years, with 13 months. Two
 of the months in the regular calendar have variable numbers of days depending on other aspects of the calendar, in order

--- a/src/NodaTime.Web/Markdown/2.0.x/calendars.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/calendars.md
@@ -1,6 +1,6 @@
 @Title="Calendars"
 
-As described in the [core concepts documentation](concepts.html), a calendar system is a scheme
+As described in the [core concepts documentation](concepts), a calendar system is a scheme
 for dividing time into eras, years, months and days and so on. As a matter of simplification,
 Noda Time treats every day as starting and ending at midnight, despite some calendars (such as
 the Islamic and Hebrew calendars) traditionally having days stretching from sunset to sunset.
@@ -25,7 +25,7 @@ concepts of eras, years, months and days - not the alternative
 mapping of a date to a "week year, week of week year, day of week".
 That is now represented by
 [`IWeekYearRule`](noda-type://NodaTime.Calendars.IWeekYearRule).
-Details are in the [week year page](weekyears.html).
+Details are in the [week year page](weekyears).
 
 ISO
 ===

--- a/src/NodaTime.Web/Markdown/2.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/concepts.md
@@ -207,7 +207,7 @@ available within periods. `Period` is used for arithmetic on locally-based value
 See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
-[2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
+[2]: https://blogs.msdn.microsoft.com/bclteam/2007/06/18/a-brief-history-of-datetime-anthony-moore/
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime

--- a/src/NodaTime.Web/Markdown/2.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/concepts.md
@@ -1,7 +1,7 @@
 @Title="Core concepts"
 
 This is a companion page to the
-["core types quick reference"](core-types.html), and ["choosing between types"](type-choices.html)
+["core types quick reference"](core-types), and ["choosing between types"](type-choices)
 pages, describing the fundamental concepts in Noda Time.
 
 One of the benefits of Noda Time over the Base Class Library (BCL)
@@ -20,7 +20,7 @@ date and time data for your whole project.
 This document introduces the core concepts, but in order to avoid it
 being too overwhelming, we won't go into the fine details. See
 individual pages (particularly the ["choosing between
-types"](type-choices.html) page) and the [API documentation][api]
+types"](type-choices) page) and the [API documentation][api]
 for more information.
 
 "Local" and "global" (or "absolute") types
@@ -118,7 +118,7 @@ although a few useful methods are exposed. Most of the time even if you
 an appropriate object, and then pass it to other constructors etc as a
 little bundle of magic which simply does the right thing for you.
 
-See the [calendars documentation](calendars.html) for more details about
+See the [calendars documentation](calendars) for more details about
 which calendar systems are supported.
 
 <a name="time-zones"></a>Time zones
@@ -173,7 +173,7 @@ Noda Time handles two of them: it is able to map BCL `TimeZoneInfo` objects
 using `BclDateTimeZone`, or it can use the [tz database][TZDB] (also known as
 the IANA Time Zone database, or zoneinfo or Olson database). A version of TZDB
 is embedded within the Noda Time distribution, and if you need a more recent
-one, there are [instructions on how to download and use new data](tzdb.html).
+one, there are [instructions on how to download and use new data](tzdb).
 We generally recommend that you isolate yourself from the provider you're using
 by only depending on [`IDateTimeZoneProvider`][IDateTimeZoneProvider], and
 injecting the appropriate provider in the normal way. "Stock" providers are
@@ -204,7 +204,7 @@ and so on) will always represent the same length of time, but they're still
 available within periods. `Period` is used for arithmetic on locally-based values
 (`LocalDateTime`, `LocalDate`, `LocalTime`).
 
-See the [arithmetic](arithmetic.html) page for more information.
+See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx

--- a/src/NodaTime.Web/Markdown/2.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/concepts.md
@@ -206,7 +206,7 @@ available within periods. `Period` is used for arithmetic on locally-based value
 
 See the [arithmetic](arithmetic.html) page for more information.
 
-[api]: ../api/Index.html
+[api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/2.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/concepts.md
@@ -213,14 +213,14 @@ See the [arithmetic](arithmetic) page for more information.
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime
 [Instant]: noda-type://NodaTime.Instant
 [CalendarSystem]: noda-type://NodaTime.CalendarSystem
-[UTC]: http://en.wikipedia.org/wiki/Coordinated_Universal_Time
+[UTC]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
 [DateTimeZone]: noda-type://NodaTime.DateTimeZone
 [Offset]: noda-type://NodaTime.Offset
 [Period]: noda-type://NodaTime.Period
 [Duration]: noda-type://NodaTime.Duration
 [OffsetDateTime]: noda-type://NodaTime.OffsetDateTime
 [ZonedDateTime]: noda-type://NodaTime.ZonedDateTime
-[TZDB]: http://www.iana.org/time-zones
+[TZDB]: https://www.iana.org/time-zones
 [IDateTimeZoneProvider]: noda-type://NodaTime.IDateTimeZoneProvider
 [DateTimeZoneProviders]: noda-type://NodaTime.DateTimeZoneProviders
-[TimeSpan]: http://msdn.microsoft.com/en-us/library/system.timespan.aspx
+[TimeSpan]: https://msdn.microsoft.com/en-us/library/system.timespan.aspx

--- a/src/NodaTime.Web/Markdown/2.0.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/core-types.md
@@ -109,7 +109,7 @@ Interval
 An [`Interval`][Interval] is simply two instants - a start and an end. The interval includes the start, and excludes the end, which means that if you have abutting intervals any instant will be in
 exactly one of those intervals.
 
-[DST]: http://en.wikipedia.org/wiki/Daylight_saving_time
+[DST]: https://en.wikipedia.org/wiki/Daylight_saving_time
 [Interval]: noda-type://NodaTime.Interval
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/2.0.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/core-types.md
@@ -1,7 +1,7 @@
 @Title="Core types quick reference"
 
 This is a companion page to the
-["core concepts"](concepts.html), and ["choosing between types"](type-choices.html)
+["core concepts"](concepts), and ["choosing between types"](type-choices)
 pages, describing the fundamental types in Noda Time very briefly, primarily for reference.
 If you're not familiar with the core concepts, read that page first.
 
@@ -93,7 +93,7 @@ January.
 IClock
 ------
 
-An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing.html), this is defined
+An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing), this is defined
 as an interface; in a production deployment you're likely to use the [`SystemClock`][SystemClock] singleton implementation.
 
 Often you may want to repeatedly access the current time or date in a specific time zone.

--- a/src/NodaTime.Web/Markdown/2.0.x/design.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/design.md
@@ -104,5 +104,5 @@ similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
 [2]: http://semver.org/
-[3]: http://www.joda.org/joda-time
+[3]: http://www.joda.org/joda-time/
 [4]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/2.0.x/design.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/design.md
@@ -58,7 +58,7 @@ developers want. However, we do *not* default to using the system
 time zone, or using "now" as a default date/time value, or using
 the current thread's current format provider for parsing and
 formatting (except for the BCL-compatible method calls; see [text
-handling][5] for more information on this).
+handling](text) for more information on this).
   We make it easy to do all of these things, but they're just not
 appropriate as implicit defaults. It's too easy to *accidentally*
 depend on the time zone your system happens to be running in (etc)
@@ -67,7 +67,7 @@ without anything obvious in your code.
 What this means in practice
 ---------------------------
 
-- There are rather more types and [concepts][1] to learn about in
+- There are rather more types and [concepts](concepts) to learn about in
 Noda Time than in .NET. One of the *problems* with .NET's date and
 time API is that `DateTime` doesn't have a single well-defined
 meaning.
@@ -80,7 +80,7 @@ LocalDateTime()` or `default(LocalDateTime)`) is *not* a useful
 value. This is unfortunate, but hard to avoid.
 
 - All the value types and almost all the reference types are
-immutable and [thread-safe](threading.html). We expect objects like calendars, time
+immutable and [thread-safe](threading). We expect objects like calendars, time
 zones, and patterns for formatting and parsing text to be reused
 freely between many threads. Occasionally there's hidden mutability
 in terms of caches, but this should not affect you, the user. We make sure it
@@ -103,8 +103,6 @@ requirements, chances are someone else will want to do something
 similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
-[1]: concepts.html
 [2]: http://semver.org/
 [3]: http://www.joda.org/joda-time
 [4]: https://groups.google.com/group/noda-time
-[5]: text.html

--- a/src/NodaTime.Web/Markdown/2.0.x/duration-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/duration-patterns.md
@@ -13,7 +13,7 @@ The following standard pattern is supported:
 Custom Patterns
 ---------------
 
-The following custom pattern characters are supported for durations. See [custom pattern notes](text.html#custom-patterns)
+The following custom pattern characters are supported for durations. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 The pattern letters basically split into two categories:

--- a/src/NodaTime.Web/Markdown/2.0.x/index.json
+++ b/src/NodaTime.Web/Markdown/2.0.x/index.json
@@ -22,5 +22,5 @@
       "pageIds": [ "testing", "tzdb", "mono", "limitations", "roadmap" ]
     }
   ],
-  "resources":  ["conversions.png"]
+  "resources": [ "conversions.png" ]
 }

--- a/src/NodaTime.Web/Markdown/2.0.x/index.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/index.md
@@ -25,5 +25,5 @@ Resources
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com/
-[so-tag]: http://stackoverflow.com/questions/tagged/nodatime
+[so]: https://stackoverflow.com/
+[so-tag]: https://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/2.0.x/index.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/index.md
@@ -20,10 +20,10 @@ Resources
 - [Blog][blog]
 - [Mailing list][group]
 
-[blog]: http://blog.nodatime.org
+[blog]: http://blog.nodatime.org/
 [group]: https://groups.google.com/group/noda-time
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com
+[so]: http://stackoverflow.com/
 [so-tag]: http://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/2.0.x/installation.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/installation.md
@@ -1,11 +1,11 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org/) with
+Our primary distribution channel is [NuGet](https://www.nuget.org/) with
 three packages:
 
-- [NodaTime](http://nuget.org/packages/NodaTime)
-- [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing)
-- [NodaTime.Serialization.JsonNet](http://nuget.org/packages/NodaTime.Serialization.JsonNet)
+- [NodaTime](https://www.nuget.org/packages/NodaTime)
+- [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing)
+- [NodaTime.Serialization.JsonNet](https://www.nuget.org/packages/NodaTime.Serialization.JsonNet)
 
 Alternatively, source and binary downloads are available on the
 [project download page][downloads].
@@ -64,9 +64,9 @@ be able to start using Noda Time immediately, with no further effort.
 Debugging
 ---------
 
-As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org/). You can configure
+As of version 1.1, the source code of Noda Time is published to [SymbolSource](https://www.symbolsource.org/). You can configure
 Visual Studio to automatically fetch the source code if you need to step into it when debugging your application. It takes a little
-bit of setup, but there are [full instructions](http://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
+bit of setup, but there are [full instructions](https://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
 (The instructions aren't specific to Noda Time, so if you're
 already using SymbolSource as one of your symbol servers, you just need to make sure you're not excluding Noda Time from the list of
 modules to fetch.)

--- a/src/NodaTime.Web/Markdown/2.0.x/installation.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/installation.md
@@ -22,7 +22,7 @@ System requirements
 
 From release 1.1 onwards, there are two builds of Noda Time: the desktop version and the Portable Class Library version.
 
-The desktop version requires .NET 3.5 (client profile). This build also supports Mono, [with some caveats](mono.html).
+The desktop version requires .NET 3.5 (client profile). This build also supports Mono, [with some caveats](mono).
 
 The PCL build is configured to support:
 
@@ -35,7 +35,7 @@ The PCL build also appears to work with Xamarin.iOS and Xamarin.Android apps, bu
 
 Noda Time does *not* support XBox 360 or Silverlight 3, and it's unlikely that we'd ever want to introduce support
 for these. (It's more likely that over time, we'll drop support for Silverlight - but not imminently, of course.)
-See the [limitations](limitations.html) page for differences between the PCL build and the desktop build.
+See the [limitations](limitations) page for differences between the PCL build and the desktop build.
 
 The NodaTime.Serialization.JsonNet assembly is built and tested against Json.NET version 4.5.11. It's likely that any version
 of Json.NET from 4.5.0 onwards will work with Noda Time, but we'd recommend using at least 4.5.11. As far as we know, there
@@ -47,14 +47,14 @@ Package contents and getting started
 ------------------------------------
 
 Everything you need to *use* Noda Time is contained in the NodaTime package. The NodaTime.Testing package is designed
-for testing code which uses Noda Time. See the [testing guide](testing.html) for more information. It is expected
+for testing code which uses Noda Time. See the [testing guide](testing) for more information. It is expected
 that production code will only refer to the `NodaTime.dll` assembly, and that's all that's required at execution time.
-This assembly includes the [TZDB database](tzdb.html) as an embedded resource.
+This assembly includes the [TZDB database](tzdb) as an embedded resource.
 
 For Json.NET serialization, the NodaTime.Serialization.JsonNet package (containing a single assembly of the same name) is 
 required, as well as an appropriate version of Json.NET itself. There is a NuGet dependency from NodaTime.Serialization.JsonNet
 to the newtonsoft.json package, so if you're using NuGet you just need to refer to NodaTime.Serialization.JsonNet and an 
-appropriate version of Json.NET will be installed automatically. See the [serialization guide](serialization.html) for more
+appropriate version of Json.NET will be installed automatically. See the [serialization guide](serialization) for more
 information on using Noda Time with Json.NET.
 
 Everything within the NodaTime assembly is in the NodaTime namespace or a "child" namespace. After adding a reference to

--- a/src/NodaTime.Web/Markdown/2.0.x/installation.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/installation.md
@@ -1,6 +1,6 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org) with
+Our primary distribution channel is [NuGet](http://nuget.org/) with
 three packages:
 
 - [NodaTime](http://nuget.org/packages/NodaTime)
@@ -64,7 +64,7 @@ be able to start using Noda Time immediately, with no further effort.
 Debugging
 ---------
 
-As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org). You can configure
+As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org/). You can configure
 Visual Studio to automatically fetch the source code if you need to step into it when debugging your application. It takes a little
 bit of setup, but there are [full instructions](http://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
 (The instructions aren't specific to Noda Time, so if you're

--- a/src/NodaTime.Web/Markdown/2.0.x/instant-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/instant-patterns.md
@@ -16,6 +16,6 @@ The following standard pattern is supported:
 Custom Patterns
 ---------------
 
-[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns.html).
+[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns).
 The pattern allows the culture to be specified, but *always* uses the ISO-8601 calendar, and *always* uses the UTC
 time zone. The "template value" is always the unix epoch.

--- a/src/NodaTime.Web/Markdown/2.0.x/limitations.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/limitations.md
@@ -46,7 +46,7 @@ we may want to optimize further at some point too.
 
 Additionally, all our text localization resources (day and month names) come from the .NET
 framework itself. That has some significant limitations, and makes Noda Time more reliant
-on `CultureInfo` than is ideal. [CLDR](http://cldr.unicode.org) contains more information,
+on `CultureInfo` than is ideal. [CLDR](http://cldr.unicode.org/) contains more information,
 which should allow for features such as ordinal day numbers ("1st", "2nd", "3rd") and
 a broader set of supported calendar/culture combinations (such as English names for the
 Hebrew calendar months).
@@ -67,7 +67,7 @@ hot-fixes for cultures which we don't support as well as we might.
 More time zone information
 ==========================
 
-[CLDR](http://cldr.unicode.org) provides useful information about
+[CLDR](http://cldr.unicode.org/) provides useful information about
 time zones such as a canonical ID and user-friendly representations
 (countries and sample cities). We'd also like to make it clearer
 when one zoneinfo time zone is an alias for another.

--- a/src/NodaTime.Web/Markdown/2.0.x/limitations.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/limitations.md
@@ -6,7 +6,7 @@ aspects we'd like to improve; see the
 [issues list](https://github.com/nodatime/nodatime/issues) for
 others.
 
-We also have a [roadmap](roadmap.html) of intended releases. This is
+We also have a [roadmap](roadmap) of intended releases. This is
 always tentative, of course, but it helps to give some clarity to our
 decisions in terms of what to work on next.
 
@@ -33,7 +33,7 @@ Additionally, the PCL doesn't support .NET resource files as fully as the deskto
 framework; in particular, it doesn't allow you to retrieve non-string resources. This
 has provoked a change from the previous resource-based format used for TZDB, to a
 stream-based format, which is now the default. For most users this will be a no-op
-change, but it does affect how you [build and use a custom version of TZDB](tzdb.html).
+change, but it does affect how you [build and use a custom version of TZDB](tzdb).
 
 Fuller text support
 ===================
@@ -52,7 +52,7 @@ a broader set of supported calendar/culture combinations (such as English names 
 Hebrew calendar months).
 
 Speaking of the Hebrew calendar, initial support for the calendar has been introduced
-in 1.3.0, but month names are *not* properly supported currently. See [local date formatting](localdate-patterns.html) for more details of this limitation.
+in 1.3.0, but month names are *not* properly supported currently. See [local date formatting](localdate-patterns) for more details of this limitation.
 
 Better resource handling
 ========================
@@ -81,7 +81,7 @@ highest priority is probably an adapter for the BCL calendars.
 Smarter arithmetic
 ==================
 
-As noted in the [arithmetic guide](arithmetic.html), arithmetic using
+As noted in the [arithmetic guide](arithmetic), arithmetic using
 [`Period`](noda-type://NodaTime.Period) is pretty simplistic. We may
 want something smarter, probably to go alongside the "dumb but
 predictable" existing logic. This will definitely be driven by real

--- a/src/NodaTime.Web/Markdown/2.0.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/localdate-patterns.md
@@ -19,7 +19,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom format pattern characters are supported for local dates. See [custom pattern notes](text.html#custom-patterns)
+The following custom format pattern characters are supported for local dates. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 For the meanings of "absolute" years and text handling, see later details.

--- a/src/NodaTime.Web/Markdown/2.0.x/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/localdate-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `d`: Short format pattern.  
-  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
+  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
   For example, in the invariant culture this is "MM/dd/yyyy".
 
 - `D`: Long format pattern.  
-  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
+  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
   For example, in the invariant culture this is "dddd, dd MMMM yyyy".
   This is the default format pattern.
 

--- a/src/NodaTime.Web/Markdown/2.0.x/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/localdatetime-patterns.md
@@ -20,17 +20,17 @@ The following standard patterns are supported:
 
 - `s`: The sortable pattern, which is always "uuuu'-'MM'-'dd'T'HH':'mm':'ss" using the invariant culture. (Note: this is only truly sortable for years within the range \[0-9999\].)
 
-- `f`: The culture's [long date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `f`: The culture's [long date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
+- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
   For example, in the invariant culture this is "dddd, dd MMMM yyyy HH:mm:ss".
 
-- `g`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `g`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `G`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [long time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
+- `G`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [long time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
   This is the default format pattern.
 
 Custom Patterns

--- a/src/NodaTime.Web/Markdown/2.0.x/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/localdatetime-patterns.md
@@ -36,8 +36,8 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The custom format patterns for local date and time values are provided by combining the [custom patterns for `LocalDate`](localdate-patterns.html) with
-the [custom patterns for `LocalTime`](localtime-patterns.html). The result is simply the combination of the date and the time.
+The custom format patterns for local date and time values are provided by combining the [custom patterns for `LocalDate`](localdate-patterns) with
+the [custom patterns for `LocalTime`](localtime-patterns). The result is simply the combination of the date and the time.
 
 There are two exceptions to this:
 

--- a/src/NodaTime.Web/Markdown/2.0.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/localtime-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `t`: Short format pattern.  
-  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx). 
+  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx). 
   For example, in the invariant culture this is "HH:mm".
 
 - `T`: Long format pattern.  
-  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx). 
+  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx). 
   For example, in the invariant culture this is "HH:mm:ss". This is the default format pattern.
 
 - `r`: Round-trip pattern.  

--- a/src/NodaTime.Web/Markdown/2.0.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/localtime-patterns.md
@@ -39,7 +39,7 @@ for general notes on custom patterns, including characters used for escaping and
         The hour of day in the 24-hour clock; a value 0-23.
         <p>Note that when parsing local date/time values, a value of <code>24</code>
         may be exceptionally permitted to allow
-        <a href="localdatetime-patterns.md">specification of a following day's
+        <a href="localdatetime-patterns">specification of a following day's
         midnight</a>.
       </td>
       <td>

--- a/src/NodaTime.Web/Markdown/2.0.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/localtime-patterns.md
@@ -21,7 +21,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom format pattern characters are supported for local times. See [custom pattern notes](text.html#custom-patterns)
+The following custom format pattern characters are supported for local times. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/2.0.x/mono.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com) is an open source implementation of
+[Mono](http://mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/2.0.x/mono.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com/) is an open source implementation of
+[Mono](http://www.mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/2.0.x/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/offset-patterns.md
@@ -29,7 +29,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom pattern characters are supported for offsets. See [custom pattern notes](text.html#custom-patterns)
+The following custom pattern characters are supported for offsets. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/2.0.x/offsetdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/offsetdatetime-patterns.md
@@ -12,9 +12,9 @@ Standard Patterns
 Custom Patterns
 ---------------
 
-The custom format patterns for the local date and time parts of the value are the same as the [custom patterns for `LocalDateTime`](localdatetime-patterns.html). There is an additional specifier for the offset.
+The custom format patterns for the local date and time parts of the value are the same as the [custom patterns for `LocalDateTime`](localdatetime-patterns). There is an additional specifier for the offset.
 
-The "o" specifier must always be followed by a [pattern for `Offset`](offset-patterns.html) within angle brackets. The pattern may be a standard pattern or a custom pattern. For example, a pattern of `uuuu-MM-dd HH:mm:ss o<G>` might produce output of "2013-07-17 06:20:35 Z" or "2013-07-17 07:20:35 +01:00".
+The "o" specifier must always be followed by a [pattern for `Offset`](offset-patterns) within angle brackets. The pattern may be a standard pattern or a custom pattern. For example, a pattern of `uuuu-MM-dd HH:mm:ss o<G>` might produce output of "2013-07-17 06:20:35 Z" or "2013-07-17 07:20:35 +01:00".
 
 To use culture-specific standard date or time patterns in a custom `OffsetDateTime` pattern, use some combination of the following specifiers:
 

--- a/src/NodaTime.Web/Markdown/2.0.x/range.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/range.md
@@ -118,7 +118,7 @@ which is just shy of 7,304,119 days. Internally, durations are stored in terms o
 implementation detail to be sure, but one which sometimes affects other decisions).
 
 Additionally, it seems useful to be able to cover the full range of
-[`TimeSpan`](http://msdn.microsoft.com/en-us/library/system.timespan), given that `Duration` is meant to be the roughly-equivalent
+[`TimeSpan`](https://msdn.microsoft.com/en-us/library/system.timespan), given that `Duration` is meant to be the roughly-equivalent
 type.
 
 The result is that we have a range of days from -2<sup>24</sup> to +2<sup>24</sup>-1 - and the nanosecond part means that the

--- a/src/NodaTime.Web/Markdown/2.0.x/rationale.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/rationale.md
@@ -28,5 +28,5 @@ a new date/time API, the Noda Time team would happily go into
 retirement (other than for the sake of those forced to stick with
 earlier versions of .NET, of course).
 
-[1]: http://www.joda.org/joda-time
+[1]: http://www.joda.org/joda-time/
 [2]: http://blog.nodatime.org/2011/08/what-wrong-with-datetime-anyway.html

--- a/src/NodaTime.Web/Markdown/2.0.x/roadmap.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/roadmap.md
@@ -2,7 +2,7 @@
 
 Our online Developer Guide contains [an _approximate_ roadmap][roadmap] for the
 major features that we hope to support in Noda Time, some of which are inspired
-by Noda Time's [current limitations](limitations.html).
+by Noda Time's [current limitations](limitations).
 
 [roadmap]: /developer/roadmap
 

--- a/src/NodaTime.Web/Markdown/2.0.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/serialization.md
@@ -187,7 +187,7 @@ An extension method of `ConfigureForNodaTime` is provided on both `JsonSerialize
 `JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields
 for individual converters. (All converters are immutable.)
 
-Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter_1).
+Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter-1).
 
 Please ensure that *all* relevant JSON handlers are configured appropriately. In some cases there may be more than
 one involved, possibly one for reading and one for writing, depending on your configuration. For ASP.NET using

--- a/src/NodaTime.Web/Markdown/2.0.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/serialization.md
@@ -174,12 +174,12 @@ The serialized form is not documented here as it is not expected to be consumed 
 Third-party serialization
 -------------------------
 
-The Noda Time project itself has support for [Json.NET](http://json.net). Additionally, there is a separate project for [ServiceStack.Text](https://github.com/ServiceStack/ServiceStack.Text/) support. Details of both are given below.
+The Noda Time project itself has support for [Json.NET](http://json.net/). Additionally, there is a separate project for [ServiceStack.Text](https://github.com/ServiceStack/ServiceStack.Text/) support. Details of both are given below.
 
 Json.NET: NodaTime.Serialization.JsonNet
 ----------------------------------------
 
-[Json.NET](http://json.net) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
+[Json.NET](http://json.net/) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
 of the same name. This assembly is built against Json.NET 4.5.11, and is available in both portable and desktop flavours. It can be installed using NuGet, again with a package name of `NodaTime.Serialization.JsonNet`. See the
 [installation guide](installation) for more details.
 

--- a/src/NodaTime.Web/Markdown/2.0.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/serialization.md
@@ -67,9 +67,9 @@ properties, which would entirely defeat the point of the exercise.
 
 It's also worth noting that the XML serialization in .NET doesn't allow any user-defined types to be
 serialized via attributes. So while it would make perfect sense to be able to apply
-[`[XmlAttribute]`](http://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlattributeattribute)
+[`[XmlAttribute]`](https://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlattributeattribute)
 to a particular property and have it serialized as an attribute, in reality you need to use
-[`[XmlElement]`](http://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlelementattribute.aspx)
+[`[XmlElement]`](https://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlelementattribute.aspx)
 instead. There's nothing Noda Time can do here; it's just a [limitation of .NET XML serialization](http://connect.microsoft.com/VisualStudio/feedback/details/277641/xmlattribute-xmltext-cannot-be-used-to-encode-types-implementing-ixmlserializable).
 
 Finally, serialization of `ZonedDateTime` comes with the tricky question of which `IDateTimeZoneProvider` to use in order to convert a time zone ID specified in the XML into a `DateTimeZone`.

--- a/src/NodaTime.Web/Markdown/2.0.x/serialization.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/serialization.md
@@ -181,7 +181,7 @@ Json.NET: NodaTime.Serialization.JsonNet
 
 [Json.NET](http://json.net) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
 of the same name. This assembly is built against Json.NET 4.5.11, and is available in both portable and desktop flavours. It can be installed using NuGet, again with a package name of `NodaTime.Serialization.JsonNet`. See the
-[installation guide](installation.html) for more details.
+[installation guide](installation) for more details.
 
 An extension method of `ConfigureForNodaTime` is provided on both `JsonSerializer` and
 `JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields

--- a/src/NodaTime.Web/Markdown/2.0.x/testing.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/testing.md
@@ -6,7 +6,7 @@ which *uses* Noda Time.
 NodaTime.Testing
 ----------------
 
-Firstly, get hold of the [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
+Firstly, get hold of the [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
 small, but it will no doubt grow - and it will make your life much easier. The purpose of the assembly is to provide
 easy-to-use test doubles which can be used instead of the real implementations.
 

--- a/src/NodaTime.Web/Markdown/2.0.x/text.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/text.md
@@ -61,15 +61,15 @@ available patterns are as consistent as possible within reason, but
 documenting each separately avoids confusion with some field
 specifiers being available for some types but not others.
 
-- [Duration patterns](duration-patterns.html)
-- [Offset patterns](offset-patterns.html)
-- [Instant patterns](instant-patterns.html)
-- [LocalTime patterns](localtime-patterns.html)
-- [LocalDate patterns](localdate-patterns.html)
-- [LocalDateTime patterns](localdatetime-patterns.html)
-- [OffsetDateTime patterns](offsetdatetime-patterns.html)
-- [ZonedDateTime patterns](zoneddatetime-patterns.html)
-- [Period patterns](period-patterns.html)
+- [Duration patterns](duration-patterns)
+- [Offset patterns](offset-patterns)
+- [Instant patterns](instant-patterns)
+- [LocalTime patterns](localtime-patterns)
+- [LocalDate patterns](localdate-patterns)
+- [LocalDateTime patterns](localdatetime-patterns)
+- [OffsetDateTime patterns](offsetdatetime-patterns)
+- [ZonedDateTime patterns](zoneddatetime-patterns)
+- [Period patterns](period-patterns)
 
 <a name="custom-patterns"></a>Custom patterns
 ---------------

--- a/src/NodaTime.Web/Markdown/2.0.x/text.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/text.md
@@ -165,7 +165,7 @@ Often you don't have much choice about how to parse or format text: if you're in
   - Try to use a pattern which is ISO-friendly where possible; it'll make it easier to interoperate with other systems in the future.
   - Quote all non-field values other than spaces.
 
-  [2]: http://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
+  [2]: https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
   [3]: noda-ns://NodaTime.Text
   [4]: noda-type://NodaTime.LocalDateTime
   [5]: noda-type://NodaTime.Instant

--- a/src/NodaTime.Web/Markdown/2.0.x/text.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/text.md
@@ -34,10 +34,10 @@ information or other options.
 Each core Noda type has its own pattern type such as
 [`OffsetPattern`](noda-type://NodaTime.Text.OffsetPattern). All
 these patterns implement the
-[`IPattern<T>`](noda-type://NodaTime.Text.IPattern_1) interface,
+[`IPattern<T>`](noda-type://NodaTime.Text.IPattern-1) interface,
 which has simple `Format` and `Parse` methods taking just the value
 and text respectively. The result of `Parse` is a
-[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult_1) which
+[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult-1) which
 encapsulates both success and failure results.
 
 The BCL-based API

--- a/src/NodaTime.Web/Markdown/2.0.x/threading.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/threading.md
@@ -62,6 +62,6 @@ Enums
 Enums should generally be treated as immutable value types. Accessing the enum values directly can *never* have any nasty effects,
 but be careful around using a writable field of an enum type, for the same reasons as given in the earlier discussion.
 
-[lippert]: http://blogs.msdn.com/b/ericlippert/archive/2009/10/19/what-is-this-thing-you-call-thread-safe.aspx
-[immutability]: http://blogs.msdn.com/b/ericlippert/archive/tags/immutability/
+[lippert]: https://blogs.msdn.microsoft.com/ericlippert/2009/10/19/what-is-this-thing-you-call-thread-safe/
+[immutability]: https://blogs.msdn.microsoft.com/ericlippert/tag/immutability/
 [mailing list]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/2.0.x/trivia.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/trivia.md
@@ -88,12 +88,12 @@ year), they'd be somewhere in between for about 40 years.
 While this almost sounds like a reasonable plan (almost like the way that
 [Google "smears" a leap second across a whole minute rather than simply
 adding a
-second](http://googleblog.blogspot.com/2011/09/time-technology-and-leaping-seconds.html)),
+second](https://googleblog.blogspot.com/2011/09/time-technology-and-leaping-seconds.html)),
 it went horribly wrong. In February 1700, Sweden skipped the leap year,
 according to plan. That meant that they were one day ahead of the countries
 still following the Julian calendar. Unfortunately, in the  same year -
 although ironically *before* February 28th - the [Great Northern
-War](http://en.wikipedia.org/wiki/Great_Northern_War) broke out. This
+War](https://en.wikipedia.org/wiki/Great_Northern_War) broke out. This
 distracted Sweden from their calendrical machinations, and they *did* have a
 leap year in 1704 and 1708.
 
@@ -115,7 +115,7 @@ alone in such an odd way.
 
 **Read more:**
 
-- [Wikipedia](http://en.wikipedia.org/wiki/February_30)
+- [Wikipedia](https://en.wikipedia.org/wiki/February_30)
 
 The time in Greenwich at the Unix epoch
 ---
@@ -154,7 +154,7 @@ offset. The transition from summer time to standard time on October 27th
 
 - [BBC News](http://www.bbc.co.uk/news/uk-scotland-11643098)
 - [History of Legal Time in
-  Britain](http://www.polyomino.org.uk/british-time/)
+  Britain](https://www.polyomino.org.uk/british-time/)
 
 <sup>1</sup> I'm studiously avoiding the differentiation between, UTC, UT,
 UT0, TAI and the like. They make my head hurt, and in common usage time zone
@@ -223,7 +223,7 @@ careful before you compare it with another date. To avoid *too* much
 confusion, many historical dates are given using the Julian calendar, which
 was being observed at the time (depending on the place, of course), while
 using the "New Style" of year numbering. For example, [Henry
-VIII](http://en.wikipedia.org/wiki/Henry_VIII_of_England) died on January
+VIII](https://en.wikipedia.org/wiki/Henry_VIII_of_England) died on January
 28th 1547 (New Style) or January 28th 1546 (Old Style). In my experience,
 some web pages explicitly call out which numbering style they're using,
 others record it as "January 28th 1546/1547" and hope that readers
@@ -241,11 +241,11 @@ anyway.
 
 - [Wikipedia: Calender (New Style) act][wikipedia-newstyle-act]
 - [Wikipedia: Old and New Style
-  dates](http://en.wikipedia.org/wiki/Old_Style_and_New_Style_dates)
+  dates](https://en.wikipedia.org/wiki/Old_Style_and_New_Style_dates)
 - [Malcolm Rowe's write-up in
   Google+](https://plus.google.com/+MalcolmRowe/posts/Bf5swesMPUV)
 
-[wikipedia-newstyle-act]: http://en.wikipedia.org/wiki/Calendar_(New_Style)_Act_1750
+[wikipedia-newstyle-act]: https://en.wikipedia.org/wiki/Calendar_(New_Style)_Act_1750
 
 <sup>1</sup> When I say "we" here, I really mean "Malcolm" who did most of
 the work on understanding this issue based on Wikipedia and primary
@@ -304,9 +304,9 @@ typically deploys changes to the *Windows* time zone database...
 **Read more:**
 
 - [Argentina (announcement on 7th October 2009, due 18th
-  October)](http://www.timeanddate.com/news/time/argentina-dst-2009-2010.html)
+  October)](https://www.timeanddate.com/news/time/argentina-dst-2009-2010.html)
 - [Morocco (September
-  2013)](http://www.timeanddate.com/news/time/morocco-ends-dst-2013.html)
+  2013)](https://www.timeanddate.com/news/time/morocco-ends-dst-2013.html)
 - [Libya (October
-  2013)](http://www.timeanddate.com/news/time/libya-cancels-dst-switch-2013.html)
-- [Turkey (March 2011)](http://www.timeanddate.com/news/time/turkey-starts-dst-2011.html)
+  2013)](https://www.timeanddate.com/news/time/libya-cancels-dst-switch-2013.html)
+- [Turkey (March 2011)](https://www.timeanddate.com/news/time/turkey-starts-dst-2011.html)

--- a/src/NodaTime.Web/Markdown/2.0.x/trivia.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/trivia.md
@@ -292,7 +292,7 @@ between a change being announced and Noda Time supporting it in production:
 4. I run a script to pull the latest version from TZDB, build it as an NZD
    file and push it to the Noda Time web site
 5. The system in question pulls the latest version from the web site and
-   [starts using it](tzdb.html)
+   [starts using it](tzdb)
 
 As you can see, this depends on a lot of different people, so some delay is
 inevitable. However, if your application is configured to poll the web site

--- a/src/NodaTime.Web/Markdown/2.0.x/type-choices.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/type-choices.md
@@ -1,7 +1,7 @@
 @Title="Choosing (and converting) between types"
 
 This is a companion page to the
-["core concepts"](concepts.html), and ["core types quick reference"](core-types.html)
+["core concepts"](concepts), and ["core types quick reference"](core-types)
 pages, describing when it's appropriate to use which type, and how to convert between them.
 
 Ultimately, you should be thinking about what data you really have,
@@ -155,5 +155,5 @@ as they're generally very straightforward.)
 Most of these are pretty simple, but a few are worth calling out
 specifically. The biggest "gotcha" is converting `LocalDateTime` to
 `ZonedDateTime` - it has some corner cases you need to consider. See the ["times zones" section of
-the core concepts guide](concepts.html#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
+the core concepts guide](concepts#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
 for more information.

--- a/src/NodaTime.Web/Markdown/2.0.x/tzdb.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/tzdb.md
@@ -1,7 +1,7 @@
 @Title="Updating the time zone database"
 
 Noda Time comes with a version of the
-[tz database](http://www.iana.org/time-zones) (also known as the IANA Time Zone
+[tz database](https://www.iana.org/time-zones) (also known as the IANA Time Zone
 database, or zoneinfo or Olson database), which is now hosted by IANA. This
 database changes over time, as countries decide to change their time zone
 rules.  As new versions of Noda Time are released, the version of tzdb will be
@@ -43,8 +43,8 @@ This may be used for automation.
 Building a NodaZoneData file
 ----------------------------
 
-1. Find the link to the [latest tzdb release](http://www.iana.org/time-zones), e.g.
-   http://www.iana.org/time-zones/repository/releases/tzdata2015e.tar.gz
+1. Find the link to the [latest tzdb release](https://www.iana.org/time-zones), e.g.
+   https://www.iana.org/time-zones/repository/releases/tzdata2015e.tar.gz
 2. Determine the Windows mapping file you want to use, or let NodaTime.TzdbCompiler do it for you
    with the versions supplied with the Noda Time source in the `data\cldr` directory. If these are
    out of date, you can download a new file from [CLDR](http://cldr.unicode.org/).

--- a/src/NodaTime.Web/Markdown/2.0.x/tzdb.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/tzdb.md
@@ -47,7 +47,7 @@ Building a NodaZoneData file
    http://www.iana.org/time-zones/repository/releases/tzdata2015e.tar.gz
 2. Determine the Windows mapping file you want to use, or let NodaTime.TzdbCompiler do it for you
    with the versions supplied with the Noda Time source in the `data\cldr` directory. If these are
-   out of date, you can download a new file from [CLDR](http://cldr.unicode.org).
+   out of date, you can download a new file from [CLDR](http://cldr.unicode.org/).
 3. Run NodaTime.TzdbCompiler. I'd suggest leaving it in its build directory and running it like this:
 
 ```bat

--- a/src/NodaTime.Web/Markdown/2.0.x/zoneddatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/zoneddatetime-patterns.md
@@ -17,7 +17,7 @@ Custom Patterns
 ---------------
 
 The custom format patterns for a zoned date and time are provided by combining
-the [custom patterns for `OffsetDateTime`](offsetdatetime-patterns.html) with
+the [custom patterns for `OffsetDateTime`](offsetdatetime-patterns) with
 the addition of two extra custom format specifiers: `z` and `x`.
 
 `z` is used to parse or format that time zone identifier. When parsing, an [`IDateTimeZoneProvider`](noda-type://NodaTime.IDateTimeZoneProvider) is used to extract candidate identifiers and fetch time zones for them. The UTC+/-xx:xx format for fixed offset time zones is always valid, regardless of provider. The provider is part of the `ZonedDateTimePattern`, and a new pattern with a different provider can be created using the `WithZoneProvider` method. The provider is not used when formatting: the time zone identifier is simply used directly. Note that if you format a `ZonedDateTime` which uses a time zone from a different provider than the one in the pattern, you may not be able to parse it again with the same pattern. A null provider can be specified, in which case

--- a/src/NodaTime.Web/Markdown/developer/building.md
+++ b/src/NodaTime.Web/Markdown/developer/building.md
@@ -145,7 +145,7 @@ can be most easily obtained via [NuGet](https://www.nuget.org/).
 
 To fetch NuGet.exe locally, download and run (using `mono`) the
 (auto-updating) [NuGet.exe command-line
-tool](http://nuget.codeplex.com/releases/view/58939).
+tool](https://github.com/NuGet/Home/releases).
 
 You can then fetch the NuGet packages locally (into `src/packages/`):
 

--- a/src/NodaTime.Web/Markdown/developer/building.md
+++ b/src/NodaTime.Web/Markdown/developer/building.md
@@ -112,7 +112,7 @@ Note that for Ubuntu specifically, you'll either need Ubuntu 11.10 (Oneiric) or
 later, or work out how to install an unofficial backport; earlier versions of
 Ubuntu [do not include a suitable version of Mono][MonoUbuntu].
 
-[MonoUbuntu]: http://www.mono-project.com/DistroPackages/Ubuntu
+[MonoUbuntu]: http://www.mono-project.com/DistroPackages/Ubuntu/
 
 To build Noda Time under OS X, [download][MonoDownload] the latest stable
 release of Mono. Be sure to choose the developer package, not the smaller
@@ -120,7 +120,7 @@ runtime-only package.  To use the provided `Makefile`, you'll either need to
 install [Xcode][xcode] or obtain `make` separately (for example, using
 [osx-gcc-installer][] to install just the open-source parts of Xcode).
 
-[MonoDownload]: http://www.mono-project.com/Download
+[MonoDownload]: http://www.mono-project.com/Download/
 [xcode]: https://developer.apple.com/xcode/
 [osx-gcc-installer]: https://github.com/kennethreitz/osx-gcc-installer#readme
 

--- a/src/NodaTime.Web/Markdown/developer/building.md
+++ b/src/NodaTime.Web/Markdown/developer/building.md
@@ -9,8 +9,8 @@ platform packs, however.
 To fetch the source code from the main GitHub repository, you'll need a
 [git][] client. You may also want a Git GUI, such as [SourceTree][].
 
-[git]: http://git-scm.com/
-[SourceTree]: http://www.sourcetreeapp.com/
+[git]: https://git-scm.com/
+[SourceTree]: https://www.sourcetreeapp.com/
 
 To run the tests, you'll need [NUnit][] version 2.5.10 or higher.
 
@@ -197,7 +197,7 @@ All the main source code is under the `src` directory. There are multiple projec
 
 - NodaTime: The main library to be distributed
 - NodaTime.Benchmarks: Benchmarks run regularly to check the performance
-- NodaTime.Demo: Demonstration code written as unit tests. Interesting [Stack Overflow](http://stackoverflow.com/) questions can lead to code in this project, for example.
+- NodaTime.Demo: Demonstration code written as unit tests. Interesting [Stack Overflow](https://stackoverflow.com/) questions can lead to code in this project, for example.
 - NodaTime.Serialization.JsonNet: Library to enable [Json.NET](http://json.net/) serialization of NodaTime types.
 - NodaTime.Serialization.Test: Tests for all serialization assemblies, under the assumption that at some point we'll support more than just Json.NET.
 - NodaTime.Test: Tests for the main library

--- a/src/NodaTime.Web/Markdown/developer/building.md
+++ b/src/NodaTime.Web/Markdown/developer/building.md
@@ -197,8 +197,8 @@ All the main source code is under the `src` directory. There are multiple projec
 
 - NodaTime: The main library to be distributed
 - NodaTime.Benchmarks: Benchmarks run regularly to check the performance
-- NodaTime.Demo: Demonstration code written as unit tests. Interesting [Stack Overflow](http://stackoverflow.com) questions can lead to code in this project, for example.
-- NodaTime.Serialization.JsonNet: Library to enable [Json.NET](http://json.net) serialization of NodaTime types.
+- NodaTime.Demo: Demonstration code written as unit tests. Interesting [Stack Overflow](http://stackoverflow.com/) questions can lead to code in this project, for example.
+- NodaTime.Serialization.JsonNet: Library to enable [Json.NET](http://json.net/) serialization of NodaTime types.
 - NodaTime.Serialization.Test: Tests for all serialization assemblies, under the assumption that at some point we'll support more than just Json.NET.
 - NodaTime.Test: Tests for the main library
 - NodaTime.Testing: Library to help users test code which depends on Noda Time. Also used within our own tests.

--- a/src/NodaTime.Web/Markdown/developer/release-process.md
+++ b/src/NodaTime.Web/Markdown/developer/release-process.md
@@ -18,7 +18,7 @@ a checklist by the person doing a release.
 
 Note that we should not build releases on Mono at present, since the resulting
 IL triggers a bug in the .NET 4 64-bit CLR (see the
-[building and testing](building.html) section in the developer guide).
+[building and testing](building) section in the developer guide).
 
 ## When to release
 
@@ -29,7 +29,7 @@ Search the issue tracker for open issues with the right milestone (e.g.
 `is:open is:issue milestone:1.4.0`).
 
 Update to the candidate revision (probably HEAD) of the correct branch (e.g.
-`1.0.x`) and [build and run all the tests](building.html) as normal. The build
+`1.0.x`) and [build and run all the tests](building) as normal. The build
 and test steps should pass on Visual Studio 2015 and at least one supported
 OS/version combination for Mono (i.e. 'Mono 2.10.9 on Linux').
 
@@ -39,7 +39,7 @@ If necessary, update the version of tzdb on the branch to the latest current
 version, following the instructions in the
 ["Updating the time zone database"][tzdb] section in the user guide.
 
-[tzdb]: ../userguide/tzdb.html
+[tzdb]: /userguide/tzdb
 
 ## Pre-release branching
 

--- a/src/NodaTime.Web/Markdown/developer/release-process.md
+++ b/src/NodaTime.Web/Markdown/developer/release-process.md
@@ -46,7 +46,7 @@ version, following the instructions in the
 Before building the first release with a given minor version number (i.e. 1.0.0,
 1.1.0, or more typically, a -beta or -rc version of the same), we'll need to
 branch. New user-visible functionality is introduced with a new minor version
-number (per the [Semantic versioning](http://semver.org) spec).
+number (per the [Semantic versioning](http://semver.org/) spec).
 
 The branching model used by Noda Time is the Subversion-style backport model.
 In brief:

--- a/src/NodaTime.Web/Markdown/developer/release-process.md
+++ b/src/NodaTime.Web/Markdown/developer/release-process.md
@@ -14,7 +14,7 @@ a checklist by the person doing a release.
 - Access to the (git) repository for the nodatime.org web site
 
 [Jekyll]: https://jekyllrb.com/docs/installation/
-[redcarpet]: http://rubygems.org/gems/redcarpet
+[redcarpet]: https://rubygems.org/gems/redcarpet
 
 Note that we should not build releases on Mono at present, since the resulting
 IL triggers a bug in the .NET 4 64-bit CLR (see the

--- a/src/NodaTime.Web/Markdown/developer/release-process.md
+++ b/src/NodaTime.Web/Markdown/developer/release-process.md
@@ -13,7 +13,7 @@ a checklist by the person doing a release.
   assembly) and the nuget.org API key
 - Access to the (git) repository for the nodatime.org web site
 
-[Jekyll]: http://jekyllrb.com/docs/installation/
+[Jekyll]: https://jekyllrb.com/docs/installation/
 [redcarpet]: http://rubygems.org/gems/redcarpet
 
 Note that we should not build releases on Mono at present, since the resulting
@@ -87,7 +87,7 @@ Suppose we were building version 1.2.3-beta4, then:
   Overflow post][assemblyversion] for more information about how these are
   used.)
 
-[assemblyversion]: http://stackoverflow.com/a/65062
+[assemblyversion]: https://stackoverflow.com/a/65062
 
 Update the version number by building the tools solution and then running the `SetVersion` tool:
 

--- a/src/NodaTime.Web/Markdown/developer/tzdb-file-format.md
+++ b/src/NodaTime.Web/Markdown/developer/tzdb-file-format.md
@@ -227,7 +227,7 @@ This field must occur exactly once, and it uses the string pool.
 
 ## Field 4: CLDR mapping between Windows system time zone IDs and TZDB IDs
 
-This field contains the data from the windowsZones.xml file in [CLDR](http://cldr.unicode.org). The format is:
+This field contains the data from the windowsZones.xml file in [CLDR](http://cldr.unicode.org/). The format is:
 
 - A `string` for the mapping version number (currently a string representation of the revision number)
 - A `string` for the TZDB version the mapping was generated against

--- a/src/NodaTime.Web/Markdown/developer/tzdb-file-format.md
+++ b/src/NodaTime.Web/Markdown/developer/tzdb-file-format.md
@@ -2,7 +2,7 @@
 
 This document describes the Noda Time-specific binary file format that is
 produced by Noda Time's `NodaTime.TzdbCompiler` tool. This tool reads the
-text files from the [tz database](http://www.iana.org/time-zones) along with
+text files from the [tz database](https://www.iana.org/time-zones) along with
 some additional input from CLDR; it produces output in one of two different
 formats:
 

--- a/src/NodaTime.Web/Markdown/root/versions.md
+++ b/src/NodaTime.Web/Markdown/root/versions.md
@@ -219,7 +219,7 @@ Major features:
 - Noda Time core types now support XML and (on the desktop build) binary
   serialization (issues [issue 24] and [issue 226])
 - New optional `NodaTime.Serialization.JsonNet` NuGet package enabling JSON
-  serialization for Noda Time types using [Json.NET](http://json.net)
+  serialization for Noda Time types using [Json.NET](http://json.net/)
 - New support for parsing and formatting `Duration`, `OffsetDateTime`, and
   `ZonedDateTime`, including new custom format patterns representing an
   embedded offset (`o`), time zone identifier (`z`), (format-only) time zone

--- a/src/NodaTime.Web/Markdown/root/versions.md
+++ b/src/NodaTime.Web/Markdown/root/versions.md
@@ -203,7 +203,7 @@ Other:
   match the given part of the pattern ([issue 288])
 - API documentation now indicates which versions of Noda Time support the given
   member ([issue 261])
-- Annotations added to support [ReSharper](http://jetbrains.com/resharper) users,
+- Annotations added to support [ReSharper](https://www.jetbrains.com/resharper/) users,
   by indicating pure members, parameters which must be non-null etc
   ([issue 207])
 

--- a/src/NodaTime.Web/Markdown/root/versions.md
+++ b/src/NodaTime.Web/Markdown/root/versions.md
@@ -341,7 +341,7 @@ API changes:
 Major features:
 
 - Noda Time assemblies are now also available in Portable Class Library
-  versions (see the [installation instructions](installation.html) for details)
+  versions (see the [installation instructions](/userguide/installation) for details)
 - Noda Time now uses a self-contained (and more compact) format for storing
   TZDB data that is not directly tied to .NET resources; the old format was
   not supportable in the PCL build
@@ -441,7 +441,7 @@ Bug fixes:
 Other:
 
 - Symbols for the release are now published to SymbolSource. See the
-  [installation guide](installation.html) for details of how to debug into Noda
+  [installation guide](/userguide/installation) for details of how to debug into Noda
   Time using this
 - The version of SHFB used to generate the documentation has changed, along
   with some settings around which members to generate documentation for.

--- a/src/NodaTime.Web/Markdown/unstable/arithmetic.md
+++ b/src/NodaTime.Web/Markdown/unstable/arithmetic.md
@@ -209,7 +209,7 @@ Arithmetic with the Hebrew calendar
 One exception to the rules given above is the Hebrew calendar system. For a start,
 the Hebrew calendar has a *leap month* - in a leap year, the single month of
 Adar becomes Adar I and Adar II ([with Adar I being considered the leap
-month](http://judaism.stackexchange.com/questions/37308)).
+month](https://judaism.stackexchange.com/questions/37308)).
 When an arithmetic operation requires that a date in Adar is mapped to a leap year, we use
 the same day-of-month but within Adar II. When an arithmetic operation requires that a date in
 Adar I or Adar II is mapped to a non-leap year, we use the same day-of-month in Adar. (This can
@@ -225,7 +225,7 @@ not the month *number*. So for example, bearing in mind that 5402 is a leap year
 
 Additionally, the "truncate the day-of-month if necessary" rule does not apply to the Hebrew
 calendar system, in the rules implemented in Noda Time 1.3.0. Instead,
-[following Hebrew scriptural rules](http://judaism.stackexchange.com/questions/39053), if changing
+[following Hebrew scriptural rules](https://judaism.stackexchange.com/questions/39053), if changing
 year makes a day-of-month invalid (which can happen if the original month is Adar I, Kislev or Heshvan),
 the result is instead the first day of the subsequent month. So for example, adding one year to the 30th of Kislev
 will result in the 1st of Tevet, if Kislev only has 29 days in the "target" year.

--- a/src/NodaTime.Web/Markdown/unstable/calendars.md
+++ b/src/NodaTime.Web/Markdown/unstable/calendars.md
@@ -34,7 +34,7 @@ First supported in v1.0.0
 API access: [`CalendarSystem.Iso`](noda-property://NodaTime.CalendarSystem.Iso)
 
 This is the default calendar system when constructing values without explicitly specifying a calendar.
-It is designed to correspond to the calendar described in [ISO-8601](http://en.wikipedia.org/wiki/ISO_8601),
+It is designed to correspond to the calendar described in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601),
 and is equivalent to the Gregorian calendar in all respects other than the century and year-of-century values.
 
 As of Noda Time 2.0, century and year-of-century properties have
@@ -51,7 +51,7 @@ API access:
 
 - [`CalendarSystem.Gregorian`](noda-property://NodaTime.CalendarSystem.Gregorian)
 
-The [Gregorian calendar](http://en.wikipedia.org/wiki/Gregorian_calendar) was a refinement to the Julian calendar,
+The [Gregorian calendar](https://en.wikipedia.org/wiki/Gregorian_calendar) was a refinement to the Julian calendar,
 changing the formula for which years are leap years from "whenever the year is divisible by 4" to
 "whenever the year is divisible by 4, except when it's also divisible by 100 and *not* divisible by 400". This keeps
 the calendar in closer sync with the observed rotation of the earth around the sun.
@@ -68,7 +68,7 @@ Julian
 First supported in v1.0.0  
 API access: [`CalendarSystem.Julian`](noda-property://NodaTime.CalendarSystem.Julian)
 
-The [Julian calendar](http://en.wikipedia.org/wiki/Julian_calendar) was introduced by Julius Caesar in 46BC, and took
+The [Julian calendar](https://en.wikipedia.org/wiki/Julian_calendar) was introduced by Julius Caesar in 46BC, and took
 effect in 45BC. It was like the Gregorian calendar, but with a simpler leap year rule - every year number divisible by
 4 was a leap year.
 
@@ -98,7 +98,7 @@ API access:
 - [`CalendarSystem.GetIslamicCalendar()`](noda-type://NodaTime.CalendarSystem#NodaTime_CalendarSystem_GetIslamicCalendar_NodaTime_Calendars_IslamicLeapYearPattern_NodaTime_Calendars_IslamicEpoch_)
 - [`CalendarSystem.IslamicBcl`](noda-property://NodaTime.CalendarSystem.IslamicBcl)
 
-The [Islamic (or Hijri) calendar](http://en.wikipedia.org/wiki/Islamic_calendar) is a lunar calendar with years of 12
+The [Islamic (or Hijri) calendar](https://en.wikipedia.org/wiki/Islamic_calendar) is a lunar calendar with years of 12
 months, totalling either 355 or 354 days depending on whether or not it's a leap year. There are various schemes
 for determining which years are leap years, all based on a 30 year cycle. Noda Time supports four options here,
 specified in the [`IslamicLeapYearPattern`](noda-type://NodaTime.Calendars.IslamicLeapYearPattern) enumeration.
@@ -129,7 +129,7 @@ API access:
 - [`CalendarSystem.PersianAstronomical`](noda-property://NodaTime.CalendarSystem.PersianAstronomical)
 - [`CalendarSystem.PersianArithmetic`](noda-property://NodaTime.CalendarSystem.PersianArithmetic)
 
-The [Persian (or Solar Hijri) calendar](http://en.wikipedia.org/wiki/Solar_Hijri_calendar) is the official calendar of
+The [Persian (or Solar Hijri) calendar](https://en.wikipedia.org/wiki/Solar_Hijri_calendar) is the official calendar of
 Iran and Pakistan. Three variants of this are supported in Noda Time:
 
 - The "simple" calendar, which was the only one supported in Noda Time 1.3, and matches the behaviour of the BCL
@@ -150,13 +150,13 @@ Um Al Qura
 First supported in v2.0.0  
 API access: [`CalendarSystem.UmAlQura`](noda-property://NodaTime.CalendarSystem.UmAlQura)
 
-The [Um Al Qura (or Umm al-Qura) calendar](http://en.wikipedia.org/wiki/Islamic_calendar#Saudi_Arabia.27s_Umm_al-Qura_calendar),
+The [Um Al Qura (or Umm al-Qura) calendar](https://en.wikipedia.org/wiki/Islamic_calendar#Saudi_Arabia.27s_Umm_al-Qura_calendar),
 primarily used in Saudi Arabia, is similar to the Islamic Hijri calendar, except that instead of being algorithmic it relies on
 tabular data. Each month has 29 or 30 days, and each year has 354 or 355 days, but the month lengths cannot be determined
 algorithmically.
 
 The Noda Time implementation uses data from the BCL
-[`UmAlQuraCalendar`](http://msdn.microsoft.com/en-us/library/system.globalization.umalquracalendar.aspx) to obtain the required
+[`UmAlQuraCalendar`](https://msdn.microsoft.com/en-us/library/system.globalization.umalquracalendar.aspx) to obtain the required
 information, but the data is baked into Noda Time so it is available
 on all platforms.
 
@@ -170,7 +170,7 @@ API access:
 - [`CalendarSystem.HebrewCivil`](noda-property://NodaTime.CalendarSystem.HebrewCivil)
 - [`CalendarSystem.HebrewScriptural`](noda-property://NodaTime.CalendarSystem.HebrewScriptural)
 
-The [Hebrew calendar](http://en.wikipedia.org/wiki/Hebrew_calendar) is a lunisolar calendar used primarily for determination
+The [Hebrew calendar](https://en.wikipedia.org/wiki/Hebrew_calendar) is a lunisolar calendar used primarily for determination
 of religious holidays within Judaism. It was originally observational, but a computed version is now commonly used. Even
 this is very complicated, however: most years have 12 months, but 7 in every 19 years are leap years, with 13 months. Two
 of the months in the regular calendar have variable numbers of days depending on other aspects of the calendar, in order

--- a/src/NodaTime.Web/Markdown/unstable/calendars.md
+++ b/src/NodaTime.Web/Markdown/unstable/calendars.md
@@ -1,6 +1,6 @@
 @Title="Calendars"
 
-As described in the [core concepts documentation](concepts.html), a calendar system is a scheme
+As described in the [core concepts documentation](concepts), a calendar system is a scheme
 for dividing time into eras, years, months and days and so on. As a matter of simplification,
 Noda Time treats every day as starting and ending at midnight, despite some calendars (such as
 the Islamic and Hebrew calendars) traditionally having days stretching from sunset to sunset.
@@ -25,7 +25,7 @@ concepts of eras, years, months and days - not the alternative
 mapping of a date to a "week year, week of week year, day of week".
 That is now represented by
 [`IWeekYearRule`](noda-type://NodaTime.Calendars.IWeekYearRule).
-Details are in the [week year page](weekyears.html).
+Details are in the [week year page](weekyears).
 
 ISO
 ===

--- a/src/NodaTime.Web/Markdown/unstable/concepts.md
+++ b/src/NodaTime.Web/Markdown/unstable/concepts.md
@@ -207,7 +207,7 @@ available within periods. `Period` is used for arithmetic on locally-based value
 See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
-[2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
+[2]: https://blogs.msdn.microsoft.com/bclteam/2007/06/18/a-brief-history-of-datetime-anthony-moore/
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime

--- a/src/NodaTime.Web/Markdown/unstable/concepts.md
+++ b/src/NodaTime.Web/Markdown/unstable/concepts.md
@@ -1,7 +1,7 @@
 @Title="Core concepts"
 
 This is a companion page to the
-["core types quick reference"](core-types.html), and ["choosing between types"](type-choices.html)
+["core types quick reference"](core-types), and ["choosing between types"](type-choices)
 pages, describing the fundamental concepts in Noda Time.
 
 One of the benefits of Noda Time over the Base Class Library (BCL)
@@ -20,7 +20,7 @@ date and time data for your whole project.
 This document introduces the core concepts, but in order to avoid it
 being too overwhelming, we won't go into the fine details. See
 individual pages (particularly the ["choosing between
-types"](type-choices.html) page) and the [API documentation][api]
+types"](type-choices) page) and the [API documentation][api]
 for more information.
 
 "Local" and "global" (or "absolute") types
@@ -118,7 +118,7 @@ although a few useful methods are exposed. Most of the time even if you
 an appropriate object, and then pass it to other constructors etc as a
 little bundle of magic which simply does the right thing for you.
 
-See the [calendars documentation](calendars.html) for more details about
+See the [calendars documentation](calendars) for more details about
 which calendar systems are supported.
 
 <a name="time-zones"></a>Time zones
@@ -173,7 +173,7 @@ Noda Time handles two of them: it is able to map BCL `TimeZoneInfo` objects
 using `BclDateTimeZone`, or it can use the [tz database][TZDB] (also known as
 the IANA Time Zone database, or zoneinfo or Olson database). A version of TZDB
 is embedded within the Noda Time distribution, and if you need a more recent
-one, there are [instructions on how to download and use new data](tzdb.html).
+one, there are [instructions on how to download and use new data](tzdb).
 We generally recommend that you isolate yourself from the provider you're using
 by only depending on [`IDateTimeZoneProvider`][IDateTimeZoneProvider], and
 injecting the appropriate provider in the normal way. "Stock" providers are
@@ -204,7 +204,7 @@ and so on) will always represent the same length of time, but they're still
 available within periods. `Period` is used for arithmetic on locally-based values
 (`LocalDateTime`, `LocalDate`, `LocalTime`).
 
-See the [arithmetic](arithmetic.html) page for more information.
+See the [arithmetic](arithmetic) page for more information.
 
 [api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx

--- a/src/NodaTime.Web/Markdown/unstable/concepts.md
+++ b/src/NodaTime.Web/Markdown/unstable/concepts.md
@@ -206,7 +206,7 @@ available within periods. `Period` is used for arithmetic on locally-based value
 
 See the [arithmetic](arithmetic.html) page for more information.
 
-[api]: ../api/Index.html
+[api]: ../api/
 [2]: http://blogs.msdn.com/b/bclteam/archive/2007/06/18/a-brief-history-of-datetime-anthony-moore.aspx
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/unstable/concepts.md
+++ b/src/NodaTime.Web/Markdown/unstable/concepts.md
@@ -213,14 +213,14 @@ See the [arithmetic](arithmetic) page for more information.
 [LocalDateTime]: noda-type://NodaTime.LocalDateTime
 [Instant]: noda-type://NodaTime.Instant
 [CalendarSystem]: noda-type://NodaTime.CalendarSystem
-[UTC]: http://en.wikipedia.org/wiki/Coordinated_Universal_Time
+[UTC]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
 [DateTimeZone]: noda-type://NodaTime.DateTimeZone
 [Offset]: noda-type://NodaTime.Offset
 [Period]: noda-type://NodaTime.Period
 [Duration]: noda-type://NodaTime.Duration
 [OffsetDateTime]: noda-type://NodaTime.OffsetDateTime
 [ZonedDateTime]: noda-type://NodaTime.ZonedDateTime
-[TZDB]: http://www.iana.org/time-zones
+[TZDB]: https://www.iana.org/time-zones
 [IDateTimeZoneProvider]: noda-type://NodaTime.IDateTimeZoneProvider
 [DateTimeZoneProviders]: noda-type://NodaTime.DateTimeZoneProviders
-[TimeSpan]: http://msdn.microsoft.com/en-us/library/system.timespan.aspx
+[TimeSpan]: https://msdn.microsoft.com/en-us/library/system.timespan.aspx

--- a/src/NodaTime.Web/Markdown/unstable/core-types.md
+++ b/src/NodaTime.Web/Markdown/unstable/core-types.md
@@ -109,7 +109,7 @@ Interval
 An [`Interval`][Interval] is simply two instants - a start and an end. The interval includes the start, and excludes the end, which means that if you have abutting intervals any instant will be in
 exactly one of those intervals.
 
-[DST]: http://en.wikipedia.org/wiki/Daylight_saving_time
+[DST]: https://en.wikipedia.org/wiki/Daylight_saving_time
 [Interval]: noda-type://NodaTime.Interval
 [LocalTime]: noda-type://NodaTime.LocalTime
 [LocalDate]: noda-type://NodaTime.LocalDate

--- a/src/NodaTime.Web/Markdown/unstable/core-types.md
+++ b/src/NodaTime.Web/Markdown/unstable/core-types.md
@@ -1,7 +1,7 @@
 @Title="Core types quick reference"
 
 This is a companion page to the
-["core concepts"](concepts.html), and ["choosing between types"](type-choices.html)
+["core concepts"](concepts), and ["choosing between types"](type-choices)
 pages, describing the fundamental types in Noda Time very briefly, primarily for reference.
 If you're not familiar with the core concepts, read that page first.
 
@@ -93,7 +93,7 @@ January.
 IClock
 ------
 
-An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing.html), this is defined
+An [`IClock`][IClock] implementation provides information about the current instant. It knows nothing about time zones or calendar systems. For [testability](testing), this is defined
 as an interface; in a production deployment you're likely to use the [`SystemClock`][SystemClock] singleton implementation.
 
 Often you may want to repeatedly access the current time or date in a specific time zone.

--- a/src/NodaTime.Web/Markdown/unstable/design.md
+++ b/src/NodaTime.Web/Markdown/unstable/design.md
@@ -104,5 +104,5 @@ similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
 [2]: http://semver.org/
-[3]: http://www.joda.org/joda-time
+[3]: http://www.joda.org/joda-time/
 [4]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/unstable/design.md
+++ b/src/NodaTime.Web/Markdown/unstable/design.md
@@ -58,7 +58,7 @@ developers want. However, we do *not* default to using the system
 time zone, or using "now" as a default date/time value, or using
 the current thread's current format provider for parsing and
 formatting (except for the BCL-compatible method calls; see [text
-handling][5] for more information on this).
+handling](text) for more information on this).
   We make it easy to do all of these things, but they're just not
 appropriate as implicit defaults. It's too easy to *accidentally*
 depend on the time zone your system happens to be running in (etc)
@@ -67,7 +67,7 @@ without anything obvious in your code.
 What this means in practice
 ---------------------------
 
-- There are rather more types and [concepts][1] to learn about in
+- There are rather more types and [concepts](concepts) to learn about in
 Noda Time than in .NET. One of the *problems* with .NET's date and
 time API is that `DateTime` doesn't have a single well-defined
 meaning.
@@ -80,7 +80,7 @@ LocalDateTime()` or `default(LocalDateTime)`) is *not* a useful
 value. This is unfortunate, but hard to avoid.
 
 - All the value types and almost all the reference types are
-immutable and [thread-safe](threading.html). We expect objects like calendars, time
+immutable and [thread-safe](threading). We expect objects like calendars, time
 zones, and patterns for formatting and parsing text to be reused
 freely between many threads. Occasionally there's hidden mutability
 in terms of caches, but this should not affect you, the user. We make sure it
@@ -103,8 +103,6 @@ requirements, chances are someone else will want to do something
 similar - so pop along to the [mailing list][4] and we can collaborate on
 trying to solve your problem within Noda Time itself.
 
-[1]: concepts.html
 [2]: http://semver.org/
 [3]: http://www.joda.org/joda-time
 [4]: https://groups.google.com/group/noda-time
-[5]: text.html

--- a/src/NodaTime.Web/Markdown/unstable/duration-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/duration-patterns.md
@@ -13,7 +13,7 @@ The following standard pattern is supported:
 Custom Patterns
 ---------------
 
-The following custom pattern characters are supported for durations. See [custom pattern notes](text.html#custom-patterns)
+The following custom pattern characters are supported for durations. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 The pattern letters basically split into two categories:

--- a/src/NodaTime.Web/Markdown/unstable/index.md
+++ b/src/NodaTime.Web/Markdown/unstable/index.md
@@ -25,5 +25,5 @@ Resources
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com/
-[so-tag]: http://stackoverflow.com/questions/tagged/nodatime
+[so]: https://stackoverflow.com/
+[so-tag]: https://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/unstable/index.md
+++ b/src/NodaTime.Web/Markdown/unstable/index.md
@@ -20,10 +20,10 @@ Resources
 - [Blog][blog]
 - [Mailing list][group]
 
-[blog]: http://blog.nodatime.org
+[blog]: http://blog.nodatime.org/
 [group]: https://groups.google.com/group/noda-time
 [home]: https://github.com/nodatime/nodatime
 [api]: ../api/
 [Developer guide]: /developer/
-[so]: http://stackoverflow.com
+[so]: http://stackoverflow.com/
 [so-tag]: http://stackoverflow.com/questions/tagged/nodatime

--- a/src/NodaTime.Web/Markdown/unstable/installation.md
+++ b/src/NodaTime.Web/Markdown/unstable/installation.md
@@ -1,11 +1,11 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org/) with
+Our primary distribution channel is [NuGet](https://www.nuget.org/) with
 three packages:
 
-- [NodaTime](http://nuget.org/packages/NodaTime)
-- [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing)
-- [NodaTime.Serialization.JsonNet](http://nuget.org/packages/NodaTime.Serialization.JsonNet)
+- [NodaTime](https://www.nuget.org/packages/NodaTime)
+- [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing)
+- [NodaTime.Serialization.JsonNet](https://www.nuget.org/packages/NodaTime.Serialization.JsonNet)
 
 Alternatively, source and binary downloads are available on the
 [project download page][downloads].
@@ -64,9 +64,9 @@ be able to start using Noda Time immediately, with no further effort.
 Debugging
 ---------
 
-As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org/). You can configure
+As of version 1.1, the source code of Noda Time is published to [SymbolSource](https://www.symbolsource.org/). You can configure
 Visual Studio to automatically fetch the source code if you need to step into it when debugging your application. It takes a little
-bit of setup, but there are [full instructions](http://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
+bit of setup, but there are [full instructions](https://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
 (The instructions aren't specific to Noda Time, so if you're
 already using SymbolSource as one of your symbol servers, you just need to make sure you're not excluding Noda Time from the list of
 modules to fetch.)

--- a/src/NodaTime.Web/Markdown/unstable/installation.md
+++ b/src/NodaTime.Web/Markdown/unstable/installation.md
@@ -22,7 +22,7 @@ System requirements
 
 From release 1.1 onwards, there are two builds of Noda Time: the desktop version and the Portable Class Library version.
 
-The desktop version requires .NET 3.5 (client profile). This build also supports Mono, [with some caveats](mono.html).
+The desktop version requires .NET 3.5 (client profile). This build also supports Mono, [with some caveats](mono).
 
 The PCL build is configured to support:
 
@@ -35,7 +35,7 @@ The PCL build also appears to work with Xamarin.iOS and Xamarin.Android apps, bu
 
 Noda Time does *not* support XBox 360 or Silverlight 3, and it's unlikely that we'd ever want to introduce support
 for these. (It's more likely that over time, we'll drop support for Silverlight - but not imminently, of course.)
-See the [limitations](limitations.html) page for differences between the PCL build and the desktop build.
+See the [limitations](limitations) page for differences between the PCL build and the desktop build.
 
 The NodaTime.Serialization.JsonNet assembly is built and tested against Json.NET version 4.5.11. It's likely that any version
 of Json.NET from 4.5.0 onwards will work with Noda Time, but we'd recommend using at least 4.5.11. As far as we know, there
@@ -47,14 +47,14 @@ Package contents and getting started
 ------------------------------------
 
 Everything you need to *use* Noda Time is contained in the NodaTime package. The NodaTime.Testing package is designed
-for testing code which uses Noda Time. See the [testing guide](testing.html) for more information. It is expected
+for testing code which uses Noda Time. See the [testing guide](testing) for more information. It is expected
 that production code will only refer to the `NodaTime.dll` assembly, and that's all that's required at execution time.
-This assembly includes the [TZDB database](tzdb.html) as an embedded resource.
+This assembly includes the [TZDB database](tzdb) as an embedded resource.
 
 For Json.NET serialization, the NodaTime.Serialization.JsonNet package (containing a single assembly of the same name) is 
 required, as well as an appropriate version of Json.NET itself. There is a NuGet dependency from NodaTime.Serialization.JsonNet
 to the newtonsoft.json package, so if you're using NuGet you just need to refer to NodaTime.Serialization.JsonNet and an 
-appropriate version of Json.NET will be installed automatically. See the [serialization guide](serialization.html) for more
+appropriate version of Json.NET will be installed automatically. See the [serialization guide](serialization) for more
 information on using Noda Time with Json.NET.
 
 Everything within the NodaTime assembly is in the NodaTime namespace or a "child" namespace. After adding a reference to

--- a/src/NodaTime.Web/Markdown/unstable/installation.md
+++ b/src/NodaTime.Web/Markdown/unstable/installation.md
@@ -1,6 +1,6 @@
 @Title="Installation"
 
-Our primary distribution channel is [NuGet](http://nuget.org) with
+Our primary distribution channel is [NuGet](http://nuget.org/) with
 three packages:
 
 - [NodaTime](http://nuget.org/packages/NodaTime)
@@ -64,7 +64,7 @@ be able to start using Noda Time immediately, with no further effort.
 Debugging
 ---------
 
-As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org). You can configure
+As of version 1.1, the source code of Noda Time is published to [SymbolSource](http://www.symbolsource.org/). You can configure
 Visual Studio to automatically fetch the source code if you need to step into it when debugging your application. It takes a little
 bit of setup, but there are [full instructions](http://www.symbolsource.org/Public/Home/VisualStudio) on the SymbolSource web site.
 (The instructions aren't specific to Noda Time, so if you're

--- a/src/NodaTime.Web/Markdown/unstable/instant-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/instant-patterns.md
@@ -16,6 +16,6 @@ The following standard pattern is supported:
 Custom Patterns
 ---------------
 
-[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns.html).
+[`Instant`](noda-type://NodaTime.Instant) supports all the [`LocalDateTime` custom patterns](localdatetime-patterns).
 The pattern allows the culture to be specified, but *always* uses the ISO-8601 calendar, and *always* uses the UTC
 time zone. The "template value" is always the unix epoch.

--- a/src/NodaTime.Web/Markdown/unstable/limitations.md
+++ b/src/NodaTime.Web/Markdown/unstable/limitations.md
@@ -46,7 +46,7 @@ we may want to optimize further at some point too.
 
 Additionally, all our text localization resources (day and month names) come from the .NET
 framework itself. That has some significant limitations, and makes Noda Time more reliant
-on `CultureInfo` than is ideal. [CLDR](http://cldr.unicode.org) contains more information,
+on `CultureInfo` than is ideal. [CLDR](http://cldr.unicode.org/) contains more information,
 which should allow for features such as ordinal day numbers ("1st", "2nd", "3rd") and
 a broader set of supported calendar/culture combinations (such as English names for the
 Hebrew calendar months).
@@ -67,7 +67,7 @@ hot-fixes for cultures which we don't support as well as we might.
 More time zone information
 ==========================
 
-[CLDR](http://cldr.unicode.org) provides useful information about
+[CLDR](http://cldr.unicode.org/) provides useful information about
 time zones such as a canonical ID and user-friendly representations
 (countries and sample cities). We'd also like to make it clearer
 when one zoneinfo time zone is an alias for another.

--- a/src/NodaTime.Web/Markdown/unstable/limitations.md
+++ b/src/NodaTime.Web/Markdown/unstable/limitations.md
@@ -6,7 +6,7 @@ aspects we'd like to improve; see the
 [issues list](https://github.com/nodatime/nodatime/issues) for
 others.
 
-We also have a [roadmap](roadmap.html) of intended releases. This is
+We also have a [roadmap](roadmap) of intended releases. This is
 always tentative, of course, but it helps to give some clarity to our
 decisions in terms of what to work on next.
 
@@ -33,7 +33,7 @@ Additionally, the PCL doesn't support .NET resource files as fully as the deskto
 framework; in particular, it doesn't allow you to retrieve non-string resources. This
 has provoked a change from the previous resource-based format used for TZDB, to a
 stream-based format, which is now the default. For most users this will be a no-op
-change, but it does affect how you [build and use a custom version of TZDB](tzdb.html).
+change, but it does affect how you [build and use a custom version of TZDB](tzdb).
 
 Fuller text support
 ===================
@@ -52,7 +52,7 @@ a broader set of supported calendar/culture combinations (such as English names 
 Hebrew calendar months).
 
 Speaking of the Hebrew calendar, initial support for the calendar has been introduced
-in 1.3.0, but month names are *not* properly supported currently. See [local date formatting](localdate-patterns.html) for more details of this limitation.
+in 1.3.0, but month names are *not* properly supported currently. See [local date formatting](localdate-patterns) for more details of this limitation.
 
 Better resource handling
 ========================
@@ -81,7 +81,7 @@ highest priority is probably an adapter for the BCL calendars.
 Smarter arithmetic
 ==================
 
-As noted in the [arithmetic guide](arithmetic.html), arithmetic using
+As noted in the [arithmetic guide](arithmetic), arithmetic using
 [`Period`](noda-type://NodaTime.Period) is pretty simplistic. We may
 want something smarter, probably to go alongside the "dumb but
 predictable" existing logic. This will definitely be driven by real

--- a/src/NodaTime.Web/Markdown/unstable/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/localdate-patterns.md
@@ -19,7 +19,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom format pattern characters are supported for local dates. See [custom pattern notes](text.html#custom-patterns)
+The following custom format pattern characters are supported for local dates. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 For the meanings of "absolute" years and text handling, see later details.

--- a/src/NodaTime.Web/Markdown/unstable/localdate-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/localdate-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `d`: Short format pattern.  
-  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
+  This is the short date pattern as defined by the culture's [`DateTimeFormatInfo.ShortDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx).
   For example, in the invariant culture this is "MM/dd/yyyy".
 
 - `D`: Long format pattern.  
-  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
+  This is the long date pattern as defined by the culture's [`DateTimeFormatInfo.LongDatePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx).
   For example, in the invariant culture this is "dddd, dd MMMM yyyy".
   This is the default format pattern.
 

--- a/src/NodaTime.Web/Markdown/unstable/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/localdatetime-patterns.md
@@ -20,17 +20,17 @@ The following standard patterns are supported:
 
 - `s`: The sortable pattern, which is always "uuuu'-'MM'-'dd'T'HH':'mm':'ss" using the invariant culture. (Note: this is only truly sortable for years within the range \[0-9999\].)
 
-- `f`: The culture's [long date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `f`: The culture's [long date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
+- `F`: The full date and time pattern as defined by the culture's [`DateTimeFormatInfo.FullDateTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.fulldatetimepattern.aspx) 
   For example, in the invariant culture this is "dddd, dd MMMM yyyy HH:mm:ss".
 
-- `g`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [short time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
+- `g`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [short time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx).
 
-- `G`: The culture's [short date pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
-  followed by the [long time pattern](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
+- `G`: The culture's [short date pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shortdatepattern.aspx) followed by a space,
+  followed by the [long time pattern](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx).
   This is the default format pattern.
 
 Custom Patterns

--- a/src/NodaTime.Web/Markdown/unstable/localdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/localdatetime-patterns.md
@@ -36,8 +36,8 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The custom format patterns for local date and time values are provided by combining the [custom patterns for `LocalDate`](localdate-patterns.html) with
-the [custom patterns for `LocalTime`](localtime-patterns.html). The result is simply the combination of the date and the time.
+The custom format patterns for local date and time values are provided by combining the [custom patterns for `LocalDate`](localdate-patterns) with
+the [custom patterns for `LocalTime`](localtime-patterns). The result is simply the combination of the date and the time.
 
 There are two exceptions to this:
 

--- a/src/NodaTime.Web/Markdown/unstable/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/localtime-patterns.md
@@ -8,11 +8,11 @@ Standard Patterns
 The following standard patterns are supported:
 
 - `t`: Short format pattern.  
-  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx). 
+  This is the short time pattern as defined by the culture's [`DateTimeFormatInfo.ShortTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.shorttimepattern.aspx). 
   For example, in the invariant culture this is "HH:mm".
 
 - `T`: Long format pattern.  
-  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](http://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx). 
+  This is the long time pattern as defined by the culture's [`DateTimeFormatInfo.LongTimePattern`](https://msdn.microsoft.com/en-us/library/system.globalization.datetimeformatinfo.longtimepattern.aspx). 
   For example, in the invariant culture this is "HH:mm:ss". This is the default format pattern.
 
 - `r`: Round-trip pattern.  

--- a/src/NodaTime.Web/Markdown/unstable/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/localtime-patterns.md
@@ -39,7 +39,7 @@ for general notes on custom patterns, including characters used for escaping and
         The hour of day in the 24-hour clock; a value 0-23.
         <p>Note that when parsing local date/time values, a value of <code>24</code>
         may be exceptionally permitted to allow
-        <a href="localdatetime-patterns.md">specification of a following day's
+        <a href="localdatetime-patterns">specification of a following day's
         midnight</a>.
       </td>
       <td>

--- a/src/NodaTime.Web/Markdown/unstable/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/localtime-patterns.md
@@ -21,7 +21,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom format pattern characters are supported for local times. See [custom pattern notes](text.html#custom-patterns)
+The following custom format pattern characters are supported for local times. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/unstable/mono.md
+++ b/src/NodaTime.Web/Markdown/unstable/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com) is an open source implementation of
+[Mono](http://mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/unstable/mono.md
+++ b/src/NodaTime.Web/Markdown/unstable/mono.md
@@ -1,6 +1,6 @@
 @Title="Mono support"
 
-[Mono](http://mono-project.com/) is an open source implementation of
+[Mono](http://www.mono-project.com/) is an open source implementation of
 the Common Language Infrastructure which runs on various platforms,
 including Windows, Linux and OS X.
 

--- a/src/NodaTime.Web/Markdown/unstable/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/offset-patterns.md
@@ -29,7 +29,7 @@ The following standard patterns are supported:
 Custom Patterns
 ---------------
 
-The following custom pattern characters are supported for offsets. See [custom pattern notes](text.html#custom-patterns)
+The following custom pattern characters are supported for offsets. See [custom pattern notes](text#custom-patterns)
 for general notes on custom patterns, including characters used for escaping and text literals.
 
 <table>

--- a/src/NodaTime.Web/Markdown/unstable/offsetdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/offsetdatetime-patterns.md
@@ -12,9 +12,9 @@ Standard Patterns
 Custom Patterns
 ---------------
 
-The custom format patterns for the local date and time parts of the value are the same as the [custom patterns for `LocalDateTime`](localdatetime-patterns.html). There is an additional specifier for the offset.
+The custom format patterns for the local date and time parts of the value are the same as the [custom patterns for `LocalDateTime`](localdatetime-patterns). There is an additional specifier for the offset.
 
-The "o" specifier must always be followed by a [pattern for `Offset`](offset-patterns.html) within angle brackets. The pattern may be a standard pattern or a custom pattern. For example, a pattern of `uuuu-MM-dd HH:mm:ss o<G>` might produce output of "2013-07-17 06:20:35 Z" or "2013-07-17 07:20:35 +01:00".
+The "o" specifier must always be followed by a [pattern for `Offset`](offset-patterns) within angle brackets. The pattern may be a standard pattern or a custom pattern. For example, a pattern of `uuuu-MM-dd HH:mm:ss o<G>` might produce output of "2013-07-17 06:20:35 Z" or "2013-07-17 07:20:35 +01:00".
 
 To use culture-specific standard date or time patterns in a custom `OffsetDateTime` pattern, use some combination of the following specifiers:
 

--- a/src/NodaTime.Web/Markdown/unstable/range.md
+++ b/src/NodaTime.Web/Markdown/unstable/range.md
@@ -118,7 +118,7 @@ which is just shy of 7,304,119 days. Internally, durations are stored in terms o
 implementation detail to be sure, but one which sometimes affects other decisions).
 
 Additionally, it seems useful to be able to cover the full range of
-[`TimeSpan`](http://msdn.microsoft.com/en-us/library/system.timespan), given that `Duration` is meant to be the roughly-equivalent
+[`TimeSpan`](https://msdn.microsoft.com/en-us/library/system.timespan), given that `Duration` is meant to be the roughly-equivalent
 type.
 
 The result is that we have a range of days from -2<sup>24</sup> to +2<sup>24</sup>-1 - and the nanosecond part means that the

--- a/src/NodaTime.Web/Markdown/unstable/rationale.md
+++ b/src/NodaTime.Web/Markdown/unstable/rationale.md
@@ -28,5 +28,5 @@ a new date/time API, the Noda Time team would happily go into
 retirement (other than for the sake of those forced to stick with
 earlier versions of .NET, of course).
 
-[1]: http://www.joda.org/joda-time
+[1]: http://www.joda.org/joda-time/
 [2]: http://blog.nodatime.org/2011/08/what-wrong-with-datetime-anyway.html

--- a/src/NodaTime.Web/Markdown/unstable/roadmap.md
+++ b/src/NodaTime.Web/Markdown/unstable/roadmap.md
@@ -2,7 +2,7 @@
 
 Our online Developer Guide contains [an _approximate_ roadmap][roadmap] for the
 major features that we hope to support in Noda Time, some of which are inspired
-by Noda Time's [current limitations](limitations.html).
+by Noda Time's [current limitations](limitations).
 
 [roadmap]: /developer/roadmap
 

--- a/src/NodaTime.Web/Markdown/unstable/serialization.md
+++ b/src/NodaTime.Web/Markdown/unstable/serialization.md
@@ -187,7 +187,7 @@ An extension method of `ConfigureForNodaTime` is provided on both `JsonSerialize
 `JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields
 for individual converters. (All converters are immutable.)
 
-Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter_1).
+Custom converters can be created easily from patterns using [`NodaPatternConverter`](noda-type://NodaTime.Serialization.JsonNet.NodaPatternConverter-1).
 
 Please ensure that *all* relevant JSON handlers are configured appropriately. In some cases there may be more than
 one involved, possibly one for reading and one for writing, depending on your configuration. For ASP.NET using

--- a/src/NodaTime.Web/Markdown/unstable/serialization.md
+++ b/src/NodaTime.Web/Markdown/unstable/serialization.md
@@ -174,12 +174,12 @@ The serialized form is not documented here as it is not expected to be consumed 
 Third-party serialization
 -------------------------
 
-The Noda Time project itself has support for [Json.NET](http://json.net). Additionally, there is a separate project for [ServiceStack.Text](https://github.com/ServiceStack/ServiceStack.Text/) support. Details of both are given below.
+The Noda Time project itself has support for [Json.NET](http://json.net/). Additionally, there is a separate project for [ServiceStack.Text](https://github.com/ServiceStack/ServiceStack.Text/) support. Details of both are given below.
 
 Json.NET: NodaTime.Serialization.JsonNet
 ----------------------------------------
 
-[Json.NET](http://json.net) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
+[Json.NET](http://json.net/) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
 of the same name. This assembly is built against Json.NET 4.5.11, and is available in both portable and desktop flavours. It can be installed using NuGet, again with a package name of `NodaTime.Serialization.JsonNet`. See the
 [installation guide](installation) for more details.
 

--- a/src/NodaTime.Web/Markdown/unstable/serialization.md
+++ b/src/NodaTime.Web/Markdown/unstable/serialization.md
@@ -67,9 +67,9 @@ properties, which would entirely defeat the point of the exercise.
 
 It's also worth noting that the XML serialization in .NET doesn't allow any user-defined types to be
 serialized via attributes. So while it would make perfect sense to be able to apply
-[`[XmlAttribute]`](http://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlattributeattribute)
+[`[XmlAttribute]`](https://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlattributeattribute)
 to a particular property and have it serialized as an attribute, in reality you need to use
-[`[XmlElement]`](http://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlelementattribute.aspx)
+[`[XmlElement]`](https://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlelementattribute.aspx)
 instead. There's nothing Noda Time can do here; it's just a [limitation of .NET XML serialization](http://connect.microsoft.com/VisualStudio/feedback/details/277641/xmlattribute-xmltext-cannot-be-used-to-encode-types-implementing-ixmlserializable).
 
 Finally, serialization of `ZonedDateTime` comes with the tricky question of which `IDateTimeZoneProvider` to use in order to convert a time zone ID specified in the XML into a `DateTimeZone`.

--- a/src/NodaTime.Web/Markdown/unstable/serialization.md
+++ b/src/NodaTime.Web/Markdown/unstable/serialization.md
@@ -181,7 +181,7 @@ Json.NET: NodaTime.Serialization.JsonNet
 
 [Json.NET](http://json.net) is supported within the `NodaTime.Serialization.JsonNet` assembly and the namespace
 of the same name. This assembly is built against Json.NET 4.5.11, and is available in both portable and desktop flavours. It can be installed using NuGet, again with a package name of `NodaTime.Serialization.JsonNet`. See the
-[installation guide](installation.html) for more details.
+[installation guide](installation) for more details.
 
 An extension method of `ConfigureForNodaTime` is provided on both `JsonSerializer` and
 `JsonSerializerSettings`. Alternatively, the [`NodaConverters`](noda-type://NodaTime.Serialization.JsonNet.NodaConverters) type provides public static read-only fields

--- a/src/NodaTime.Web/Markdown/unstable/testing.md
+++ b/src/NodaTime.Web/Markdown/unstable/testing.md
@@ -6,7 +6,7 @@ which *uses* Noda Time.
 NodaTime.Testing
 ----------------
 
-Firstly, get hold of the [NodaTime.Testing](http://nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
+Firstly, get hold of the [NodaTime.Testing](https://www.nuget.org/packages/NodaTime.Testing) assembly. It's currently fairly
 small, but it will no doubt grow - and it will make your life much easier. The purpose of the assembly is to provide
 easy-to-use test doubles which can be used instead of the real implementations.
 

--- a/src/NodaTime.Web/Markdown/unstable/text.md
+++ b/src/NodaTime.Web/Markdown/unstable/text.md
@@ -61,15 +61,15 @@ available patterns are as consistent as possible within reason, but
 documenting each separately avoids confusion with some field
 specifiers being available for some types but not others.
 
-- [Duration patterns](duration-patterns.html)
-- [Offset patterns](offset-patterns.html)
-- [Instant patterns](instant-patterns.html)
-- [LocalTime patterns](localtime-patterns.html)
-- [LocalDate patterns](localdate-patterns.html)
-- [LocalDateTime patterns](localdatetime-patterns.html)
-- [OffsetDateTime patterns](offsetdatetime-patterns.html)
-- [ZonedDateTime patterns](zoneddatetime-patterns.html)
-- [Period patterns](period-patterns.html)
+- [Duration patterns](duration-patterns)
+- [Offset patterns](offset-patterns)
+- [Instant patterns](instant-patterns)
+- [LocalTime patterns](localtime-patterns)
+- [LocalDate patterns](localdate-patterns)
+- [LocalDateTime patterns](localdatetime-patterns)
+- [OffsetDateTime patterns](offsetdatetime-patterns)
+- [ZonedDateTime patterns](zoneddatetime-patterns)
+- [Period patterns](period-patterns)
 
 <a name="custom-patterns"></a>Custom patterns
 ---------------

--- a/src/NodaTime.Web/Markdown/unstable/text.md
+++ b/src/NodaTime.Web/Markdown/unstable/text.md
@@ -165,7 +165,7 @@ Often you don't have much choice about how to parse or format text: if you're in
   - Try to use a pattern which is ISO-friendly where possible; it'll make it easier to interoperate with other systems in the future.
   - Quote all non-field values other than spaces.
 
-  [2]: http://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
+  [2]: https://msdn.microsoft.com/en-us/library/system.globalization.cultureinfo.aspx
   [3]: noda-ns://NodaTime.Text
   [4]: noda-type://NodaTime.LocalDateTime
   [5]: noda-type://NodaTime.Instant

--- a/src/NodaTime.Web/Markdown/unstable/text.md
+++ b/src/NodaTime.Web/Markdown/unstable/text.md
@@ -34,10 +34,10 @@ information or other options.
 Each core Noda type has its own pattern type such as
 [`OffsetPattern`](noda-type://NodaTime.Text.OffsetPattern). All
 these patterns implement the
-[`IPattern<T>`](noda-type://NodaTime.Text.IPattern_1) interface,
+[`IPattern<T>`](noda-type://NodaTime.Text.IPattern-1) interface,
 which has simple `Format` and `Parse` methods taking just the value
 and text respectively. The result of `Parse` is a
-[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult_1) which
+[`ParseResult<T>`](noda-type://NodaTime.Text.ParseResult-1) which
 encapsulates both success and failure results.
 
 The BCL-based API

--- a/src/NodaTime.Web/Markdown/unstable/threading.md
+++ b/src/NodaTime.Web/Markdown/unstable/threading.md
@@ -62,6 +62,6 @@ Enums
 Enums should generally be treated as immutable value types. Accessing the enum values directly can *never* have any nasty effects,
 but be careful around using a writable field of an enum type, for the same reasons as given in the earlier discussion.
 
-[lippert]: http://blogs.msdn.com/b/ericlippert/archive/2009/10/19/what-is-this-thing-you-call-thread-safe.aspx
-[immutability]: http://blogs.msdn.com/b/ericlippert/archive/tags/immutability/
+[lippert]: https://blogs.msdn.microsoft.com/ericlippert/2009/10/19/what-is-this-thing-you-call-thread-safe/
+[immutability]: https://blogs.msdn.microsoft.com/ericlippert/tag/immutability/
 [mailing list]: https://groups.google.com/group/noda-time

--- a/src/NodaTime.Web/Markdown/unstable/trivia.md
+++ b/src/NodaTime.Web/Markdown/unstable/trivia.md
@@ -88,12 +88,12 @@ year), they'd be somewhere in between for about 40 years.
 While this almost sounds like a reasonable plan (almost like the way that
 [Google "smears" a leap second across a whole minute rather than simply
 adding a
-second](http://googleblog.blogspot.com/2011/09/time-technology-and-leaping-seconds.html)),
+second](https://googleblog.blogspot.com/2011/09/time-technology-and-leaping-seconds.html)),
 it went horribly wrong. In February 1700, Sweden skipped the leap year,
 according to plan. That meant that they were one day ahead of the countries
 still following the Julian calendar. Unfortunately, in the  same year -
 although ironically *before* February 28th - the [Great Northern
-War](http://en.wikipedia.org/wiki/Great_Northern_War) broke out. This
+War](https://en.wikipedia.org/wiki/Great_Northern_War) broke out. This
 distracted Sweden from their calendrical machinations, and they *did* have a
 leap year in 1704 and 1708.
 
@@ -115,7 +115,7 @@ alone in such an odd way.
 
 **Read more:**
 
-- [Wikipedia](http://en.wikipedia.org/wiki/February_30)
+- [Wikipedia](https://en.wikipedia.org/wiki/February_30)
 
 The time in Greenwich at the Unix epoch
 ---
@@ -154,7 +154,7 @@ offset. The transition from summer time to standard time on October 27th
 
 - [BBC News](http://www.bbc.co.uk/news/uk-scotland-11643098)
 - [History of Legal Time in
-  Britain](http://www.polyomino.org.uk/british-time/)
+  Britain](https://www.polyomino.org.uk/british-time/)
 
 <sup>1</sup> I'm studiously avoiding the differentiation between, UTC, UT,
 UT0, TAI and the like. They make my head hurt, and in common usage time zone
@@ -223,7 +223,7 @@ careful before you compare it with another date. To avoid *too* much
 confusion, many historical dates are given using the Julian calendar, which
 was being observed at the time (depending on the place, of course), while
 using the "New Style" of year numbering. For example, [Henry
-VIII](http://en.wikipedia.org/wiki/Henry_VIII_of_England) died on January
+VIII](https://en.wikipedia.org/wiki/Henry_VIII_of_England) died on January
 28th 1547 (New Style) or January 28th 1546 (Old Style). In my experience,
 some web pages explicitly call out which numbering style they're using,
 others record it as "January 28th 1546/1547" and hope that readers
@@ -241,11 +241,11 @@ anyway.
 
 - [Wikipedia: Calender (New Style) act][wikipedia-newstyle-act]
 - [Wikipedia: Old and New Style
-  dates](http://en.wikipedia.org/wiki/Old_Style_and_New_Style_dates)
+  dates](https://en.wikipedia.org/wiki/Old_Style_and_New_Style_dates)
 - [Malcolm Rowe's write-up in
   Google+](https://plus.google.com/+MalcolmRowe/posts/Bf5swesMPUV)
 
-[wikipedia-newstyle-act]: http://en.wikipedia.org/wiki/Calendar_(New_Style)_Act_1750
+[wikipedia-newstyle-act]: https://en.wikipedia.org/wiki/Calendar_(New_Style)_Act_1750
 
 <sup>1</sup> When I say "we" here, I really mean "Malcolm" who did most of
 the work on understanding this issue based on Wikipedia and primary
@@ -304,9 +304,9 @@ typically deploys changes to the *Windows* time zone database...
 **Read more:**
 
 - [Argentina (announcement on 7th October 2009, due 18th
-  October)](http://www.timeanddate.com/news/time/argentina-dst-2009-2010.html)
+  October)](https://www.timeanddate.com/news/time/argentina-dst-2009-2010.html)
 - [Morocco (September
-  2013)](http://www.timeanddate.com/news/time/morocco-ends-dst-2013.html)
+  2013)](https://www.timeanddate.com/news/time/morocco-ends-dst-2013.html)
 - [Libya (October
-  2013)](http://www.timeanddate.com/news/time/libya-cancels-dst-switch-2013.html)
-- [Turkey (March 2011)](http://www.timeanddate.com/news/time/turkey-starts-dst-2011.html)
+  2013)](https://www.timeanddate.com/news/time/libya-cancels-dst-switch-2013.html)
+- [Turkey (March 2011)](https://www.timeanddate.com/news/time/turkey-starts-dst-2011.html)

--- a/src/NodaTime.Web/Markdown/unstable/trivia.md
+++ b/src/NodaTime.Web/Markdown/unstable/trivia.md
@@ -292,7 +292,7 @@ between a change being announced and Noda Time supporting it in production:
 4. I run a script to pull the latest version from TZDB, build it as an NZD
    file and push it to the Noda Time web site
 5. The system in question pulls the latest version from the web site and
-   [starts using it](tzdb.html)
+   [starts using it](tzdb)
 
 As you can see, this depends on a lot of different people, so some delay is
 inevitable. However, if your application is configured to poll the web site

--- a/src/NodaTime.Web/Markdown/unstable/type-choices.md
+++ b/src/NodaTime.Web/Markdown/unstable/type-choices.md
@@ -1,7 +1,7 @@
 @Title="Choosing (and converting) between types"
 
 This is a companion page to the
-["core concepts"](concepts.html), and ["core types quick reference"](core-types.html)
+["core concepts"](concepts), and ["core types quick reference"](core-types)
 pages, describing when it's appropriate to use which type, and how to convert between them.
 
 Ultimately, you should be thinking about what data you really have,
@@ -155,5 +155,5 @@ as they're generally very straightforward.)
 Most of these are pretty simple, but a few are worth calling out
 specifically. The biggest "gotcha" is converting `LocalDateTime` to
 `ZonedDateTime` - it has some corner cases you need to consider. See the ["times zones" section of
-the core concepts guide](concepts.html#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
+the core concepts guide](concepts#time-zones) and the [`DateTimeZone`](noda-type://NodaTime.DateTimeZone) documentation
 for more information.

--- a/src/NodaTime.Web/Markdown/unstable/tzdb.md
+++ b/src/NodaTime.Web/Markdown/unstable/tzdb.md
@@ -1,7 +1,7 @@
 @Title="Updating the time zone database"
 
 Noda Time comes with a version of the
-[tz database](http://www.iana.org/time-zones) (also known as the IANA Time Zone
+[tz database](https://www.iana.org/time-zones) (also known as the IANA Time Zone
 database, or zoneinfo or Olson database), which is now hosted by IANA. This
 database changes over time, as countries decide to change their time zone
 rules.  As new versions of Noda Time are released, the version of tzdb will be
@@ -43,8 +43,8 @@ This may be used for automation.
 Building a NodaZoneData file
 ----------------------------
 
-1. Find the link to the [latest tzdb release](http://www.iana.org/time-zones), e.g.
-   http://www.iana.org/time-zones/repository/releases/tzdata2015e.tar.gz
+1. Find the link to the [latest tzdb release](https://www.iana.org/time-zones), e.g.
+   https://www.iana.org/time-zones/repository/releases/tzdata2015e.tar.gz
 2. Determine the Windows mapping file you want to use, or let NodaTime.TzdbCompiler do it for you
    with the versions supplied with the Noda Time source in the `data\cldr` directory. If these are
    out of date, you can download a new file from [CLDR](http://cldr.unicode.org/).

--- a/src/NodaTime.Web/Markdown/unstable/tzdb.md
+++ b/src/NodaTime.Web/Markdown/unstable/tzdb.md
@@ -47,7 +47,7 @@ Building a NodaZoneData file
    http://www.iana.org/time-zones/repository/releases/tzdata2015e.tar.gz
 2. Determine the Windows mapping file you want to use, or let NodaTime.TzdbCompiler do it for you
    with the versions supplied with the Noda Time source in the `data\cldr` directory. If these are
-   out of date, you can download a new file from [CLDR](http://cldr.unicode.org).
+   out of date, you can download a new file from [CLDR](http://cldr.unicode.org/).
 3. Run NodaTime.TzdbCompiler. I'd suggest leaving it in its build directory and running it like this:
 
 ```bat

--- a/src/NodaTime.Web/Markdown/unstable/zoneddatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/unstable/zoneddatetime-patterns.md
@@ -17,7 +17,7 @@ Custom Patterns
 ---------------
 
 The custom format patterns for a zoned date and time are provided by combining
-the [custom patterns for `OffsetDateTime`](offsetdatetime-patterns.html) with
+the [custom patterns for `OffsetDateTime`](offsetdatetime-patterns) with
 the addition of two extra custom format specifiers: `z` and `x`.
 
 `z` is used to parse or format that time zone identifier. When parsing, an [`IDateTimeZoneProvider`](noda-type://NodaTime.IDateTimeZoneProvider) is used to extract candidate identifiers and fetch time zones for them. The UTC+/-xx:xx format for fixed offset time zones is always valid, regardless of provider. The provider is part of the `ZonedDateTimePattern`, and a new pattern with a different provider can be created using the `WithZoneProvider` method. The provider is not used when formatting: the time zone identifier is simply used directly. Note that if you format a `ZonedDateTime` which uses a time zone from a different provider than the one in the pattern, you may not be able to parse it again with the same pattern. A null provider can be specified, in which case

--- a/src/NodaTime.Web/Providers/MarkdownLoader.cs
+++ b/src/NodaTime.Web/Providers/MarkdownLoader.cs
@@ -21,6 +21,7 @@ namespace NodaTime.Web.Providers
     {
         private const string NodaTypePrefix = "noda-type://";
         private const string NodaPropertyPrefix = "noda-property://";
+        private const string NodaNamespacePrefix = "noda-ns://";
         private static readonly Regex IssuePlaceholderPattern = new Regex(@"^issue \d+$");
 
         private readonly IFileProvider fileProvider;
@@ -105,6 +106,14 @@ namespace NodaTime.Web.Providers
             if (url.StartsWith(NodaTypePrefix))
             {
                 url = url.Substring(NodaTypePrefix.Length);
+                int hashIndex = url.IndexOf('#');
+                string type = hashIndex < 0 ? url : url.Substring(0, hashIndex);
+                string anchor = hashIndex < 0 ? "" : url.Substring(hashIndex);
+                return $"../api/{type}.html{anchor}";
+            }
+            else if (url.StartsWith(NodaNamespacePrefix))
+            {
+                url = url.Substring(NodaNamespacePrefix.Length);
                 int hashIndex = url.IndexOf('#');
                 string type = hashIndex < 0 ? url : url.Substring(0, hashIndex);
                 string anchor = hashIndex < 0 ? "" : url.Substring(hashIndex);

--- a/src/NodaTime.Web/Views/Downloads/Index.cshtml
+++ b/src/NodaTime.Web/Views/Downloads/Index.cshtml
@@ -9,7 +9,7 @@
     <div>
         <h1>Downloads</h1>
         <p>
-            Most developers will use <a href="http://www.nuget.org">NuGet</a> to
+            Most developers will use <a href="http://www.nuget.org/">NuGet</a> to
             use Noda Time, but this page contains source and binary zip files for all
             releases.
         </p>

--- a/src/NodaTime.Web/Views/Downloads/Index.cshtml
+++ b/src/NodaTime.Web/Views/Downloads/Index.cshtml
@@ -9,7 +9,7 @@
     <div>
         <h1>Downloads</h1>
         <p>
-            Most developers will use <a href="http://www.nuget.org/">NuGet</a> to
+            Most developers will use <a href="https://www.nuget.org/">NuGet</a> to
             use Noda Time, but this page contains source and binary zip files for all
             releases.
         </p>

--- a/src/NodaTime.Web/Views/Home/Index.cshtml
+++ b/src/NodaTime.Web/Views/Home/Index.cshtml
@@ -23,7 +23,7 @@
     </div>
     <div class="hide-for-small large-6 columns">
         <div class="example unit">
-            <p class="title">Examples (see <a href="/userguide">User Guide</a>)</p>
+            <p class="title">Examples (see <a href="/userguide/">User Guide</a>)</p>
             <div class="highlight">
 <pre><code class="csharp">// Instant represents time from epoch
 Instant now = SystemClock.Instance.GetCurrentInstant();
@@ -63,13 +63,13 @@ var before = london.AtStrictly(localDate);
         </div>
         <div class="large-4 columns">
             <h3><i class="foundicon-page"></i> Documentation</h3>
-            <p>It is recommended that you read at least the first few pages of the <a href="/userguide">User Guide</a> before starting to develop using Noda Time.</p>
-            <p>You can also check out the <a href="/api">API reference</a>.</p>
+            <p>It is recommended that you read at least the first few pages of the <a href="/userguide/">User Guide</a> before starting to develop using Noda Time.</p>
+            <p>You can also check out the <a href="/api/">API reference</a>.</p>
             <p>Noda Time is licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 license</a>.</p>
         </div>
         <div class="large-4 columns">
             <h3><i class="foundicon-add-doc"></i> Contributing</h3>
-            <p>Developers interested in contributing to Noda Time itself should also check out the <a href="/developer">Developer Guide</a> and <a href="/developer/roadmap">current roadmap</a>.</p>
+            <p>Developers interested in contributing to Noda Time itself should also check out the <a href="/developer/">Developer Guide</a> and <a href="/developer/roadmap">current roadmap</a>.</p>
             <p>If you just want the code, you can <a href="https://github.com/nodatime/nodatime">check it out from the repository</a>.
         </div>
     </div>

--- a/src/NodaTime.Web/Views/Home/Index.cshtml
+++ b/src/NodaTime.Web/Views/Home/Index.cshtml
@@ -58,14 +58,14 @@ var before = london.AtStrictly(localDate);
         <div class="large-4 columns">
             <h3><i class="foundicon-globe"></i> Community</h3>
             <p>Find out more about Noda Time on our <a href="https://groups.google.com/group/noda-time">group mailing list</a> or our <a href="http://blog.nodatime.org/">blog</a>.  You can also <a href="https://gitter.im/nodatime/nodatime">chat with us on Gitter</a>.</p>
-            <p>For more specific "How do I solve problem X?" questions, please ask on Stack Overflow using the <a href="http://stackoverflow.com/questions/tagged/nodatime">nodatime</a> tag.</p>
+            <p>For more specific "How do I solve problem X?" questions, please ask on Stack Overflow using the <a href="https://stackoverflow.com/questions/tagged/nodatime">nodatime</a> tag.</p>
             <p>The <a href="https://github.com/nodatime/nodatime/issues">issue tracker</a> is hosted on the <a href="https://github.com/nodatime/nodatime">project's GitHub site</a>.
         </div>
         <div class="large-4 columns">
             <h3><i class="foundicon-page"></i> Documentation</h3>
             <p>It is recommended that you read at least the first few pages of the <a href="/userguide/">User Guide</a> before starting to develop using Noda Time.</p>
             <p>You can also check out the <a href="/api/">API reference</a>.</p>
-            <p>Noda Time is licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 license</a>.</p>
+            <p>Noda Time is licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0 license</a>.</p>
         </div>
         <div class="large-4 columns">
             <h3><i class="foundicon-add-doc"></i> Contributing</h3>

--- a/src/NodaTime.Web/Views/Shared/_Layout.cshtml
+++ b/src/NodaTime.Web/Views/Shared/_Layout.cshtml
@@ -109,7 +109,7 @@
             </div>
             <div class="small-6 columns copy">
                 &copy; <a href="https://github.com/nodatime/nodatime/blob/master/AUTHORS.txt">The Noda Time Authors</a>,
-                <span class="design">Web Design by <a href="http://nathanpalmer.com/">Nathan Palmer</a></span>
+                <span class="design">Web Design by Nathan Palmer</span>
             </div>
         </div>
     </footer>

--- a/src/NodaTime.Web/Views/Shared/_Layout.cshtml
+++ b/src/NodaTime.Web/Views/Shared/_Layout.cshtml
@@ -58,7 +58,7 @@
                             <li><a href="/1.3.x/userguide/">1.3.x</a></li>
                             <li><a href="/2.0.x/userguide/">2.0.x</a></li>
                             <li class="divider hide-for-small"></li>
-                            <li><a href="/unstable/userguide">Unstable</a></li>
+                            <li><a href="/unstable/userguide/">Unstable</a></li>
                         </ul>
                     </li>
                     <li class="divider hide-for-small"></li>
@@ -77,7 +77,7 @@
                     </li>
                     <li class="divider"></li>
                     <li>
-                        <a href="/developer">Developer Guide</a>
+                        <a href="/developer/">Developer Guide</a>
                     </li>
                     <li class="divider"></li>
                     <li>

--- a/src/NodaTime.Web/Views/Shared/_Layout.cshtml
+++ b/src/NodaTime.Web/Views/Shared/_Layout.cshtml
@@ -109,7 +109,7 @@
             </div>
             <div class="small-6 columns copy">
                 &copy; <a href="https://github.com/nodatime/nodatime/blob/master/AUTHORS.txt">The Noda Time Authors</a>,
-                <span class="design">Web Design by <a href="http://nathanpalmer.com">Nathan Palmer</a></span>
+                <span class="design">Web Design by <a href="http://nathanpalmer.com/">Nathan Palmer</a></span>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Fixes various broken links within nodatime.org, collapses chains of 302, and rewrites URLs as https:// where possible.

See individual commits for more details, but in summary:

- fixes links from the user guide to API parameterised types (`IParseResult<T>`, etc) and namespaces, which were broken.
- fixes or removes some other miscellaneous broken links.
- removes `.html` suffixes from links to the user guide; these result in a 302.
- switches URLs for sites like Wikipedia, MSDN, etc to https://.
- update various URLs that have changed (e.g. blogs.msdn.com -> blogs.msdn.microsoft.com, with a different path).

Fixes #760.