### PR TITLE
Highlight the 1.3.x and 2.0.x versions of the API and User Guide.

### DIFF
--- a/src/NodaTime.Web/Views/Shared/_Layout.cshtml
+++ b/src/NodaTime.Web/Views/Shared/_Layout.cshtml
@@ -50,28 +50,28 @@
                     <li class="has-dropdown">
                         <a href="#">User Guide</a>
                         <ul class="dropdown">
-                            <li><label>Versions</label></li>
+                            <li><label>Current</label></li>
+                            <li><a href="/1.3.x/userguide/">1.3.x</a></li>
+                            <li><a href="/2.0.x/userguide/">2.0.x</a></li>
+                            <li><a href="/unstable/userguide/">Development</a></li>
+                            <li><label>Old</label></li>
                             <li><a href="/1.0.x/userguide/">1.0.x</a></li>
                             <li><a href="/1.1.x/userguide/">1.1.x</a></li>
                             <li><a href="/1.2.x/userguide/">1.2.x</a></li>
-                            <li><a href="/1.3.x/userguide/">1.3.x</a></li>
-                            <li><a href="/2.0.x/userguide/">2.0.x</a></li>
-                            <li class="divider hide-for-small-only"></li>
-                            <li><a href="/unstable/userguide/">Unstable</a></li>
                         </ul>
                     </li>
                     <li class="divider hide-for-small-only"></li>
                     <li class="has-dropdown">
                         <a href="#">API</a>
                         <ul class="dropdown">
-                            <li><label>Versions</label></li>
+                            <li><label>Current</label></li>
+                            <li><a href="/1.3.x/api/">1.3.x</a></li>
+                            <li><a href="/2.0.x/api/">2.0.x</a></li>
+                            <li><a href="/unstable/api/">Development</a></li>
+                            <li><label>Old</label></li>
                             <li><a href="/1.0.x/api/">1.0.x</a></li>
                             <li><a href="/1.1.x/api/">1.1.x</a></li>
                             <li><a href="/1.2.x/api/">1.2.x</a></li>
-                            <li><a href="/1.3.x/api/">1.3.x</a></li>
-                            <li><a href="/2.0.x/api/">2.0.x</a></li>
-                            <li class="divider hide-for-small-only"></li>
-                            <li><a href="/unstable/api/">Unstable</a></li>
                         </ul>
                     </li>
                     <li class="divider"></li>


### PR DESCRIPTION
Place the current (1.3.x and 2.0.x) versions at the top of the API/User Guide menu options, and rename "Unstable" to "Development" (in the menu label only).

Also remove the dividers, which don't seem to be adding much.