### PR TITLE
Added option to override default ToString implementation

### DIFF
--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -708,6 +708,33 @@ namespace NodaTime
             Preconditions.CheckNotNull(adjuster, nameof(adjuster)).Invoke(this);
 
         #region Formatting
+        private static Func<LocalDate, string> defaultToStringFormatter = localDate => LocalDatePattern.BclSupport.Format(localDate, null, CultureInfo.CurrentCulture);
+        private static Func<LocalDate, string, IFormatProvider, string> defaultIFormattableFormatter = (localDate, patternText, formatProvider) =>
+            LocalDatePattern.BclSupport.Format(localDate, patternText, formatProvider);
+        /// <summary>
+        /// Provides the option to override the default ToString behavior
+        /// </summary>
+        public static Func<LocalDate, string> DefaultToStringFormatter {
+            get => defaultToStringFormatter;
+            set {
+                if (value == null)
+                    throw new ArgumentNullException("Default formatter cannot be null");
+                else
+                    defaultToStringFormatter = value;
+            }  
+        }
+        /// <summary>
+        /// Provides the option to override the default IFormattable behavior
+        /// </summary>
+        public static Func<LocalDate, string, IFormatProvider, string> DefaultIFormattableFormatter {
+            get => defaultIFormattableFormatter;
+            set {
+                if (value == null)
+                    throw new ArgumentNullException("Default formatter cannot be null");
+                else
+                    defaultIFormattableFormatter = value;
+            }
+        }
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
         /// </summary>
@@ -715,7 +742,7 @@ namespace NodaTime
         /// The value of the current instance in the default format pattern ("D"), using the current thread's
         /// culture to obtain a format provider.
         /// </returns>
-        public override string ToString() => LocalDatePattern.BclSupport.Format(this, null, CultureInfo.CurrentCulture);
+        public override string ToString() => DefaultToStringFormatter(this);
 
         /// <summary>
         /// Formats the value of the current instance using the specified pattern.
@@ -731,7 +758,7 @@ namespace NodaTime
         /// </param>
         /// <filterpriority>2</filterpriority>
         public string ToString(string patternText, IFormatProvider formatProvider) =>
-            LocalDatePattern.BclSupport.Format(this, patternText, formatProvider);
+            defaultIFormattableFormatter(this, patternText, formatProvider);
         #endregion Formatting
 
         #region XML serialization

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -869,15 +869,41 @@ namespace NodaTime
         }
 
         #region Formatting
+        private static Func<LocalDateTime, string> defaultToStringFormatter = localDateTime => LocalDateTimePattern.BclSupport.Format(localDateTime, null, CultureInfo.CurrentCulture);
+        private static Func<LocalDateTime, string, IFormatProvider, string> defaultIFormattableFormatter = (localDateTime, patternText, formatProvider) =>
+            LocalDateTimePattern.BclSupport.Format(localDateTime, patternText, formatProvider);
+        /// <summary>
+        /// Provides the option to override the default ToString behavior
+        /// </summary>
+        public static Func<LocalDateTime, string> DefaultToStringFormatter {
+            get => defaultToStringFormatter;
+            set {
+                if (value == null)
+                    throw new ArgumentNullException("Default formatter cannot be null");
+                else
+                    defaultToStringFormatter = value;
+            }
+        }
+        /// <summary>
+        /// Provides the option to override the default IFormattable behavior
+        /// </summary>
+        public static Func<LocalDateTime, string, IFormatProvider, string> DefaultIFormattableFormatter {
+            get => defaultIFormattableFormatter;
+            set {
+                if (value == null)
+                    throw new ArgumentNullException("Default formatter cannot be null");
+                else
+                    defaultIFormattableFormatter = value;
+            }
+        }
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
         /// </summary>
         /// <returns>
-        /// The value of the current instance in the default format pattern ("G"), using the current thread's
+        /// The value of the current instance in the default format pattern ("D"), using the current thread's
         /// culture to obtain a format provider.
         /// </returns>
-        public override string ToString() =>
-            LocalDateTimePattern.BclSupport.Format(this, null, CultureInfo.CurrentCulture);
+        public override string ToString() => DefaultToStringFormatter(this);
 
         /// <summary>
         /// Formats the value of the current instance using the specified pattern.
@@ -893,7 +919,7 @@ namespace NodaTime
         /// </param>
         /// <filterpriority>2</filterpriority>
         public string ToString(string patternText, IFormatProvider formatProvider) =>
-            LocalDateTimePattern.BclSupport.Format(this, patternText, formatProvider);
+            DefaultIFormattableFormatter(this, patternText, formatProvider);
         #endregion Formatting
 
         #region XML serialization

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -691,14 +691,43 @@ namespace NodaTime
         public LocalDateTime On(LocalDate date) => date + this;
 
         #region Formatting
+        private static Func<LocalTime, string> defaultToStringFormatter = localTime => LocalTimePattern.BclSupport.Format(localTime, null, CultureInfo.CurrentCulture);
+        private static Func<LocalTime, string, IFormatProvider, string> defaultIFormattableFormatter = 
+            (localTime, patternText, formatProvider) => LocalTimePattern.BclSupport.Format(localTime, patternText, formatProvider);
+        /// <summary>
+        /// Provides the option to override the default ToString behavior
+        /// </summary>
+        public static Func<LocalTime, string> DefaultToStringFormatter {
+            get => defaultToStringFormatter;
+            set {
+                if (value == null)
+                    throw new ArgumentNullException("Default formatter cannot be null");
+                else
+                    defaultToStringFormatter = value;
+            }
+        }
+        
+        /// <summary>
+        /// Provides the option to override the default IFormattable behavior
+        /// </summary>
+        public static Func<LocalTime, string, IFormatProvider, string> DefaultIFormattableFormatter {
+            get => defaultIFormattableFormatter;
+            set {
+                if (value == null)
+                    throw new ArgumentNullException("Default formatter cannot be null");
+                else
+                    defaultIFormattableFormatter = value;
+            }
+        }
+
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.
         /// </summary>
         /// <returns>
-        /// The value of the current instance in the default format pattern ("T"), using the current thread's
+        /// The value of the current instance in the default format pattern ("D"), using the current thread's
         /// culture to obtain a format provider.
         /// </returns>
-        public override string ToString() => LocalTimePattern.BclSupport.Format(this, null, CultureInfo.CurrentCulture);
+        public override string ToString() => DefaultToStringFormatter(this);
 
         /// <summary>
         /// Formats the value of the current instance using the specified pattern.
@@ -713,8 +742,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
-            LocalTimePattern.BclSupport.Format(this, patternText, formatProvider);
+        public string ToString(string patternText, IFormatProvider formatProvider) => DefaultIFormattableFormatter(this, patternText, formatProvider);
         #endregion Formatting
 
         #region XML serialization


### PR DESCRIPTION
I would like to be able to change the default ToString for the basic noda data types. My locale is Bulgaria and ToString results in cyrillic output that is very inconvenient to work with. Also I am working with financial data and I would like to have all LocalTimes output with nanosecond precision in the debugger or when I print or interpolate them.

I achieved this by adding two delegates, static DefaultStringFormatter and DefaultIFormattableFormatter .. they are used by the new versions of ToString() and ToString(string, IFormatProvider). They are initially set to their default values but by overriding them you can change the ToString behavior.

Here is some example code using my modifications along with the output before overriding ToString and the output after overriding ToString:

https://gist.github.com/Jivko1212/b7cf9c2581af786862b7fd85075e302c

