### PR TITLE
Optimize Duration.From* integer methods

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTimeTests/DurationBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/DurationBenchmarks.cs
@@ -61,7 +61,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public Duration FromMilliseconds_Medium() => Duration.FromMilliseconds(50L * 365 * NodaConstants.MillisecondsPerDay);
 
         [Benchmark]
-        public Duration FromTicks_Medium() => Duration.FromMilliseconds(50L * 365 * NodaConstants.TicksPerDay);
+        public Duration FromTicks_Medium() => Duration.FromTicks(50L * 365 * NodaConstants.TicksPerDay);
 
         [Benchmark]
         public Duration FromNanoseconds_MediumInt64() => Duration.FromNanoseconds(50L * 365 * NodaConstants.NanosecondsPerDay);


### PR DESCRIPTION
- For most units, we can stick entirely in Int64 arithmetic, so do that
- More test cases (expressed more cleanly)
- Fix a typo in DurationBenchmark

Fixes #837.

Benchmark results (on netcoreapp1.1, just the affected tests):

Before:

```
 |                           Method |        Mean |    StdErr |     StdDev |      Median |
 |--------------------------------- |------------ |---------- |----------- |------------ |
 |                   FromHours_Tiny |  25.7766 ns | 0.2758 ns |  1.3510 ns |  25.3726 ns |
 |                 FromMinutes_Tiny |  27.1239 ns | 0.2874 ns |  1.9280 ns |  26.5030 ns |
 |                 FromSeconds_Tiny |  27.3131 ns | 0.2909 ns |  2.3456 ns |  26.4874 ns |
 |            FromMilliseconds_Tiny |  25.8455 ns | 0.2895 ns |  1.0832 ns |  25.7541 ns |
 |                 FromHours_Medium | 487.7141 ns | 4.6941 ns | 19.3542 ns | 490.0666 ns |
 |               FromMinutes_Medium | 474.2799 ns | 2.9392 ns | 10.9976 ns | 469.0765 ns |
 |               FromSeconds_Medium | 427.7582 ns | 3.4088 ns | 12.7544 ns | 434.4823 ns |
 |          FromMilliseconds_Medium | 448.4690 ns | 4.4377 ns | 20.8146 ns | 438.3665 ns |
 |                  FromHours_Large | 509.1508 ns | 4.1882 ns | 16.2209 ns | 512.3120 ns |
 |                FromMinutes_Large | 509.7735 ns | 3.1912 ns | 12.3595 ns | 511.7030 ns |
 |                FromSeconds_Large | 483.3398 ns | 0.6121 ns |  2.2901 ns | 483.1985 ns |
 |           FromMilliseconds_Large | 473.9485 ns | 3.4093 ns | 13.2041 ns | 472.0565 ns |
```

After:

```
 |                           Method |        Mean |    StdErr |     StdDev |
 |--------------------------------- |------------ |---------- |----------- |
 |                   FromHours_Tiny |  17.0223 ns | 0.1081 ns |  0.4188 ns |
 |                 FromMinutes_Tiny |  17.4258 ns | 0.1071 ns |  0.4007 ns |
 |                 FromSeconds_Tiny |  17.4751 ns | 0.1252 ns |  0.4851 ns |
 |            FromMilliseconds_Tiny |  17.3598 ns | 0.1466 ns |  0.5678 ns |
 |                   FromTicks_Tiny |   9.1634 ns | 0.0878 ns |  0.3399 ns |
 |                 FromHours_Medium |  17.2020 ns | 0.1242 ns |  0.4811 ns |
 |               FromMinutes_Medium |  17.6043 ns | 0.1552 ns |  0.6011 ns |
 |               FromSeconds_Medium |  17.2294 ns | 0.1933 ns |  0.7485 ns |
 |          FromMilliseconds_Medium |  17.6689 ns | 0.1288 ns |  0.4820 ns |
 |                  FromHours_Large |  18.2558 ns | 0.1942 ns |  0.9313 ns |
 |                FromMinutes_Large |  18.4420 ns | 0.2537 ns |  1.0459 ns |
 |                FromSeconds_Large |  18.7508 ns | 0.2069 ns |  1.2583 ns |
 |           FromMilliseconds_Large |  17.2388 ns | 0.1389 ns |  0.5378 ns |
```

Direct mean comparisons:

```
 |                           Method |      Before |      After |
 |--------------------------------- |------------ |----------- |
 |                   FromHours_Tiny |  25.7766 ns | 17.0223 ns | 
 |                 FromMinutes_Tiny |  27.1239 ns | 17.4258 ns |
 |                 FromSeconds_Tiny |  27.3131 ns | 17.4751 ns |
 |            FromMilliseconds_Tiny |  25.8455 ns | 17.3598 ns |
 |                 FromHours_Medium | 487.7141 ns | 17.2020 ns |
 |               FromMinutes_Medium | 474.2799 ns | 17.6043 ns |
 |               FromSeconds_Medium | 427.7582 ns | 17.2294 ns |
 |          FromMilliseconds_Medium | 448.4690 ns | 17.6689 ns |
 |                  FromHours_Large | 509.1508 ns | 18.2558 ns |
 |                FromMinutes_Large | 509.7735 ns | 18.4420 ns |
 |                FromSeconds_Large | 483.3398 ns | 18.7508 ns |
 |           FromMilliseconds_Large | 473.9485 ns | 17.2388 ns |
```
