### PR TITLE
Build more projects in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,10 @@ dotnet: 1.0.1
 dist: trusty
 
 script:
-  - dotnet restore src/NodaTime
-  - dotnet restore src/NodaTime.Test
-  - dotnet build src/NodaTime -f netstandard1.3
-  - dotnet build src/NodaTime.Test -f netcoreapp1.0
+  - dotnet restore src/NodaTime-All.sln
+  - dotnet build src/NodaTime/*.csproj -f netstandard1.3
+  - dotnet build src/NodaTime.Testing/*.csproj -f netstandard1.3
+  - dotnet build src/NodaTime.Benchmarks/*.csproj -f netcoreapp1.1
+  - dotnet build src/NodaTime.Demo/*.csproj -f netcoreapp1.0
+  - dotnet build src/NodaTime.Test/*.csproj -f netcoreapp1.0
   - dotnet run -p src/NodaTime.Test/*.csproj -f netcoreapp1.0 -- --where=cat!=Slow

--- a/build/appveyor.sh
+++ b/build/appveyor.sh
@@ -5,15 +5,14 @@
 
 cd $(dirname $0)/..
 
+dotnet restore src/NodaTime-All.sln
+dotnet build -c Release src/NodaTime-All.sln
+
 if [ -n "$COVERALLS_REPO_TOKEN" ]
 then
   build/coverage.sh
   packages/coveralls.net.0.7.0/tools/csmacnz.Coveralls.exe --opencover -i coverage.xml --useRelativePaths
 else
-  # Just do the build and test instead...
-  dotnet restore src/NodaTime
-  dotnet restore src/NodaTime.Test
-  dotnet build -c Release src/NodaTime
-  dotnet build -c Release src/NodaTime.Test
+  # Just run tests instead...
   dotnet run -c Release -f net451 -p src/NodaTime.Test/*.csproj -- --where=cat!=Slow
 fi

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -2,16 +2,14 @@
 
 set -e
 
+# Note: this script assumes everything has already been built
+
 # cd to repository root
 cd $(dirname $0)/..
 
 nuget install -Verbosity quiet -OutputDirectory packages -Version 4.6.519 OpenCover
 nuget install -Verbosity quiet -OutputDirectory packages -Version 0.7.0 coveralls.net
 nuget install -Verbosity quiet -OutputDirectory packages -Version 2.4.5.0 ReportGenerator
-
-dotnet restore src/NodaTime
-dotnet restore src/NodaTime.Test
-dotnet build -c Release src/NodaTime.Test
 
 # Use the legacy JIT to avoid getting InvalidProgramException.
 export COMPLUS_useLegacyJit=1


### PR DESCRIPTION
In AppVeyor we can build all of NodaTime-All.sln

In Travis it's harder, as building the solution will fail due to the
desktop frameworks not being available.