### PR TITLE
expose factory methods and conversions

### DIFF
--- a/src/NodaTime/Text/ParseResult.cs
+++ b/src/NodaTime/Text/ParseResult.cs
@@ -108,7 +108,7 @@ namespace NodaTime.Text
         /// Converts this result to a new target type, either by executing the given projection
         /// for a success result, or propagating the exception provider for failure.
         /// </summary>
-        internal ParseResult<TTarget> Convert<TTarget>(Func<T, TTarget> projection) =>
+        public ParseResult<TTarget> Convert<TTarget>(Func<T, TTarget> projection) =>
             Success ? ParseResult<TTarget>.ForValue(projection(Value))
                     : new ParseResult<TTarget>(exceptionProvider, ContinueAfterErrorWithMultipleFormats);
 
@@ -116,7 +116,7 @@ namespace NodaTime.Text
         /// Converts this result to a new target type by propagating the exception provider.
         /// This parse result must already be an error result.
         /// </summary>
-        internal ParseResult<TTarget> ConvertError<TTarget>()
+        public ParseResult<TTarget> ConvertError<TTarget>()
         {
             if (Success)
             {
@@ -126,10 +126,20 @@ namespace NodaTime.Text
         }
 
         #region Factory methods and readonly static fields
-        // TODO(feature): Expose this and following method? What about continueOnMultiple?
-        internal static ParseResult<T> ForValue(T value) => new ParseResult<T>(value);
+        
+        /// <summary>
+        /// Produces a ParseResult which represents a successful parse
+        /// </summary>
+        /// <param name="value">the successfully parsed value</param>
+        /// <returns></returns>
+        public static ParseResult<T> ForValue(T value) => new ParseResult<T>(value);
 
-        internal static ParseResult<T> ForException(Func<Exception> exceptionProvider) => new ParseResult<T>(exceptionProvider, false);
+        /// <summary>
+        /// Produces a ParseResult which represents a failed parse
+        /// </summary>
+        /// <param name="exceptionProvider">the function that produces the Exception that represents the error that caused the parse to fail</param>
+        /// <returns></returns>
+        public static ParseResult<T> ForException(Func<Exception> exceptionProvider) => new ParseResult<T>(exceptionProvider, false);
 
         internal static ParseResult<T> ForInvalidValue(ValueCursor cursor, string formatString, params object[] parameters)
         {

--- a/src/NodaTime/Text/ParseResult.cs
+++ b/src/NodaTime/Text/ParseResult.cs
@@ -108,7 +108,7 @@ namespace NodaTime.Text
         /// Converts this result to a new target type, either by executing the given projection
         /// for a success result, or propagating the exception provider for failure.
         /// </summary>
-        public ParseResult<TTarget> Convert<TTarget>(Func<T, TTarget> projection) =>
+        [NotNull] public ParseResult<TTarget> Convert<TTarget>([NotNull] Func<T, TTarget> projection) =>
             Success ? ParseResult<TTarget>.ForValue(projection(Value))
                     : new ParseResult<TTarget>(exceptionProvider, ContinueAfterErrorWithMultipleFormats);
 
@@ -116,7 +116,7 @@ namespace NodaTime.Text
         /// Converts this result to a new target type by propagating the exception provider.
         /// This parse result must already be an error result.
         /// </summary>
-        public ParseResult<TTarget> ConvertError<TTarget>()
+        [NotNull] public ParseResult<TTarget> ConvertError<TTarget>()
         {
             if (Success)
             {
@@ -126,20 +126,20 @@ namespace NodaTime.Text
         }
 
         #region Factory methods and readonly static fields
-        
+
         /// <summary>
         /// Produces a ParseResult which represents a successful parse
         /// </summary>
         /// <param name="value">the successfully parsed value</param>
         /// <returns></returns>
-        public static ParseResult<T> ForValue(T value) => new ParseResult<T>(value);
+        [NotNull] public static ParseResult<T> ForValue([NotNull] T value) => new ParseResult<T>(value);
 
-        /// <summary>
-        /// Produces a ParseResult which represents a failed parse
-        /// </summary>
-        /// <param name="exceptionProvider">the function that produces the Exception that represents the error that caused the parse to fail</param>
-        /// <returns></returns>
-        public static ParseResult<T> ForException(Func<Exception> exceptionProvider) => new ParseResult<T>(exceptionProvider, false);
+         /// <summary>
+         /// Produces a ParseResult which represents a failed parse
+         /// </summary>
+         /// <param name="exceptionProvider">the function that produces the Exception that represents the error that caused the parse to fail</param>
+         /// <returns></returns>
+         [NotNull] public static ParseResult<T> ForException([NotNull] Func<Exception> exceptionProvider) => new ParseResult<T>(exceptionProvider, false);
 
         internal static ParseResult<T> ForInvalidValue(ValueCursor cursor, string formatString, params object[] parameters)
         {


### PR DESCRIPTION
Expose those methods to conveniently be able to extend ParseResult with recovery and monadic operations/LINQ, based on discussion in #780

This isn't the absolute minimum exposed set to do things as a consumer; Convert and ConvertError can be reimplemented with just ForValue and ForException, but it is somewhat convenient to expose them, and I do believe generally useful. If you prefer not to expose those members, I'd be really happy with a variant with just the factory methods too.