### PR TITLE
"Rename" ToIsoDayOfWeek(IsoDayOfWeek) to ToDayOfWeek(IsoDayOfWeek)

### DIFF
--- a/src/NodaTime/Extensions/IsoDayOfWeekExtensions.cs
+++ b/src/NodaTime/Extensions/IsoDayOfWeekExtensions.cs
@@ -18,6 +18,15 @@ namespace NodaTime.Extensions
         /// <remarks>This is a convenience method which calls <see cref="BclConversions.ToDayOfWeek"/>.</remarks>        
         /// <param name="isoDayOfWeek">The <c>IsoDayOfWeek</c> to convert.</param>
         /// <returns>The <c>DayOfWeek</c> equivalent to <paramref name="isoDayOfWeek"/></returns>
-        public static DayOfWeek ToIsoDayOfWeek(this IsoDayOfWeek isoDayOfWeek) => BclConversions.ToDayOfWeek(isoDayOfWeek);
+        [Obsolete("This method was incorrectly named. Use ToDayOfWeek instead")]
+        public static DayOfWeek ToIsoDayOfWeek(this IsoDayOfWeek isoDayOfWeek) => ToDayOfWeek(isoDayOfWeek);
+
+        /// <summary>
+        /// Converts a <see cref="IsoDayOfWeek"/> into the corresponding <see cref="DayOfWeek"/>.
+        /// </summary>
+        /// <remarks>This is a convenience method which calls <see cref="BclConversions.ToDayOfWeek"/>.</remarks>        
+        /// <param name="isoDayOfWeek">The <c>IsoDayOfWeek</c> to convert.</param>
+        /// <returns>The <c>DayOfWeek</c> equivalent to <paramref name="isoDayOfWeek"/></returns>
+        public static DayOfWeek ToDayOfWeek(this IsoDayOfWeek isoDayOfWeek) => BclConversions.ToDayOfWeek(isoDayOfWeek);
     }
 }


### PR DESCRIPTION
We have to live with this until 3.0 now, of course... but at least
we can make the badly-named method obsolete.

Fixes #776.