### PR TITLE
Fix Period computation bug

### DIFF
--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -67,6 +67,22 @@ namespace NodaTime.Test
         }
 
         [Test]
+        public void BetweenLocalDateTimes_AcrossDays()
+        {
+            Period expected = Period.FromHours(23) + Period.FromMinutes(59);
+            Period actual = Period.Between(TestDateTime1, TestDateTime1.PlusDays(1).PlusMinutes(-1));
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void BetweenLocalDateTimes_AcrossDays_MinutesAndSeconds()
+        {
+            Period expected = Period.FromMinutes(24 * 60 - 1) + Period.FromSeconds(59);
+            Period actual = Period.Between(TestDateTime1, TestDateTime1.PlusDays(1).PlusSeconds(-1), PeriodUnits.Minutes | PeriodUnits.Seconds);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         public void BetweenLocalDates_InvalidUnits()
         {
             Assert.Throws<ArgumentException>(() => Period.Between(TestDate1, TestDate2, 0));

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -1152,7 +1152,7 @@ namespace NodaTime
         /// there may be values just within Int64 range for which this property returns true, but they're
         /// unlikely to come up... this property should *only* be used for optimization purposes.
         /// </summary>
-        private bool IsInt64Representable => days >= MinDaysForLongNanos && days <= MaxDaysForLongNanos;
+        internal bool IsInt64Representable => days >= MinDaysForLongNanos && days <= MaxDaysForLongNanos;
 
         /// <summary>
         /// Performs an unchecked conversion from this duration to an Int64 value of nanoseconds.

--- a/src/NodaTime/Fields/TimePeriodField.cs
+++ b/src/NodaTime/Fields/TimePeriodField.cs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using System;
 using static NodaTime.NodaConstants;
 
 namespace NodaTime.Fields
@@ -145,5 +146,13 @@ namespace NodaTime.Fields
                 return nanoseconds / unitNanoseconds;
             }
         }
+
+        /// <summary>
+        /// Returns the number of units in the given duration, rounding towards zero.
+        /// </summary>
+        internal long GetUnitsInDuration(Duration duration) =>
+            duration.IsInt64Representable
+            ? duration.ToInt64Nanoseconds() / unitNanoseconds
+            : (long)(duration.ToBigIntegerNanoseconds() / unitNanoseconds);
     }
 }

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -485,9 +485,10 @@ namespace NodaTime
 
         private static long GetTimeBetween(LocalDateTime start, LocalDateTime end, TimePeriodField periodField)
         {
-            int days = DatePeriodFields.DaysField.Subtract(end.Date, start.Date);
-            long units = periodField.Subtract(end.TimeOfDay, start.TimeOfDay);
-            return units + days * periodField.UnitsPerDay;
+            LocalInstant startLocalInstant = start.ToLocalInstant();
+            LocalInstant endLocalInstant = end.ToLocalInstant();
+            Duration duration = endLocalInstant.TimeSinceLocalEpoch - startLocalInstant.TimeSinceLocalEpoch;
+            return periodField.GetUnitsInDuration(duration);
         }
 
         // TODO(optimization): These three methods are only ever used with scalar values of 1 or -1. Unlikely that


### PR DESCRIPTION
The approach taken before was fundamentally unsound. It's clearer to
consider that when we get down to time-based fields, they're all
fixed-length, so we only need to consider the duration between the
start and end points. This is an initial fix to patch into 2.0.2 -
it's not as efficient as it might be, but it's reasonably minimal.

Further refactoring will come in a separate PR, but that can stay on
the master branch only.

Fixes #824.