### PR TITLE
More 1.4 to 2.0 compatibility

### DIFF
--- a/src/NodaTime.Serialization.Test/NodaTime.Serialization.Test.csproj
+++ b/src/NodaTime.Serialization.Test/NodaTime.Serialization.Test.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -29,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed Release|AnyCPU'">
     <OutputPath>bin\Signed Release\</OutputPath>
@@ -38,6 +40,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug Portable|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -48,6 +51,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Optimize>true</Optimize>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release Portable|AnyCPU'">
     <OutputPath>bin\Release Portable\</OutputPath>
@@ -57,6 +61,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed Release Portable|AnyCPU'">
     <OutputPath>bin\Signed Release Portable\</OutputPath>
@@ -68,6 +73,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AssemblyOriginatorKeyFile>..\..\NodaTime Release.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json">

--- a/src/NodaTime.Test/Calendars/CopticCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/CopticCalendarSystemTest.cs
@@ -43,10 +43,8 @@ namespace NodaTime.Test.Calendars
             LocalDateTime coptic = new LocalDateTime(iso.LocalInstant, copticCalendar);
 
             Assert.AreEqual(Era.AnnoMartyrum, coptic.Era);
-#pragma warning disable 0618
             // The misspelled version of the Era works too.
             Assert.AreEqual(Era.AnnoMartyrm, coptic.Era);
-#pragma warning restore 0618
             Assert.AreEqual(18, coptic.CenturyOfEra);
             Assert.AreEqual(20, coptic.YearOfCentury);
             Assert.AreEqual(1720, coptic.YearOfEra);

--- a/src/NodaTime.Test/DateTimeZoneProvidersTest.cs
+++ b/src/NodaTime.Test/DateTimeZoneProvidersTest.cs
@@ -22,9 +22,7 @@ namespace NodaTime.Test
         [Test]
         public void DefaultProviderIsTzdb()
         {
-#pragma warning disable 0618
             Assert.AreSame(DateTimeZoneProviders.Tzdb, DateTimeZoneProviders.Default);
-#pragma warning restore 0618
         }
 
         [Test]

--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -44,6 +44,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -52,6 +53,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed Release|AnyCPU'">
     <OutputPath>bin\Signed Release\</OutputPath>
@@ -63,6 +65,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AssemblyOriginatorKeyFile>..\..\NodaTime Release.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug Portable|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -73,6 +76,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Optimize>true</Optimize>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release Portable|AnyCPU'">
     <OutputPath>bin\Release Portable\</OutputPath>
@@ -82,6 +86,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed Release Portable|AnyCPU'">
     <OutputPath>bin\Signed Release Portable\</OutputPath>
@@ -93,6 +98,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AssemblyOriginatorKeyFile>..\..\NodaTime Release.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=2.5.2.9222, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">

