### PR TITLE
Duration optimizations

### DIFF
--- a/src/NodaTime/Fields/TimePeriodField.cs
+++ b/src/NodaTime/Fields/TimePeriodField.cs
@@ -149,7 +149,7 @@ namespace NodaTime.Fields
         internal long GetUnitsInDuration(Duration duration) =>
             duration.IsInt64Representable
             ? duration.ToInt64Nanoseconds() / unitNanoseconds
-            : (long)(duration.ToBigIntegerNanoseconds() / unitNanoseconds);
+            : (long)(duration.ToDecimalNanoseconds() / unitNanoseconds);
 
         /// <summary>
         /// Returns a <see cref="Duration"/> representing the given number of units.
@@ -157,7 +157,6 @@ namespace NodaTime.Fields
         internal Duration ToDuration(long units) =>
             units >= -maxLongUnits && units <= maxLongUnits
             ? Duration.FromNanoseconds(units * unitNanoseconds)
-            : Duration.FromNanoseconds(units * (BigInteger)unitNanoseconds);
-
+            : Duration.FromNanoseconds(units * (decimal)unitNanoseconds);
     }
 }

--- a/src/NodaTime/Fields/TimePeriodField.cs
+++ b/src/NodaTime/Fields/TimePeriodField.cs
@@ -27,15 +27,15 @@ namespace NodaTime.Fields
         internal static readonly TimePeriodField Hours = new TimePeriodField(NanosecondsPerHour);
 
         private readonly long unitNanoseconds;
+        // The largest number of units (positive or negative) we can multiply unitNanoseconds by without overflowing a long.
         private readonly long maxLongUnits;
-
-        public long UnitsPerDay { get; }
+        private readonly long unitsPerDay;
 
         private TimePeriodField(long unitNanoseconds)
         {
             this.unitNanoseconds = unitNanoseconds;
             maxLongUnits = long.MaxValue / unitNanoseconds;
-            UnitsPerDay = NanosecondsPerDay / unitNanoseconds;
+            unitsPerDay = NanosecondsPerDay / unitNanoseconds;
         }
 
         internal LocalDateTime Add(LocalDateTime start, long units)
@@ -55,9 +55,9 @@ namespace NodaTime.Fields
                 // into a day, so we can make sure we add a value which is less than a day.
                 if (value >= 0)
                 {
-                    if (value >= UnitsPerDay)
+                    if (value >= unitsPerDay)
                     {
-                        value = value % UnitsPerDay;
+                        value = value % unitsPerDay;
                     }
                     long nanosToAdd = value * unitNanoseconds;
                     long newNanos = localTime.NanosecondOfDay + nanosToAdd;
@@ -69,9 +69,9 @@ namespace NodaTime.Fields
                 }
                 else
                 {
-                    if (value <= -UnitsPerDay)
+                    if (value <= -unitsPerDay)
                     {
-                        value = value % UnitsPerDay;
+                        value = value % unitsPerDay;
                     }
                     long nanosToAdd = value * unitNanoseconds;
                     long newNanos = localTime.NanosecondOfDay + nanosToAdd;
@@ -96,12 +96,12 @@ namespace NodaTime.Fields
                 // It's possible that there are better ways to do this, but this at least feels simple.
                 if (value >= 0)
                 {
-                    if (value >= UnitsPerDay)
+                    if (value >= unitsPerDay)
                     {
-                        long longDays = value / UnitsPerDay;
+                        long longDays = value / unitsPerDay;
                         // If this overflows, that's fine. (An OverflowException is a reasonable outcome.)
                         days = checked ((int) longDays);
-                        value = value % UnitsPerDay;
+                        value = value % unitsPerDay;
                     }
                     long nanosToAdd = value * unitNanoseconds;
                     long newNanos = localTime.NanosecondOfDay + nanosToAdd;
@@ -115,12 +115,12 @@ namespace NodaTime.Fields
                 }
                 else
                 {
-                    if (value <= -UnitsPerDay)
+                    if (value <= -unitsPerDay)
                     {
-                        long longDays = value / UnitsPerDay;
+                        long longDays = value / unitsPerDay;
                         // If this overflows, that's fine. (An OverflowException is a reasonable outcome.)
                         days = checked((int) longDays);
-                        value = value % UnitsPerDay;
+                        value = value % unitsPerDay;
                     }
                     long nanosToAdd = value * unitNanoseconds;
                     long newNanos = localTime.NanosecondOfDay + nanosToAdd;


### PR DESCRIPTION
Fixes #838 

(I've managed to delete the benchmark comparisons I had, but they were fairly significant - particularly avoiding using BigInteger on the way to double. When we've got benchmarks on the website I can edit this PR comment to link to an appropriate comparison :)