--- a/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
@@ -92,10 +92,8 @@ namespace NodaTime.Test.TimeZones
         [Test]
         public void CanLoadNodaTimeResourceFromOnePointZeroRelease()
         {
-#pragma warning disable 0618
             var source = new TzdbDateTimeZoneSource("NodaTime.Test.TestData.Tzdb2012iFromNodaTime1.0",
                 Assembly.GetExecutingAssembly());
-#pragma warning restore 0618
             Assert.AreEqual("TZDB: 2012i (mapping: 6356)", source.VersionId);
 
             var utc = Instant.FromUtc(2007, 8, 24, 9, 30, 0);

--- a/src/NodaTime.Testing/FakeClock.cs
+++ b/src/NodaTime.Testing/FakeClock.cs
@@ -2,6 +2,8 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using System;
+
 namespace NodaTime.Testing
 {
     /// <summary>
@@ -134,6 +136,14 @@ namespace NodaTime.Testing
         /// </summary>
         /// <param name="hours">The number of hours to advance the clock by (or if negative, the number to move it
         /// back by).</param>
+        public void AdvanceHours(int hours) => AdvanceHours((long) hours);
+
+        /// <summary>
+        /// Advances the clock by the given number of hours.
+        /// </summary>
+        /// <param name="hours">The number of hours to advance the clock by (or if negative, the number to move it
+        /// back by).</param>
+        [Obsolete("Use AdvanceHours(Int32) for compatibility with 2.0")]
         public void AdvanceHours(long hours)
         {
             Advance(Duration.FromHours(hours));
@@ -144,6 +154,14 @@ namespace NodaTime.Testing
         /// </summary>
         /// <param name="days">The number of days to advance the clock by (or if negative, the number to move it
         /// back by).</param>
+        public void AdvanceDays(int days) => AdvanceDays((long) days);
+
+        /// <summary>
+        /// Advances the clock by the given number of standard (24-hour) days.
+        /// </summary>
+        /// <param name="days">The number of days to advance the clock by (or if negative, the number to move it
+        /// back by).</param>
+        [Obsolete("Use AdvanceDays(Int32) for compatibility with 2.0")]
         public void AdvanceDays(long days)
         {
             Advance(Duration.FromStandardDays(days));

--- a/src/NodaTime.Testing/NodaTime.Testing.csproj
+++ b/src/NodaTime.Testing/NodaTime.Testing.csproj
@@ -65,6 +65,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -74,6 +75,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\NodaTime.Testing.xml</DocumentationFile>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed Release|AnyCPU'">
     <OutputPath>bin\Signed Release\</OutputPath>
@@ -86,6 +88,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NodaTime Release.snk</AssemblyOriginatorKeyFile>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug Portable|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -95,6 +98,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release Portable|AnyCPU'">
     <OutputPath>bin\Release Portable\</OutputPath>
@@ -105,6 +109,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Release Portable\NodaTime.Testing.xml</DocumentationFile>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed Release Portable|AnyCPU'">
     <OutputPath>bin\Signed Release Portable\</OutputPath>
@@ -117,6 +122,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <AssemblyOriginatorKeyFile>..\..\NodaTime Release.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -910,7 +910,6 @@ namespace NodaTime
         /// <value>An Islamic calendar system equivalent to the one used by the BCL.</value>
         [NotNull] public static CalendarSystem IslamicBcl => GetIslamicCalendar(IslamicLeapYearPattern.Base16, IslamicEpoch.Astronomical);
 
-#pragma warning disable CS0618 // Type or member is obsolete
         /// <summary>
         /// Returns a Persian (also known as Solar Hijri) calendar system implementing the behaviour of the
         /// BCL <code>PersianCalendar</code> before .NET 4.6, and the sole Persian calendar in Noda Time 1.3.
@@ -921,7 +920,6 @@ namespace NodaTime
         /// </remarks>
         /// <value>A Persian calendar system using a simple 33-year leap cycle.</value>
         [NotNull] public static CalendarSystem PersianSimple => GetPersianCalendar();
-#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Returns a Hebrew calendar system using the civil month numbering,

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -673,6 +673,18 @@ namespace NodaTime
         }
 
         /// <summary>
+        /// The number of months within this calendar in the given year. It is assumed that
+        /// all calendars start with month 1 and go up to this month number in any valid year.
+        /// </summary>
+        /// <param name="year">The year to consider.</param>
+        /// <exception cref="ArgumentOutOfRangeException">The given year is invalid for this calendar.
+        /// Note that some implementations may return a month rather than throw this exception (for example, if all
+        /// years have the same number of months in this calendar system). Failure to throw an exception should not be
+        /// treated as an indication that the year is valid.</exception>
+        /// <returns>The maximum month number within the given year.</returns>
+        public int GetMonthsInYear(int year) => GetMaxMonth(year);
+
+        /// <summary>
         /// The maximum valid month (inclusive) within this calendar in the given year. It is assumed that
         /// all calendars start with month 1 and go up to this month number in any valid year.
         /// </summary>
@@ -682,6 +694,7 @@ namespace NodaTime
         /// years have the same number of months in this calendar system). Failure to throw an exception should not be
         /// treated as an indication that the year is valid.</exception>
         /// <returns>The maximum month number within the given year.</returns>
+        [Obsolete("Use GetMonthsInYear for compatibility with 2.0")]
         public int GetMaxMonth(int year)
         {
             return yearMonthDayCalculator.GetMaxMonth(year);

--- a/src/NodaTime/ClockExtensions.cs
+++ b/src/NodaTime/ClockExtensions.cs
@@ -18,8 +18,6 @@ namespace NodaTime
         /// <see cref="IClock.Now"/> property.</remarks>
         /// <returns>The current instant on the time line according to this clock.</returns>
         public static Instant GetCurrentInstant(this IClock clock) =>
-#pragma warning disable CS0618 // Type or member is obsolete
             Preconditions.CheckNotNull(clock, nameof(clock)).Now;
-#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -130,6 +130,16 @@ namespace NodaTime
         /// This property effectively represents all of the information within a Duration value; a duration
         /// is simply a number of ticks.
         /// </remarks>
+        public long BclCompatibleTicks => Ticks;
+
+        /// <summary>
+        /// The total number of ticks in the duration.
+        /// </summary>
+        /// <remarks>
+        /// This property effectively represents all of the information within a Duration value; a duration
+        /// is simply a number of ticks.
+        /// </remarks>
+        [Obsolete("Use BclCompatibleTicks for compatibility with 2.0.")]
         public long Ticks { get { return ticks; } }
 
         #region Object overrides
@@ -505,6 +515,15 @@ namespace NodaTime
         /// </summary>
         /// <param name="days">The number of days.</param>
         /// <returns>A <see cref="Duration"/> representing the given number of days.</returns>
+        public static Duration FromDays(int days) => FromStandardDays(days);
+
+        /// <summary>
+        /// Returns a <see cref="Duration"/> that represents the given number of days, assuming a 'standard' 24-hour
+        /// day.
+        /// </summary>
+        /// <param name="days">The number of days.</param>
+        /// <returns>A <see cref="Duration"/> representing the given number of days.</returns>
+        [Obsolete("Use FromDays for compatibility with 2.0.")]
         public static Duration FromStandardDays(long days)
         {
             return OneStandardDay * days;
@@ -515,6 +534,14 @@ namespace NodaTime
         /// </summary>
         /// <param name="hours">The number of hours.</param>
         /// <returns>A <see cref="Duration"/> representing the given number of hours.</returns>
+        public static Duration FromHours(int hours) => FromHours((long) hours);
+
+        /// <summary>
+        /// Returns a <see cref="Duration"/> that represents the given number of hours.
+        /// </summary>
+        /// <param name="hours">The number of hours.</param>
+        /// <returns>A <see cref="Duration"/> representing the given number of hours.</returns>
+        [Obsolete("Use FromHours(int) for compatibility with 2.0.")]
         public static Duration FromHours(long hours)
         {
             return OneHour * hours;

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -66,6 +66,7 @@ namespace NodaTime
         /// </remarks>
         /// <param name="ticks">The number of ticks since the Unix epoch. Negative values represent instants before the
         /// Unix epoch.</param>
+        [Obsolete("Use FromUnixTimeTicks for compatibility with 2.0.")]
         public Instant(long ticks)
         {
             this.ticks = ticks;
@@ -77,7 +78,17 @@ namespace NodaTime
         /// <remarks>
         /// A tick is equal to 100 nanoseconds. There are 10,000 ticks in a millisecond.
         /// </remarks>
+        [Obsolete("Use ToUnixTimeTicks for compatibility with 2.0")]
         public long Ticks { get { return ticks; } }
+
+        /// <summary>
+        /// The number of ticks since the Unix epoch. Negative values represent instants before the Unix epoch.
+        /// </summary>
+        /// <remarks>
+        /// A tick is equal to 100 nanoseconds. There are 10,000 ticks in a millisecond.
+        /// </remarks>
+        /// <returns>The number of ticks since the Unix epoch.</returns>
+        [Pure] public long ToUnixTimeTicks() => Ticks;
 
         #region IComparable<Instant> and IComparable Members
         /// <summary>
@@ -520,6 +531,16 @@ namespace NodaTime
         /// <param name="seconds">Number of seconds since the Unix epoch. May be negative (for instants before the epoch).</param>
         /// <returns>An <see cref="Instant"/> at exactly the given number of seconds since the Unix epoch.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The constructed instant would be out of the range representable in Noda Time.</exception>
+        public static Instant FromUnixTimeSeconds(long seconds) => FromSecondsSinceUnixEpoch(seconds);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Instant" /> struct based
+        /// on a number of seconds since the Unix epoch of (ISO) January 1st 1970, midnight, UTC.
+        /// </summary>
+        /// <param name="seconds">Number of seconds since the Unix epoch. May be negative (for instants before the epoch).</param>
+        /// <returns>An <see cref="Instant"/> at exactly the given number of seconds since the Unix epoch.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The constructed instant would be out of the range representable in Noda Time.</exception>
+        [Obsolete("Use FromUnixTimeSeconds for compatibility with 2.0.")]
         public static Instant FromSecondsSinceUnixEpoch(long seconds)
         {
             Preconditions.CheckArgumentRange("seconds", seconds, long.MinValue / NodaConstants.TicksPerSecond,
@@ -534,6 +555,16 @@ namespace NodaTime
         /// <param name="milliseconds">Number of milliseconds since the Unix epoch. May be negative (for instants before the epoch).</param>
         /// <returns>An <see cref="Instant"/> at exactly the given number of milliseconds since the Unix epoch.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The constructed instant would be out of the range representable in Noda Time.</exception>
+        public static Instant FromUnixTimeMilliseconds(long milliseconds) => FromMillisecondsSinceUnixEpoch(milliseconds);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Instant" /> struct based
+        /// on a number of milliseconds since the Unix epoch of (ISO) January 1st 1970, midnight, UTC.
+        /// </summary>
+        /// <param name="milliseconds">Number of milliseconds since the Unix epoch. May be negative (for instants before the epoch).</param>
+        /// <returns>An <see cref="Instant"/> at exactly the given number of milliseconds since the Unix epoch.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">The constructed instant would be out of the range representable in Noda Time.</exception>
+        [Obsolete("Use FromUnixTimeMilliseconds for compatibility with 2.0.")]
         public static Instant FromMillisecondsSinceUnixEpoch(long milliseconds)
         {
             Preconditions.CheckArgumentRange("milliseconds", milliseconds, long.MinValue / NodaConstants.TicksPerMillisecond,
@@ -545,10 +576,19 @@ namespace NodaTime
         /// Initializes a new instance of the <see cref="Instant" /> struct based
         /// on a number of ticks since the Unix epoch of (ISO) January 1st 1970, midnight, UTC.
         /// </summary>
+        /// <returns>An <see cref="Instant"/> at exactly the given number of ticks since the Unix epoch.</returns>
+        /// <param name="ticks">Number of ticks since the Unix epoch. May be negative (for instants before the epoch).</param>
+        public static Instant FromUnixTimeTicks(long ticks) => FromTicksSinceUnixEpoch(ticks);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Instant" /> struct based
+        /// on a number of ticks since the Unix epoch of (ISO) January 1st 1970, midnight, UTC.
+        /// </summary>
         /// <remarks>This is equivalent to calling the constructor directly, but indicates
         /// intent more explicitly.</remarks>
         /// <returns>An <see cref="Instant"/> at exactly the given number of ticks since the Unix epoch.</returns>
         /// <param name="ticks">Number of ticks since the Unix epoch. May be negative (for instants before the epoch).</param>
+        [Obsolete("Use FromUnixTimeTicks for compatibility with 2.0.")]
         public static Instant FromTicksSinceUnixEpoch(long ticks)
         {
             return new Instant(ticks);

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -126,6 +126,20 @@ namespace NodaTime
         /// <param name="tickWithinMillisecond">The tick within the millisecond.</param>
         /// <exception cref="ArgumentOutOfRangeException">The parameters do not form a valid time.</exception>
         /// <returns>The resulting time.</returns>
+        public static LocalTime FromHourMinuteSecondMillisecondTick(int hour, int minute, int second, int millisecond, int tickWithinMillisecond) =>
+            new LocalTime(hour, minute, second, millisecond, tickWithinMillisecond);
+
+        /// <summary>
+        /// Creates a local time at the given hour, minute, second, millisecond and tick within millisecond.
+        /// </summary>
+        /// <param name="hour">The hour of day.</param>
+        /// <param name="minute">The minute of the hour.</param>
+        /// <param name="second">The second of the minute.</param>
+        /// <param name="millisecond">The millisecond of the second.</param>
+        /// <param name="tickWithinMillisecond">The tick within the millisecond.</param>
+        /// <exception cref="ArgumentOutOfRangeException">The parameters do not form a valid time.</exception>
+        /// <returns>The resulting time.</returns>
+        [Obsolete("Use FromHourMinuteSecondMillisecondTick for compatibility with 2.0.x")]
         public LocalTime(int hour, int minute, int second, int millisecond, int tickWithinMillisecond)
         {
             Preconditions.CheckArgumentRange("hour", hour, 0, NodaConstants.HoursPerStandardDay - 1);

--- a/src/NodaTime/NodaConstants.cs
+++ b/src/NodaTime/NodaConstants.cs
@@ -29,15 +29,29 @@ namespace NodaTime
         public const long TicksPerHour = TicksPerMinute * MinutesPerHour;
 
         /// <summary>
+        /// A constant for the number of ticks in a 24-hour day.
+        /// The value of this constant is 864,000,000,000.
+        /// </summary>
+        public const long TicksPerDay = TicksPerStandardDay;
+
+        /// <summary>
         /// A constant for the number of ticks in a standard 24-hour day.
         /// The value of this constant is 864,000,000,000.
         /// </summary>
+        [Obsolete("Use TicksPerDay for compatibility with 2.0.x")]
         public const long TicksPerStandardDay = TicksPerHour * HoursPerStandardDay;
+
+        /// <summary>
+        /// A constant for the number of ticks in a week of seven 24-hour days.
+        /// The value of this constant is 6,048,000,000,000.
+        /// </summary>
+        public const long TicksPerWeek = TicksPerStandardWeek;
 
         /// <summary>
         /// A constant for the number of ticks in a standard week of seven 24-hour days.
         /// The value of this constant is 6,048,000,000,000.
         /// </summary>
+        [Obsolete("Use TicksPerWeek for compatibility with 2.0.x")]
         public const long TicksPerStandardWeek = TicksPerStandardDay * DaysPerStandardWeek;
 
         /// <summary>
@@ -56,14 +70,26 @@ namespace NodaTime
         /// </summary>
         public const int MillisecondsPerHour = MillisecondsPerMinute * MinutesPerHour;
         /// <summary>
+        /// A constant for the number of milliseconds per 24-hour day.
+        /// The value of this constant is 86,400,000.
+        /// </summary>
+        public const int MillisecondsPerDay = MillisecondsPerStandardDay;
+        /// <summary>
         /// A constant for the number of milliseconds per standard 24-hour day.
         /// The value of this constant is 86,400,000.
         /// </summary>
+        [Obsolete("Use MillisecondsPerDay for compatibility with 2.0.x")]
         public const int MillisecondsPerStandardDay = MillisecondsPerHour * HoursPerStandardDay;
         /// <summary>
         /// A constant for the number of milliseconds per standard week of seven 24-hour days.
         /// The value of this constant is 604,800,000.
         /// </summary>
+        public const int MillisecondsPerWeek = MillisecondsPerStandardWeek;
+        /// <summary>
+        /// A constant for the number of milliseconds per standard week of seven 24-hour days.
+        /// The value of this constant is 604,800,000.
+        /// </summary>
+        [Obsolete("Use MillisecondsPerWeek for compatibility with 2.0.x")]
         public const int MillisecondsPerStandardWeek = MillisecondsPerStandardDay * DaysPerStandardWeek;
 
         /// <summary>
@@ -77,12 +103,18 @@ namespace NodaTime
         /// </summary>
         public const int SecondsPerHour = SecondsPerMinute * MinutesPerHour;
         /// <summary>
+        /// A constant for the number of seconds per 24-hour day.
+        /// The value of this constant is 86,400.
+        /// </summary>
+        public const int SecondsPerDay = SecondsPerStandardDay;
+        /// <summary>
         /// A constant for the number of seconds per standard 24-hour day.
         /// The value of this constant is 86,400.
         /// </summary>
+        [Obsolete("Use SecondsPerDay for compatibility with 2.0.x")]
         public const int SecondsPerStandardDay = SecondsPerHour * HoursPerStandardDay;
         /// <summary>
-        /// A constant for the number of seconds per standard week of seven 24-hour days.
+        /// A constant for the number of seconds per week of seven 24-hour days.
         /// The value of this constant is 604,800.
         /// </summary>
         public const int SecondsPerWeek = SecondsPerStandardDay * DaysPerStandardWeek;
@@ -93,32 +125,64 @@ namespace NodaTime
         /// </summary>
         public const int MinutesPerHour = 60;
         /// <summary>
+        /// A constant for the number of minutes per 24-hour day.
+        /// The value of this constant is 1,440.
+        /// </summary>
+        public const int MinutesPerDay = MinutesPerStandardDay;
+        /// <summary>
         /// A constant for the number of minutes per standard 24-hour day.
         /// The value of this constant is 1,440.
         /// </summary>
+        [Obsolete("Use MinutesPerDay for compatibility with 2.0.x")]
         public const int MinutesPerStandardDay = MinutesPerHour * HoursPerStandardDay;
+        /// <summary>
+        /// A constant for the number of minutes per week of seven 24-hour days.
+        /// The value of this constant is 10,080.
+        /// </summary>
+        public const int MinutesPerWeek = MinutesPerStandardWeek;
         /// <summary>
         /// A constant for the number of minutes per standard week of seven 24-hour days.
         /// The value of this constant is 10,080.
         /// </summary>
+        [Obsolete("Use MinutesPerWeek for compatibility with 2.0.x")]
         public const int MinutesPerStandardWeek = MinutesPerStandardDay * DaysPerStandardWeek;
 
+        /// <summary>
+        /// A constant for the number of hours in a day. Note that the number of hours
+        /// in a day can vary due to daylight saving effects.
+        /// The value of this constant is 24.
+        /// </summary>
+        public const int HoursPerDay = HoursPerStandardDay;
         /// <summary>
         /// A constant for the number of hours in a standard day. Note that the number of hours
         /// in a day can vary due to daylight saving effects.
         /// The value of this constant is 24.
         /// </summary>
+        [Obsolete("Use HoursPerDay for compatibility with 2.0.x")]
         public const int HoursPerStandardDay = 24;
+        /// <summary>
+        /// A constant for the number of hours in a week of seven 24-hour days.
+        /// The value of this constant is 168.
+        /// </summary>
+        public const int HoursPerWeek = HoursPerStandardWeek;
         /// <summary>
         /// A constant for the number of hours in a standard week of seven 24-hour days.
         /// The value of this constant is 168.
         /// </summary>
+        [Obsolete("Use HoursPerWeek for compatibility with 2.0.x")]
         public const int HoursPerStandardWeek = HoursPerStandardDay * DaysPerStandardWeek;
+
+        /// <summary>
+        /// Number of days in a Gregorian week.
+        /// The value of this constant is 7.
+        /// </summary>
+        public const int DaysPerWeek = DaysPerStandardWeek;
 
         /// <summary>
         /// Number of days in a standard Gregorian week.
         /// The value of this constant is 7.
         /// </summary>
+        [Obsolete("Use DaysPerWeek for compatibility with 2.0.x")]
         public const int DaysPerStandardWeek = 7;
 
         /// <summary>

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -71,6 +71,7 @@
     <DocumentationFile>
     </DocumentationFile>
     <LangVersion>6</LangVersion>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -82,8 +83,7 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Release\NodaTime.xml</DocumentationFile>
-    <NoWarn>
-    </NoWarn>
+    <NoWarn>0618</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed Release|AnyCPU'">
@@ -99,6 +99,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <AssemblyOriginatorKeyFile>..\..\NodaTime Release.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug Portable|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -109,6 +110,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release Portable|AnyCPU'">
     <OutputPath>bin\Release Portable\</OutputPath>
@@ -121,6 +123,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Signed Release Portable|AnyCPU'">
     <OutputPath>bin\Signed Release Portable\</OutputPath>
@@ -135,6 +138,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <AssemblyOriginatorKeyFile>..\..\NodaTime Release.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>True</SignAssembly>
+    <NoWarn>0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -152,6 +152,15 @@ namespace NodaTime
         /// <param name="years">The number of years in the new period</param>
         /// <returns>A period consisting of the given number of years.</returns>
         [NotNull]
+        public static Period FromYears(int years) => FromYears((long) years);
+
+        /// <summary>
+        /// Creates a period representing the specified number of years.
+        /// </summary>
+        /// <param name="years">The number of years in the new period</param>
+        /// <returns>A period consisting of the given number of years.</returns>
+        [NotNull]
+        [Obsolete("Use FromYears(Int32) for compatibility with 2.0")]
         public static Period FromYears(long years)
         {
             return new Period(PeriodUnits.Years, years);
@@ -162,6 +171,14 @@ namespace NodaTime
         /// </summary>
         /// <param name="weeks">The number of weeks in the new period</param>
         /// <returns>A period consisting of the given number of weeks.</returns>
+        public static Period FromWeeks(int weeks) => FromWeeks((long) weeks);
+
+        /// <summary>
+        /// Creates a period representing the specified number of weeks.
+        /// </summary>
+        /// <param name="weeks">The number of weeks in the new period</param>
+        /// <returns>A period consisting of the given number of weeks.</returns>
+        [Obsolete("Use FromWeeks(Int32) for compatibility with 2.0")]
         public static Period FromWeeks(long weeks)
         {
             return new Period(PeriodUnits.Weeks, weeks);
@@ -172,6 +189,14 @@ namespace NodaTime
         /// </summary>
         /// <param name="months">The number of months in the new period</param>
         /// <returns>A period consisting of the given number of months.</returns>
+        public static Period FromMonths(int months) => FromMonths((long) months);
+
+        /// <summary>
+        /// Creates a period representing the specified number of months.
+        /// </summary>
+        /// <param name="months">The number of months in the new period</param>
+        /// <returns>A period consisting of the given number of months.</returns>
+        [Obsolete("Use FromMonths(Int32) for compatibility with 2.0")]
         public static Period FromMonths(long months)
         {
             return new Period(PeriodUnits.Months, months);
@@ -182,6 +207,14 @@ namespace NodaTime
         /// </summary>
         /// <param name="days">The number of days in the new period</param>
         /// <returns>A period consisting of the given number of days.</returns>
+        public static Period FromDays(int days) => FromDays((long) days);
+
+        /// <summary>
+        /// Creates a period representing the specified number of days.
+        /// </summary>
+        /// <param name="days">The number of days in the new period</param>
+        /// <returns>A period consisting of the given number of days.</returns>
+        [Obsolete("Use FromDays(Int32) for compatibility with 2.0")]
         public static Period FromDays(long days)
         {
             return new Period(PeriodUnits.Days, days);

--- a/src/NodaTime/Text/DurationPattern.cs
+++ b/src/NodaTime/Text/DurationPattern.cs
@@ -7,6 +7,7 @@ using NodaTime.Annotations;
 using NodaTime.Globalization;
 using NodaTime.Text.Patterns;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime.Text
 {
@@ -25,6 +26,13 @@ namespace NodaTime.Text
         /// General pattern for durations using the invariant culture, with a format string of "-D:hh:mm:ss.FFFFFFF".
         /// This pattern round-trips.
         /// </summary>
+        public static DurationPattern Roundtrip => RoundtripPattern;
+
+        /// <summary>
+        /// General pattern for durations using the invariant culture, with a format string of "-D:hh:mm:ss.FFFFFFF".
+        /// This pattern round-trips.
+        /// </summary>
+        [Obsolete("Use Roundtrip for compatibility with 2.0")]
         public static DurationPattern RoundtripPattern { get { return Patterns.RoundtripPatternImpl; } }
 
         internal static readonly PatternBclSupport<Duration> BclSupport = new PatternBclSupport<Duration>("o", fi => fi.DurationPatternParser);

--- a/src/NodaTime/Text/InstantPattern.cs
+++ b/src/NodaTime/Text/InstantPattern.cs
@@ -41,6 +41,13 @@ namespace NodaTime.Text
         /// Returns the general pattern, which always uses an invariant culture. The general pattern represents
         /// an instant as a UTC date/time in ISO-8601 style "yyyy-MM-ddTHH:mm:ss'Z'".
         /// </summary>
+        public static InstantPattern General => GeneralPattern;
+
+        /// <summary>
+        /// Returns the general pattern, which always uses an invariant culture. The general pattern represents
+        /// an instant as a UTC date/time in ISO-8601 style "yyyy-MM-ddTHH:mm:ss'Z'".
+        /// </summary>
+        [Obsolete("Use General for compatibility with 2.0")]
         public static InstantPattern GeneralPattern { get { return Patterns.GeneralPatternImpl; } }
 
         /// <summary>
@@ -48,6 +55,14 @@ namespace NodaTime.Text
         /// of sub-second accuracy. (These digits are omitted when unnecessary.)
         /// This corresponds to the text pattern "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFF'Z'".
         /// </summary>
+        public static InstantPattern ExtendedIso => ExtendedIsoPattern;
+
+        /// <summary>
+        /// Returns an invariant instant pattern which is ISO-8601 compatible, providing up to 7 decimal places
+        /// of sub-second accuracy. (These digits are omitted when unnecessary.)
+        /// This corresponds to the text pattern "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFF'Z'".
+        /// </summary>
+        [Obsolete("Use ExtendedIso for compatibility with 2.0")]
         public static InstantPattern ExtendedIsoPattern { get { return Patterns.ExtendedIsoPatternImpl; } }
 
         private const string DefaultFormatPattern = "g";

--- a/src/NodaTime/Text/LocalDatePattern.cs
+++ b/src/NodaTime/Text/LocalDatePattern.cs
@@ -7,6 +7,7 @@ using NodaTime.Annotations;
 using NodaTime.Globalization;
 using NodaTime.Text.Patterns;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime.Text
 {
@@ -32,6 +33,13 @@ namespace NodaTime.Text
         /// Returns an invariant local date pattern which is ISO-8601 compatible.
         /// This corresponds to the text pattern "yyyy'-'MM'-'dd".
         /// </summary>
+        public static LocalDatePattern Iso => IsoPattern;
+
+        /// <summary>
+        /// Returns an invariant local date pattern which is ISO-8601 compatible.
+        /// This corresponds to the text pattern "yyyy'-'MM'-'dd".
+        /// </summary>
+        [Obsolete("Use Iso for compatibility with 2.0")]
         public static LocalDatePattern IsoPattern { get { return Patterns.IsoPatternImpl; } }
         
         /// <summary>

--- a/src/NodaTime/Text/LocalDateTimePattern.cs
+++ b/src/NodaTime/Text/LocalDateTimePattern.cs
@@ -34,6 +34,14 @@ namespace NodaTime.Text
         /// This corresponds to the text pattern "yyyy'-'MM'-'dd'T'HH':'mm':'ss", and is also used as the "sortable"
         /// standard pattern.
         /// </summary>
+        public static LocalDateTimePattern GeneralIso => GeneralIsoPattern;
+
+        /// <summary>
+        /// Returns an invariant local date/time pattern which is ISO-8601 compatible, down to the second.
+        /// This corresponds to the text pattern "yyyy'-'MM'-'dd'T'HH':'mm':'ss", and is also used as the "sortable"
+        /// standard pattern.
+        /// </summary>
+        [Obsolete("Use GeneralIso for compatibility with 2.0")]
         public static LocalDateTimePattern GeneralIsoPattern { get { return Patterns.GeneralIsoPatternImpl; } }
 
         /// <summary>
@@ -41,6 +49,14 @@ namespace NodaTime.Text
         /// of sub-second accuracy. (These digits are omitted when unnecessary.)
         /// This corresponds to the text pattern "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFF".
         /// </summary>
+        public static LocalDateTimePattern ExtendedIso => ExtendedIsoPattern;
+
+        /// <summary>
+        /// Returns an invariant local date/time pattern which is ISO-8601 compatible, providing up to 7 decimal places
+        /// of sub-second accuracy. (These digits are omitted when unnecessary.)
+        /// This corresponds to the text pattern "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFF".
+        /// </summary>
+        [Obsolete("Use ExtendedIso for compatibility with 2.0")]
         public static LocalDateTimePattern ExtendedIsoPattern { get { return Patterns.ExtendedIsoPatternImpl; } }
 
         /// <summary>
@@ -49,12 +65,28 @@ namespace NodaTime.Text
         /// BCL round-trip formatting of <see cref="DateTime"/> values with a kind of "unspecified".
         /// This corresponds to the text pattern "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff".
         /// </summary>
+        public static LocalDateTimePattern BclRoundtrip => BclRoundtripPattern;
+
+        /// <summary>
+        /// Returns an invariant local date/time pattern which is ISO-8601 compatible, providing up to 7 decimal places
+        /// of sub-second accuracy which are always present (including trailing zeroes). This is compatible with the
+        /// BCL round-trip formatting of <see cref="DateTime"/> values with a kind of "unspecified".
+        /// This corresponds to the text pattern "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff".
+        /// </summary>
+        [Obsolete("Use BclRoundtrip for compatibility with 2.0")]
         public static LocalDateTimePattern BclRoundtripPattern { get { return Patterns.BclRoundtripPatternImpl; } }
 
         /// <summary>
         /// Returns an invariant local date/time pattern which round trips values including the calendar system.
         /// This corresponds to the text pattern "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff '('c')'".
         /// </summary>
+        public static LocalDateTimePattern FullRoundtrip => FullRoundtripPattern;
+
+        /// <summary>
+        /// Returns an invariant local date/time pattern which round trips values including the calendar system.
+        /// This corresponds to the text pattern "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffff '('c')'".
+        /// </summary>
+        [Obsolete("Use FullRoundtrip for compatibility with 2.0")]
         public static LocalDateTimePattern FullRoundtripPattern { get { return Patterns.FullRoundtripPatternImpl; } }
 
         /// <summary>

--- a/src/NodaTime/Text/LocalTimePattern.cs
+++ b/src/NodaTime/Text/LocalTimePattern.cs
@@ -7,6 +7,7 @@ using NodaTime.Annotations;
 using NodaTime.Globalization;
 using NodaTime.Text.Patterns;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime.Text
 {
@@ -26,6 +27,14 @@ namespace NodaTime.Text
         /// (These digits are omitted when unnecessary.)
         /// This corresponds to the text pattern "HH':'mm':'ss;FFFFFFF".
         /// </summary>
+        public static LocalTimePattern ExtendedIso => ExtendedIsoPattern;
+
+        /// <summary>
+        /// Returns an invariant local time pattern which is ISO-8601 compatible, providing up to 7 decimal places.
+        /// (These digits are omitted when unnecessary.)
+        /// This corresponds to the text pattern "HH':'mm':'ss;FFFFFFF".
+        /// </summary>
+        [Obsolete("Use ExtendedIso for compatibility with 2.0")]
         public static LocalTimePattern ExtendedIsoPattern { get { return Patterns.ExtendedIsoPatternImpl; } }
 
         private const string DefaultFormatPattern = "T"; // Long

--- a/src/NodaTime/Text/OffsetDateTimePattern.cs
+++ b/src/NodaTime/Text/OffsetDateTimePattern.cs
@@ -7,6 +7,7 @@ using NodaTime.Annotations;
 using NodaTime.Globalization;
 using NodaTime.Text.Patterns;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime.Text
 {
@@ -29,6 +30,15 @@ namespace NodaTime.Text
         /// "yyyy'-'MM'-'dd'T'HH':'mm':'sso&lt;G&gt;". This pattern is available as the "G"
         /// standard pattern (even though it is invariant).
         /// </summary>
+        public static OffsetDateTimePattern GeneralIso => GeneralIsoPattern;
+
+        /// <summary>
+        /// Returns an invariant offset date/time pattern based on ISO-8601 (down to the second), including offset from UTC.
+        /// The calendar system is not parsed or formatted as part of this pattern. It corresponds to a custom pattern of
+        /// "yyyy'-'MM'-'dd'T'HH':'mm':'sso&lt;G&gt;". This pattern is available as the "G"
+        /// standard pattern (even though it is invariant).
+        /// </summary>
+        [Obsolete("Use GeneralIso for compatibility with 2.0")]
         public static OffsetDateTimePattern GeneralIsoPattern { get { return Patterns.GeneralIsoPatternImpl; } }
 
         /// <summary>
@@ -37,6 +47,15 @@ namespace NodaTime.Text
         /// "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFo&lt;G&gt;". This will round-trip any values
         /// in the ISO calendar, and is available as the "o" standard pattern.
         /// </summary>
+        public static OffsetDateTimePattern ExtendedIso => ExtendedIsoPattern;
+
+        /// <summary>
+        /// Returns an invariant offset date/time pattern based on ISO-8601 (down to the tick), including offset from UTC.
+        /// The calendar system is not parsed or formatted as part of this pattern. It corresponds to a custom pattern of
+        /// "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFo&lt;G&gt;". This will round-trip any values
+        /// in the ISO calendar, and is available as the "o" standard pattern.
+        /// </summary>
+        [Obsolete("Use ExtendedIso for compatibility with 2.0")]
         public static OffsetDateTimePattern ExtendedIsoPattern { get { return Patterns.ExtendedIsoPatternImpl; } }
 
         /// <summary>
@@ -48,6 +67,18 @@ namespace NodaTime.Text
         /// The calendar system is not parsed or formatted as part of this pattern. It corresponds to a custom pattern of
         /// "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFo&lt;Z+HH:mm&gt;".
         /// </summary>
+        public static OffsetDateTimePattern Rfc3339 => Rfc3339Pattern;
+
+        /// <summary>
+        /// Returns an invariant offset date/time pattern based on RFC 3339 (down to the tick), including offset from UTC
+        /// as hours and minutes only. The minutes part of the offset is always included, but any sub-minute component
+        /// of the offset is lost. An offset of zero is formatted as 'Z', but all of 'Z', '+00:00' and '-00:00' are parsed
+        /// the same way. The RFC 3339 meaning of '-00:00' is not supported by Noda Time.
+        /// Note that parsing is case-sensitive (so 'T' and 'Z' must be upper case).
+        /// The calendar system is not parsed or formatted as part of this pattern. It corresponds to a custom pattern of
+        /// "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFo&lt;Z+HH:mm&gt;".
+        /// </summary>
+        [Obsolete("Use Rfc3339 for compatibility with 2.0")]
         public static OffsetDateTimePattern Rfc3339Pattern { get { return Patterns.Rfc3339PatternImpl; } }
 
         /// <summary>
@@ -56,6 +87,15 @@ namespace NodaTime.Text
         /// "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFo&lt;G&gt; '('c')'". This will round-trip any value in any calendar,
         /// and is available as the "r" standard pattern.
         /// </summary>
+        public static OffsetDateTimePattern FullRoundtrip => FullRoundtripPattern;
+
+        /// <summary>
+        /// Returns an invariant offset date/time pattern based on ISO-8601 (down to the tick)
+        /// including offset from UTC and calendar ID. It corresponds to a custom pattern of
+        /// "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFo&lt;G&gt; '('c')'". This will round-trip any value in any calendar,
+        /// and is available as the "r" standard pattern.
+        /// </summary>
+        [Obsolete("Use FullRoundtrip for compatibility with 2.0")]
         public static OffsetDateTimePattern FullRoundtripPattern { get { return Patterns.FullRoundtripPatternImpl; } }
 
         /// <summary>

--- a/src/NodaTime/Text/OffsetPattern.cs
+++ b/src/NodaTime/Text/OffsetPattern.cs
@@ -7,6 +7,7 @@ using NodaTime.Annotations;
 using NodaTime.Globalization;
 using NodaTime.Text.Patterns;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime.Text
 {
@@ -24,11 +25,25 @@ namespace NodaTime.Text
         /// <summary>
         /// The "general" offset pattern (e.g. +HH, +HH:mm, +HH:mm:ss, +HH:mm:ss.fff) for the invariant culture.
         /// </summary>
+        public static OffsetPattern GeneralInvariant => GeneralInvariantPattern;
+
+        /// <summary>
+        /// The "general" offset pattern (e.g. +HH, +HH:mm, +HH:mm:ss, +HH:mm:ss.fff) for the invariant culture.
+        /// </summary>
+        [Obsolete("Use GeneralInvariant for compatibility with 2.0")]
         public static readonly OffsetPattern GeneralInvariantPattern = CreateWithInvariantCulture("g");
+
         /// <summary>
         /// The "general" offset pattern (e.g. +HH, +HH:mm, +HH:mm:ss, +HH:mm:ss.fff) for the invariant culture,
         /// but producing (and allowing) Z as a value for a zero offset.
         /// </summary>
+        public static OffsetPattern GeneralInvariantWithZ => GeneralInvariantPatternWithZ;
+
+        /// <summary>
+        /// The "general" offset pattern (e.g. +HH, +HH:mm, +HH:mm:ss, +HH:mm:ss.fff) for the invariant culture,
+        /// but producing (and allowing) Z as a value for a zero offset.
+        /// </summary>
+        [Obsolete("Use GeneralInvariantWithZ for compatibility with 2.0")]
         public static readonly OffsetPattern GeneralInvariantPatternWithZ = CreateWithInvariantCulture("G");
 
         private const string DefaultFormatPattern = "g";

--- a/src/NodaTime/Text/PeriodPattern.cs
+++ b/src/NodaTime/Text/PeriodPattern.cs
@@ -6,6 +6,7 @@ using System.Text;
 using NodaTime.Annotations;
 using NodaTime.Properties;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime.Text
 {
@@ -23,6 +24,16 @@ namespace NodaTime.Text
         /// Each element may also be negative, independently of other elements. This pattern round-trips its
         /// values: a parse/format cycle will produce an identical period, including units.
         /// </summary>
+        public static PeriodPattern Roundtrip => RoundtripPattern;
+
+        /// <summary>
+        /// Pattern which uses the normal ISO format for all the supported ISO
+        /// fields, but extends the time part with "s" for milliseconds and "t" for ticks.
+        /// No normalization is carried out, and a period may contain weeks as well as years, months and days.
+        /// Each element may also be negative, independently of other elements. This pattern round-trips its
+        /// values: a parse/format cycle will produce an identical period, including units.
+        /// </summary>
+        [Obsolete("Use Roundtrip for compatibility with 2.0")]
         public static readonly PeriodPattern RoundtripPattern = new PeriodPattern(new RoundtripPatternImpl());
 
         /// <summary>
@@ -37,6 +48,21 @@ namespace NodaTime.Text
         /// combined weeks/days/time portions are considered. Such a period could never
         /// be useful anyway, however.
         /// </remarks>
+        public static PeriodPattern NormalizingIso => NormalizingIsoPattern;
+
+        /// <summary>
+        /// A "normalizing" pattern which abides by the ISO-8601 duration format as far as possible.
+        /// Weeks are added to the number of days (after multiplying by 7). Time units are normalized
+        /// (extending into days where necessary), and fractions of seconds are represented within the
+        /// seconds part. Unlike ISO-8601, which pattern allows for negative values within a period.
+        /// </summary>
+        /// <remarks>
+        /// Note that normalizing the period when formatting will cause an <see cref="System.OverflowException"/>
+        /// if the period contains more than <see cref="System.Int64.MaxValue"/> ticks when the
+        /// combined weeks/days/time portions are considered. Such a period could never
+        /// be useful anyway, however.
+        /// </remarks>
+        [Obsolete("Use NormalizingIso for compatibility with 2.0")]
         public static readonly PeriodPattern NormalizingIsoPattern = new PeriodPattern(new NormalizingIsoPatternImpl());
 
         private readonly IPattern<Period> pattern;

--- a/src/NodaTime/Text/ZonedDateTimePattern.cs
+++ b/src/NodaTime/Text/ZonedDateTimePattern.cs
@@ -8,6 +8,7 @@ using NodaTime.Globalization;
 using NodaTime.Text.Patterns;
 using NodaTime.TimeZones;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime.Text
 {
@@ -34,6 +35,19 @@ namespace NodaTime.Text
         /// provider is included. Call <see cref="WithZoneProvider"/> on the value of this property to obtain a
         /// pattern which can be used for parsing.
         /// </remarks>
+        public static ZonedDateTimePattern GeneralFormatOnlyIso => GeneralFormatOnlyIsoPattern;
+
+        /// <summary>
+        /// Returns an zoned local date/time pattern based on ISO-8601 (down to the second) including offset from UTC and zone ID.
+        /// It corresponds to a custom pattern of "yyyy'-'MM'-'dd'T'HH':'mm':'ss z '('o&lt;g&gt;')'" and is available
+        /// as the 'G' standard pattern.
+        /// </summary>
+        /// <remarks>
+        /// The calendar system is not formatted as part of this pattern, and it cannot be used for parsing as no time zone
+        /// provider is included. Call <see cref="WithZoneProvider"/> on the value of this property to obtain a
+        /// pattern which can be used for parsing.
+        /// </remarks>
+        [Obsolete("Use GeneralFormatOnlyIso for compatibility with 2.0")]
         public static ZonedDateTimePattern GeneralFormatOnlyIsoPattern { get { return Patterns.GeneralFormatOnlyPatternImpl; } }
 
         /// <summary>
@@ -46,6 +60,19 @@ namespace NodaTime.Text
         /// provider is included. Call <see cref="WithZoneProvider"/> on the value of this property to obtain a
         /// pattern which can be used for parsing.
         /// </remarks>
+        public static ZonedDateTimePattern ExtendedFormatOnlyIso => ExtendedFormatOnlyIsoPattern;
+
+        /// <summary>
+        /// Returns an invariant zoned date/time pattern based on ISO-8601 (down to the tick) including offset from UTC and zone ID.
+        /// It corresponds to a custom pattern of "yyyy'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFF z '('o&lt;g&gt;')'" and is available
+        /// as the 'F' standard pattern.
+        /// </summary>
+        /// <remarks>
+        /// The calendar system is not formatted as part of this pattern, and it cannot be used for parsing as no time zone
+        /// provider is included. Call <see cref="WithZoneProvider"/> on the value of this property to obtain a
+        /// pattern which can be used for parsing.
+        /// </remarks>
+        [Obsolete("Use ExtendedFormatOnlyIso for compatibility with 2.0")]
         public static ZonedDateTimePattern ExtendedFormatOnlyIsoPattern { get { return Patterns.ExtendedFormatOnlyPatternImpl; } }
 
         private readonly string patternText;


### PR DESCRIPTION
(Sorry, this is what happens when I have a flight :)

I'd suggest reviewing one commit at a time. When I've worked out the exact order in which to change things, I'll build a 1.4.x doc set, and then the change from 1.4.x to 2.0.x should show that most of the members deleted in 2.0.x were obsolete in 1.4.x.