### PR TITLE
Added IWeekYearRule to 1.4.x.

### DIFF
--- a/src/NodaTime.Test/Calendars/BclCalendars.cs
+++ b/src/NodaTime.Test/Calendars/BclCalendars.cs
@@ -1,0 +1,83 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Test.Text;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace NodaTime.Test.Calendars
+{
+    /// <summary>
+    /// In the PCL, we can't access specific subclasses of System.Globalization.Calendar.
+    /// We can fetch them from cultures though... and maybe use reflection.
+    /// </summary>
+    public class BclCalendars
+    {
+        private static readonly Dictionary<string, Calendar> calendars
+            = Cultures.AllCultures
+                .SelectMany(culture => new[] { culture.Calendar }.Concat(culture.OptionalCalendars))
+                .GroupBy(calendar => calendar.GetType())
+                .ToDictionary(g => g.Key.Name, g => g.First());
+
+        private static Calendar GetCalendar(string name)
+        {
+            Calendar calendar;
+            if (calendars.TryGetValue(name, out calendar))
+            {
+                return calendar;
+            }
+            // Try to initialize by reflection instead...
+            Type type = typeof(Calendar).Assembly.GetType($"System.Globalization.{name}");
+            if (type == null)
+            {
+                // We can start being defensive if/when we try to test on a platform where
+                // this becomes a problem.
+                throw new Exception($"Unable to get calendar {name}");
+            }
+            return (Calendar) Activator.CreateInstance(type);
+        }
+
+        public static Calendar Hebrew => GetCalendar("HebrewCalendar");
+        public static Calendar Gregorian => GetCalendar("GregorianCalendar");
+        public static Calendar UmAlQura => GetCalendar("UmAlQuraCalendar");
+        public static Calendar Persian => GetCalendar("PersianCalendar");
+        public static Calendar Julian => GetCalendar("JulianCalendar");
+        public static Calendar Hijri => GetCalendar("HijriCalendar");
+
+        /// <summary>
+        /// Returns a sequence of all the BCL calendar systems for which we have a
+        /// mapping in Noda Time. The first entry is Gregorian so that it's easy to
+        /// comment out the rest for initial testing of a new feature (where the
+        /// Gregorian calendar is typically easy to reason about).
+        /// </summary>
+        public static IEnumerable<Calendar> MappedCalendars =>
+            new[] { Gregorian, Hebrew, Julian, Hijri };
+
+        /// <summary>
+        /// Tries to work out a roughly-matching calendar system for the given BCL calendar.
+        /// This is needed where we're testing whether days of the week match - even if we can
+        /// get day/month/year values to match without getting the calendar right, the calendar
+        /// affects the day of week.
+        /// </summary>
+        internal static CalendarSystem CalendarSystemForCalendar(Calendar bcl)
+        {
+            // Yes, this is horrible... but the specific calendars aren't available to test
+            // against in the PCL
+            switch (bcl.GetType().Name)
+            {
+                case "GregorianCalendar": return CalendarSystem.Iso;
+                case "HijriCalendar": return CalendarSystem.IslamicBcl;
+                case "HebrewCalendar": return CalendarSystem.HebrewCivil;
+                case "JulianCalendar": return CalendarSystem.Julian;
+                default:
+                    // No idea - we can't test with this calendar...
+                    return null;
+            }
+        }
+    }
+}

--- a/src/NodaTime.Test/Calendars/SimpleWeekYearRuleTest.cs
+++ b/src/NodaTime.Test/Calendars/SimpleWeekYearRuleTest.cs
@@ -1,0 +1,357 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Calendars;
+using NUnit.Framework;
+using System;
+using static NodaTime.IsoDayOfWeek;
+using static NodaTime.CalendarSystem;
+using static System.Globalization.CalendarWeekRule;
+using System.Globalization;
+
+namespace NodaTime.Test.Calendars
+{
+    public class SimpleWeekYearRuleTest
+    {
+        private static readonly DayOfWeek[] BclDaysOfWeek = (DayOfWeek[])Enum.GetValues(typeof(DayOfWeek));
+        private static readonly CalendarWeekRule[] CalendarWeekRules = (CalendarWeekRule[])Enum.GetValues(typeof(CalendarWeekRule));
+
+        // Notes for tests:
+        // - ISO calendar system has January 1st on min year = Monday, December 31st on max year = Sunday,
+        //   which makes it hard to use for tests
+        // - Julian calendar is better: January 1st -27256 = Wednesday, December 31st 31196 = Wednesday
+
+        [Test]
+        public void RoundtripFirstDay_Julian7()
+        {
+            // In the Julian calendar with a minimum of 7 days in the first
+            // week, Wednesday January 1st -27256 is in week year -27257. We should be able to
+            // round-trip.
+            var rule = WeekYearRules.ForMinDaysInFirstWeek(7);
+            var date = new LocalDate(-27256, 1, 1, Julian);
+            Assert.AreEqual(date, rule.GetLocalDate(
+                rule.GetWeekYear(date),
+                rule.GetWeekOfWeekYear(date),
+                date.IsoDayOfWeek,
+                Julian));
+        }
+
+        [Test]
+        public void RoundtripLastDay_Julian1()
+        {
+            // In the Gregorian calendar with a minimum of 1 day in the first
+            // week, Wednesday December 31st 31196 is in week year 31197. We should be able to
+            // round-trip.
+            var rule = WeekYearRules.ForMinDaysInFirstWeek(1);
+            var date = new LocalDate(31196, 12, 31, Julian);
+            Assert.AreEqual(date, rule.GetLocalDate(
+                rule.GetWeekYear(date),
+                rule.GetWeekOfWeekYear(date),
+                date.IsoDayOfWeek,
+                Julian));
+        }
+
+        [Test]
+        public void OutOfRange_ValidWeekYearAndWeek_TooEarly()
+        {
+            // Julian 4: Week year -27256 starts on Monday December 30th -27257,
+            // and is therefore out of range, even though the week-year
+            // and week-of-week-year are valid.
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => WeekYearRules.Iso.GetLocalDate(-27256, 1, Monday, Julian));
+            // Ditto December 31st
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => WeekYearRules.Iso.GetLocalDate(-27256, 1, Tuesday, Julian));
+
+            // Sanity check: no exception for January 1st
+            WeekYearRules.Iso.GetLocalDate(-27255, 1, Wednesday, Julian);
+        }
+
+        [Test]
+        public void OutOfRange_ValidWeekYearAndWeek_TooLate()
+        {
+            // Julian 5: December 31st 31196 is a Wednesday, so the Thursday of the
+            // same week is therefore out of range, even though the week-year
+            // and week-of-week-year are valid.
+            var rule = WeekYearRules.ForMinDaysInFirstWeek(5);
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => rule.GetLocalDate(31196, 53, Thursday, Julian));
+
+            // Sanity check: no exception for December 31st
+            rule.GetLocalDate(31196, 53, Wednesday, Julian);
+        }
+
+        // Tests ported from IsoCalendarSystemTest and LocalDateTest.Construction
+        [Test]
+        [TestCase(2011, 1, 1, 2010, 52, Saturday)]
+        [TestCase(2012, 12, 31, 2013, 1, Monday)]
+        [TestCase(1960, 1, 19, 1960, 3, Tuesday)]
+        [TestCase(2012, 10, 19, 2012, 42, Friday)]
+        [TestCase(2011, 1, 1, 2010, 52, Saturday)]
+        [TestCase(2012, 12, 31, 2013, 1, Monday)]
+        [TestCase(2005, 1, 2, 2004, 53, Sunday)]
+        public void WeekYearDifferentToYear(int year, int month, int day, int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek)
+        {
+            var date = new LocalDate(year, month, day);
+            Assert.AreEqual(weekYear, WeekYearRules.Iso.GetWeekYear(date));
+            Assert.AreEqual(weekOfWeekYear, WeekYearRules.Iso.GetWeekOfWeekYear(date));
+            Assert.AreEqual(dayOfWeek, date.IsoDayOfWeek);
+            Assert.AreEqual(date, WeekYearRules.Iso.GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek));
+        }
+
+        // Ported from CalendarSystemTest.Validation
+        [Test]
+        [TestCase(2009, 53)]
+        [TestCase(2010, 52)]
+        [TestCase(2011, 52)]
+        [TestCase(2012, 52)]
+        [TestCase(2013, 52)]
+        [TestCase(2014, 52)]
+        [TestCase(2015, 53)]
+        [TestCase(2016, 52)]
+        [TestCase(2017, 52)]
+        [TestCase(2018, 52)]
+        [TestCase(2019, 52)]
+        public void GetWeeksInWeekYear(int weekYear, int expectedResult)
+        {
+            Assert.AreEqual(expectedResult, WeekYearRules.Iso.GetWeeksInWeekYear(weekYear));
+        }
+
+        // Ported from LocalDateTest.BasicProperties
+        // See http://stackoverflow.com/questions/8010125
+        [Test]
+        [TestCase(2007, 12, 31, 1)]
+        [TestCase(2008, 1, 6, 1)]
+        [TestCase(2008, 1, 7, 2)]
+        [TestCase(2008, 12, 28, 52)]
+        [TestCase(2008, 12, 29, 1)]
+        [TestCase(2009, 1, 4, 1)]
+        [TestCase(2009, 1, 5, 2)]
+        [TestCase(2009, 12, 27, 52)]
+        [TestCase(2009, 12, 28, 53)]
+        [TestCase(2010, 1, 3, 53)]
+        [TestCase(2010, 1, 4, 1)]
+        public void WeekOfWeekYear_ComparisonWithOracle(int year, int month, int day, int weekOfWeekYear)
+        {
+            var date = new LocalDate(year, month, day);
+            Assert.AreEqual(weekOfWeekYear, WeekYearRules.Iso.GetWeekOfWeekYear(date));
+        }
+
+        [Test]
+        [TestCase(2000, Saturday, 2)]
+        [TestCase(2001, Monday, 7)]
+        [TestCase(2002, Tuesday, 6)]
+        [TestCase(2003, Wednesday, 5)]
+        [TestCase(2004, Thursday, 4)]
+        [TestCase(2005, Saturday, 2)]
+        [TestCase(2006, Sunday, 1)]
+        public void Gregorian(int year, IsoDayOfWeek firstDayOfYear, int maxMinDaysInFirstWeekForSameWeekYear)
+        {
+            var startOfCalendarYear = new LocalDate(year, 1, 1);
+            Assert.AreEqual(firstDayOfYear, startOfCalendarYear.IsoDayOfWeek);
+
+            // Rules which put the first day of the calendar year into the same week year
+            for (int i = 1; i <= maxMinDaysInFirstWeekForSameWeekYear; i++)
+            {
+                var rule = WeekYearRules.ForMinDaysInFirstWeek(i);
+                Assert.AreEqual(year, rule.GetWeekYear(startOfCalendarYear));
+                Assert.AreEqual(1, rule.GetWeekOfWeekYear(startOfCalendarYear));
+            }
+            // Rules which put the first day of the calendar year into the previous week year
+            for (int i = maxMinDaysInFirstWeekForSameWeekYear + 1; i <= 7; i++)
+            {
+                var rule = WeekYearRules.ForMinDaysInFirstWeek(i);
+                Assert.AreEqual(year - 1, rule.GetWeekYear(startOfCalendarYear));
+                Assert.AreEqual(rule.GetWeeksInWeekYear(year - 1), rule.GetWeekOfWeekYear(startOfCalendarYear));
+            }
+        }
+
+        // Test cases from https://blogs.msdn.microsoft.com/shawnste/2006/01/24/iso-8601-week-of-year-format-in-microsoft-net/
+        // which distinguish our ISO option from the BCL. When we implement the BCL equivalents, we should have similar
+        // tests there...
+        [Test]
+        [TestCase(2000, 12, 31, 2000, 52, Sunday)]
+        [TestCase(2001, 1, 1, 2001, 1, Monday)]
+        [TestCase(2005, 1, 1, 2004, 53, Saturday)]
+        [TestCase(2007, 12, 31, 2008, 1, Monday)]
+        public void Iso(int year, int month, int day, int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek)
+        {
+            var viaCalendar = new LocalDate(year, month, day);
+            var rule = WeekYearRules.Iso;
+            Assert.AreEqual(weekYear, rule.GetWeekYear(viaCalendar));
+            Assert.AreEqual(weekOfWeekYear, rule.GetWeekOfWeekYear(viaCalendar));
+            Assert.AreEqual(dayOfWeek, viaCalendar.IsoDayOfWeek);
+            var viaRule = rule.GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek);
+            Assert.AreEqual(viaCalendar, viaRule);
+        }
+
+        /// <summary>
+        /// Just a sample test of not using the Gregorian/ISO calendar system.
+        /// </summary>
+        [Test]
+        [TestCase(5400, Thursday, 1639, 9, 29, 51, 5400, 1)]
+        [TestCase(5401, Monday, 1640, 9, 17, 50, 5401, 1)]
+        [TestCase(5402, Thursday, 1641, 9, 5, 55, 5402, 1)]
+        [TestCase(5403, Thursday, 1642, 9, 25, 51, 5403, 1)]
+        [TestCase(5404, Monday, 1643, 9, 14, 55, 5404, 1)]
+        [TestCase(5405, Saturday, 1644, 10, 1, 50, 5404, 55)]
+        [TestCase(5406, Thursday, 1645, 9, 21, 51, 5406, 1)]
+        [TestCase(5407, Monday, 1646, 9, 10, 55, 5407, 1)]
+        [TestCase(5408, Monday, 1647, 9, 30, 50, 5408, 1)]
+        [TestCase(5409, Thursday, 1648, 9, 17, 51, 5409, 1)]
+        [TestCase(5410, Tuesday, 1649, 9, 7, 55, 5410, 1)]
+        public void HebrewCalendar(int year, IsoDayOfWeek expectedFirstDay,
+            int isoYear, int isoMonth, int isoDay, // Mostly for documentation
+            int expectedWeeks, int expectedWeekYearOfFirstDay, int expectedWeekOfWeekYearOfFirstDay)
+        {
+            var civilDate = new LocalDate(year, 1, 1, HebrewCivil);
+            var rule = WeekYearRules.Iso;
+            Assert.AreEqual(expectedFirstDay, civilDate.IsoDayOfWeek);
+            Assert.AreEqual(civilDate.WithCalendar(CalendarSystem.Iso), new LocalDate(isoYear, isoMonth, isoDay));
+            Assert.AreEqual(expectedWeeks, rule.GetWeeksInWeekYear(year, HebrewCivil));
+            Assert.AreEqual(expectedWeekYearOfFirstDay, rule.GetWeekYear(civilDate));
+            Assert.AreEqual(expectedWeekOfWeekYearOfFirstDay, rule.GetWeekOfWeekYear(civilDate));
+            Assert.AreEqual(civilDate,
+                rule.GetLocalDate(expectedWeekYearOfFirstDay, expectedWeekOfWeekYearOfFirstDay, expectedFirstDay, HebrewCivil));
+
+            // The scriptural month numbering system should have the same week-year and week-of-week-year.
+            var scripturalDate = civilDate.WithCalendar(HebrewScriptural);
+            Assert.AreEqual(expectedWeeks, rule.GetWeeksInWeekYear(year, HebrewScriptural));
+            Assert.AreEqual(expectedWeekYearOfFirstDay, rule.GetWeekYear(scripturalDate));
+            Assert.AreEqual(expectedWeekOfWeekYearOfFirstDay, rule.GetWeekOfWeekYear(scripturalDate));
+            Assert.AreEqual(scripturalDate,
+                rule.GetLocalDate(expectedWeekYearOfFirstDay, expectedWeekOfWeekYearOfFirstDay, expectedFirstDay, HebrewScriptural));
+        }
+
+        // Jan 1st 2015 = Thursday
+        // Jan 1st 2016 = Friday
+        // Jan 1st 2017 = Sunday
+        [Test]
+        [TestCase(1, Wednesday, 2015, 2, Friday, 2015, 1, 9)]
+        [TestCase(7, Wednesday, 2015, 2, Friday, 2015, 1, 16)]
+        [TestCase(1, Wednesday, 2015, 1, Wednesday, 2014, 12, 31)]
+        [TestCase(3, Friday, 2016, 1, Friday, 2016, 1, 1)]
+        [TestCase(3, Friday, 2017, 1, Friday, 2016, 12, 30)]
+        // We might want to add more tests here...
+        public void NonMondayFirstDayOfWeek(int minDaysInFirstWeek, IsoDayOfWeek firstDayOfWeek,
+            int weekYear, int week, IsoDayOfWeek dayOfWeek,
+            int expectedYear, int expectedMonth, int expectedDay)
+        {
+            var rule = WeekYearRules.ForMinDaysInFirstWeek(minDaysInFirstWeek, firstDayOfWeek);
+            var actual = rule.GetLocalDate(weekYear, week, dayOfWeek);
+            var expected = new LocalDate(expectedYear, expectedMonth, expectedDay);
+            Assert.AreEqual(expected, actual);
+            Assert.AreEqual(weekYear, rule.GetWeekYear(actual));
+            Assert.AreEqual(week, rule.GetWeekOfWeekYear(actual));
+        }
+
+        // Tests for BCL rules...
+
+        /// <summary>
+        /// For each calendar and rule combination, check everything we can about every date
+        /// from mid December to mid January around each year between 2016 and 2046.
+        /// (For non-Gregorian calendars, the rough equivalent is used...)
+        /// That should give us plenty of coverage.
+        /// </summary>
+        [Test]
+        [Combinatorial]
+        public void BclEquivalence(
+            [ValueSource(typeof(BclCalendars), nameof(BclCalendars.MappedCalendars))] Calendar calendar,
+            [ValueSource(nameof(CalendarWeekRules))] CalendarWeekRule bclRule,
+            [ValueSource(nameof(BclDaysOfWeek))] DayOfWeek firstDayOfWeek)
+        {
+            var nodaCalendar = BclCalendars.CalendarSystemForCalendar(calendar);
+            var nodaRule = WeekYearRules.FromCalendarWeekRule(bclRule, firstDayOfWeek);
+            var startYear = new LocalDate(2016, 1, 1).WithCalendar(nodaCalendar).Year;
+
+            for (int year = startYear; year < startYear + 30; year++)
+            {
+                var startDate = new LocalDate(year, 1, 1, nodaCalendar).PlusDays(-15);
+                for (int day = 0; day < 30; day++)
+                {
+                    var date = startDate.PlusDays(day);
+                    var bclDate = date.AtMidnight().ToDateTimeUnspecified();
+                    var bclWeek = calendar.GetWeekOfYear(bclDate, bclRule, firstDayOfWeek);
+                    // Weird... the BCL doesn't have a way of finding out which week-year we're in.
+                    // We're starting at "start of year - 15 days", so a "small" week-of-year
+                    // value means we're in "year", whereas a "large" week-of-year value means
+                    // we're in the "year-1".
+                    var bclWeekYear = bclWeek < 10 ? year : year - 1;
+
+                    Assert.AreEqual(bclWeek, nodaRule.GetWeekOfWeekYear(date), "Date: {0}", date);
+                    Assert.AreEqual(bclWeekYear, nodaRule.GetWeekYear(date), "Date: {0}", date);
+                    Assert.AreEqual(date, nodaRule.GetLocalDate(bclWeekYear, bclWeek, date.IsoDayOfWeek, nodaCalendar),
+                        "Week-year:{0}; Week: {1}; Day: {2}", bclWeekYear, bclWeek, date.IsoDayOfWeek);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The number of weeks in the year is equal to the week-of-week-year for the last
+        /// day of the year.
+        /// </summary>
+        [Test]
+        [Combinatorial]
+        public void GetWeeksInWeekYear(
+            [ValueSource(typeof(BclCalendars), nameof(BclCalendars.MappedCalendars))] Calendar calendar,
+            [ValueSource(nameof(CalendarWeekRules))] CalendarWeekRule bclRule,
+            [ValueSource(nameof(BclDaysOfWeek))] DayOfWeek firstDayOfWeek)
+        {
+            var nodaCalendar = BclCalendars.CalendarSystemForCalendar(calendar);
+            var nodaRule = WeekYearRules.FromCalendarWeekRule(bclRule, firstDayOfWeek);
+            var startYear = new LocalDate(2016, 1, 1).WithCalendar(nodaCalendar).Year;
+
+            for (int year = startYear; year < startYear + 30; year++)
+            {
+                var bclDate = new LocalDate(year + 1, 1, 1, nodaCalendar).PlusDays(-1).AtMidnight().ToDateTimeUnspecified();
+                Assert.AreEqual(calendar.GetWeekOfYear(bclDate, bclRule, firstDayOfWeek),
+                    nodaRule.GetWeeksInWeekYear(year, nodaCalendar), "Year {0}", year);
+            }
+        }
+
+        // Tests where we ask for an invalid combination of week-year/week/day-of-week due to a week being "short"
+        // in BCL rules.
+        // Jan 1st 2016 = Friday
+        [Test]
+        [TestCase(FirstDay, DayOfWeek.Monday, 2015, 53, Saturday)]
+        [TestCase(FirstDay, DayOfWeek.Monday, 2016, 1, Thursday)]
+        public void GetLocalDate_Invalid(
+            CalendarWeekRule bclRule, DayOfWeek firstDayOfWeek,
+            int weekYear, int week, IsoDayOfWeek dayOfWeek)
+        {
+            var nodaRule = WeekYearRules.FromCalendarWeekRule(bclRule, firstDayOfWeek);
+            Assert.Throws<ArgumentOutOfRangeException>(() => nodaRule.GetLocalDate(weekYear, week, dayOfWeek));
+        }
+
+        [Test]
+        [Combinatorial]
+        public void RoundtripFirstDayBcl(
+            [ValueSource(nameof(CalendarWeekRules))] CalendarWeekRule bclRule,
+            [ValueSource(nameof(BclDaysOfWeek))] DayOfWeek firstDayOfWeek)
+        {
+            var rule = WeekYearRules.FromCalendarWeekRule(bclRule, firstDayOfWeek);
+            var date = new LocalDate(-9998, 1, 1);
+            Assert.AreEqual(date, rule.GetLocalDate(
+                rule.GetWeekYear(date),
+                rule.GetWeekOfWeekYear(date),
+                date.IsoDayOfWeek));
+        }
+
+        [Test]
+        [Combinatorial]
+        public void RoundtripLastDayBcl(
+            [ValueSource(nameof(CalendarWeekRules))] CalendarWeekRule bclRule,
+            [ValueSource(nameof(BclDaysOfWeek))] DayOfWeek firstDayOfWeek)
+        {
+            var rule = WeekYearRules.FromCalendarWeekRule(bclRule, firstDayOfWeek);
+            var date = new LocalDate(9999, 12, 31);
+            Assert.AreEqual(date, rule.GetLocalDate(
+                rule.GetWeekYear(date),
+                rule.GetWeekOfWeekYear(date),
+                date.IsoDayOfWeek));
+        }
+
+        // TODO: Test the difference in ValidateWeekYear for 9999 between regular and non-regular rules.
+    }
+}

--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -122,6 +122,7 @@
     <Compile Include="CalendarSystemTest.Ids.cs">
       <DependentUpon>CalendarSystemTest.cs</DependentUpon>
     </Compile>
+    <Compile Include="Calendars\BclCalendars.cs" />
     <Compile Include="Calendars\CopticCalendarSystemTest.cs" />
     <Compile Include="Calendars\EraTest.cs" />
     <Compile Include="Calendars\GregorianCalendarSystemTest.cs" />
@@ -137,6 +138,7 @@
     </Compile>
     <Compile Include="Calendars\HebrewCalendarSystemTest.cs" />
     <Compile Include="Calendars\PersianCalendarSystemTest.cs" />
+    <Compile Include="Calendars\SimpleWeekYearRuleTest.cs" />
     <Compile Include="Calendars\YearMonthDayCalculatorTest.cs" />
     <Compile Include="IntervalTest.cs" />
     <Compile Include="OffsetDateTimeTest.cs" />

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -363,6 +363,10 @@ namespace NodaTime
         #endregion
 
         private readonly YearMonthDayCalculator yearMonthDayCalculator;
+
+        // Introduced for SimpleWeekYearRule
+        internal YearMonthDayCalculator YearMonthDayCalculator => yearMonthDayCalculator;
+
         private readonly WeekYearCalculator weekYearCalculator;
         private readonly PeriodFieldSet periodFields;
         private readonly string id;
@@ -494,6 +498,10 @@ namespace NodaTime
         /// Returns the maximum tick number this calendar can handle.
         /// </summary>
         internal long MaxTicks { get { return maxTicks; } }
+
+        // Added in 1.4 for the sake of SimpleWeekYearRule...
+        internal int MinDays => (int) (minTicks / NodaConstants.TicksPerDay);
+        internal int MaxDays => (int)(maxTicks / NodaConstants.TicksPerDay);
 
         #region Era-based members
         /// <summary>

--- a/src/NodaTime/Calendars/IWeekYearRule.cs
+++ b/src/NodaTime/Calendars/IWeekYearRule.cs
@@ -1,0 +1,141 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using JetBrains.Annotations;
+using NodaTime.Utility;
+using System;
+
+namespace NodaTime.Calendars
+{
+    /// <summary>
+    /// A rule determining how "week years" are arranged, including the weeks within the week year.
+    /// Implementations provided by Noda Time itself can be obtained via the <see cref="WeekYearRules"/>
+    /// class.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Dates are usually identified within a calendar system by a calendar year, a month within that
+    /// calendar year, and a day within that month. For example, the date of birth of Ada Lovelace can be identified
+    /// within the Gregorian calendar system as the year 1815, the month December (12), and the day 10. However,
+    /// dates can also be identified (again within a calendar system) by week-year, week and day-of-week. How
+    /// that identification occurs depends on which rule you use - but again as an example, within the Gregorian
+    /// calendar system, using the ISO-8601 week year rule, the date of Ada Lovelace's birth is week-year 1815,
+    /// week 49, day-of-week Sunday.
+    /// </para>
+    /// <para>
+    /// The calendar year of a date and the week-year of a date are the same in most rules for most dates, but aren't
+    /// always. When they differ, it is usually because a day near the start of the calendar year is deemed to belong
+    /// to the last week of the previous week-year - or conversely because a day near the end of the calendar year is
+    /// deemed to belong to the first week of the following week-year. Some rules may be more radical -
+    /// a UK tax year rule could number weeks from April 6th onwards, such that any date earlier than that in the calendar
+    /// year would belong to the previous week-year.
+    /// </para>
+    /// <para>
+    /// The mapping of dates into week-year, week and day-of-week is always relative to a specific calendar system.
+    /// For example, years in the Hebrew calendar system vary very significantly in length due to leap months, and this
+    /// is reflected in the number of weeks within the week-years - as low as 50, and as high as 55.
+    /// </para>
+    /// <para>
+    /// This class allows conversions between the two schemes of identifying dates: <see cref="GetWeekYear(LocalDate)"/>
+    /// and <see cref="GetWeekOfWeekYear(LocalDate)"/> allow the week-year and week to be obtained for a date, and
+    /// <see cref="GetLocalDate(int, int, IsoDayOfWeek, CalendarSystem)"/> allows the reverse mapping. Note that
+    /// the calendar system does not need to be specified in the former methods as a <see cref="LocalDate"/> already
+    /// contains calendar information, and there is no method to obtain the day-of-week as that is not affected by the
+    /// week year rule being used.
+    /// </para>
+    /// <para>
+    /// All implementations within Noda Time are immutable, and it is advised that any external implementations
+    /// should be immutable too.
+    /// </para>
+    /// </remarks>
+    public interface IWeekYearRule
+    {
+        /// <summary>
+        /// Creates a <see cref="LocalDate" /> from a given week-year, week within that week-year,
+        /// and day-of-week, for the specified calendar system.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Wherever reasonable, implementations should ensure that all valid dates
+        /// can be constructed via this method. In other words, given a <see cref="LocalDate"/> <code>date</code>,
+        /// <code>rule.GetLocalDate(rule.GetWeekYear(date), rule.GetWeekOfWeekYear(date), date.IsoDayOfWeek, date.Calendar)</code>
+        /// should always return <code>date</code>. This is true for all rules within Noda Time, but third party
+        /// implementations may choose to simplify their implementations by restricting them to appropriate portions
+        /// of time.
+        /// </para>
+        /// <para>
+        /// Implementations may restrict which calendar systems supplied here, but the implementations provided by
+        /// Noda Time work with all available calendar systems.
+        /// </para>
+        /// </remarks>
+        /// <param name="weekYear">The week-year of the new date. Implementations provided by Noda Time allow any
+        /// year which is a valid calendar year, and sometimes one less than the minimum calendar year
+        /// and/or one more than the maximum calendar year, to allow for dates near the start of a calendar
+        /// year to fall in the previous week year, and similarly for dates near the end of a calendar year.</param>
+        /// <param name="weekOfWeekYear">The week of week-year of the new date. Valid values for this parameter
+        /// may vary depending on <paramref name="weekYear"/>, as the length of a year in weeks varies.</param>
+        /// <param name="dayOfWeek">The day-of-week of the new date. Valid values for this parameter may vary
+        /// depending on <paramref name="weekYear"/> and <paramref name="weekOfWeekYear"/>.</param>
+        /// <param name="calendar">The calendar system for the date.</param>
+        /// <exception cref="ArgumentOutOfRangeException">The parameters do not combine to form a valid date.</exception>
+        /// <returns>A <see cref="LocalDate"/> corresponding to the specified values.</returns>
+        LocalDate GetLocalDate(int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek, [NotNull] CalendarSystem calendar);
+
+        /// <summary>
+        /// Calculates the week-year in which the given date occurs, according to this rule.
+        /// </summary>
+        /// <param name="date">The date to compute the week-year of.</param>
+        /// <returns>The week-year of <paramref name="date"/>, according to this rule.</returns>
+        int GetWeekYear(LocalDate date);
+
+        /// <summary>
+        /// Calculates the week of the week-year in which the given date occurs, according to this rule.
+        /// </summary>
+        /// <param name="date">The date to compute the week of.</param>
+        /// <returns>The week of the week-year of <paramref name="date"/>, according to this rule.</returns>
+        int GetWeekOfWeekYear(LocalDate date);
+
+        /// <summary>
+        /// Returns the number of weeks in the given week-year, within the specified calendar system.
+        /// </summary>
+        /// <param name="weekYear">The week-year to find the range of.</param>
+        /// <param name="calendar">The calendar system the calculation is relative to.</param>
+        /// <returns>The number of weeks in the given week-year within the given calendar.</returns>
+        int GetWeeksInWeekYear(int weekYear, [NotNull] CalendarSystem calendar);
+    }
+
+    /// <summary>
+    /// Extension methods on <see cref="IWeekYearRule"/>.
+    /// </summary>
+    public static class WeekYearRuleExtensions
+    {
+        /// <summary>
+        /// Convenience method to call <see cref="IWeekYearRule.GetLocalDate(int, int, IsoDayOfWeek, CalendarSystem)"/>
+        /// passing in the ISO calendar system.
+        /// </summary>
+        /// <param name="rule">The rule to delegate the call to.</param>
+        /// <param name="weekYear">The week-year of the new date. Implementations provided by Noda Time allow any
+        /// year which is a valid calendar year, and sometimes one less than the minimum calendar year
+        /// and/or one more than the maximum calendar year, to allow for dates near the start of a calendar
+        /// year to fall in the previous week year, and similarly for dates near the end of a calendar year.</param>
+        /// <param name="weekOfWeekYear">The week of week-year of the new date. Valid values for this parameter
+        /// may vary depending on <paramref name="weekYear"/>, as the length of a year in weeks varies.</param>
+        /// <param name="dayOfWeek">The day-of-week of the new date. Valid values for this parameter may vary
+        /// depending on <paramref name="weekYear"/> and <paramref name="weekOfWeekYear"/>.</param>
+        /// <exception cref="ArgumentOutOfRangeException">The parameters do not combine to form a valid date.</exception>
+        /// <returns>A <see cref="LocalDate"/> corresponding to the specified values.</returns>
+        public static LocalDate GetLocalDate([NotNull] this IWeekYearRule rule, int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek) =>
+            Preconditions.CheckNotNull(rule, nameof(rule)).GetLocalDate(weekYear, weekOfWeekYear, dayOfWeek, CalendarSystem.Iso);
+
+        /// <summary>
+        /// Convenience overload to call <see cref="IWeekYearRule.GetWeeksInWeekYear(int, CalendarSystem)"/> with
+        /// the ISO calendar system.
+        /// </summary>
+        /// <param name="rule">The rule to delegate the call to.</param>
+        /// <param name="weekYear">The week year to calculate the number of contained weeks.</param>
+        /// <returns>The number of weeks in the given week year.</returns>
+        public static int GetWeeksInWeekYear([NotNull] this IWeekYearRule rule, int weekYear) =>
+            Preconditions.CheckNotNull(rule, nameof(rule)).GetWeeksInWeekYear(weekYear, CalendarSystem.Iso);
+    }
+}

--- a/src/NodaTime/Calendars/SimpleWeekYearRule.cs
+++ b/src/NodaTime/Calendars/SimpleWeekYearRule.cs
@@ -1,0 +1,233 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using JetBrains.Annotations;
+using NodaTime.Annotations;
+using NodaTime.Utility;
+
+namespace NodaTime.Calendars
+{
+    /// <summary>
+    /// Implements <see cref="IWeekYearRule"/> for a rule where weeks are regular:
+    /// every week has exactly 7 days, which means that some week years straddle
+    /// the calendar year boundary. (So the start of a week can occur in one calendar
+    /// year, and the end of the week in the following calendar year, but the whole
+    /// week is in the same week-year.)
+    /// </summary>
+    [Immutable]
+    internal sealed class SimpleWeekYearRule : IWeekYearRule
+    {
+        private readonly int minDaysInFirstWeek;
+        private readonly IsoDayOfWeek firstDayOfWeek;
+
+        /// <summary>
+        /// If true, the boundary of a calendar year sometimes splits a week in half. The
+        /// last day of the calendar year is *always* in the last week of the same week-year, but
+        /// the first day of the calendar year *may* be in the last week of the previous week-year.
+        /// (Basically, the rule works out when the first day of the week-year would be logically,
+        /// and then cuts it off so that it's never in the previous calendar year.)
+        ///
+        /// If false, all weeks are 7 days long, including across calendar-year boundaries.
+        /// This is the state for ISO-like rules.
+        /// </summary>
+        private readonly bool irregularWeeks;
+
+        internal SimpleWeekYearRule(int minDaysInFirstWeek, IsoDayOfWeek firstDayOfWeek, bool irregularWeeks)
+        {
+            Preconditions.CheckArgumentRange(nameof(firstDayOfWeek), (int)firstDayOfWeek, 1, 7);
+            this.minDaysInFirstWeek = minDaysInFirstWeek;
+            this.firstDayOfWeek = firstDayOfWeek;
+            this.irregularWeeks = irregularWeeks;
+        }
+
+        /// <inheritdoc />
+        public LocalDate GetLocalDate(int weekYear, int weekOfWeekYear, IsoDayOfWeek dayOfWeek, [NotNull] CalendarSystem calendar)
+        {
+            Preconditions.CheckNotNull(calendar, nameof(calendar));
+            ValidateWeekYear(weekYear, calendar);
+
+            // The actual message for this won't be ideal, but it's clear enough.
+            Preconditions.CheckArgumentRange(nameof(dayOfWeek), (int)dayOfWeek, 1, 7);
+
+            var yearMonthDayCalculator = calendar.YearMonthDayCalculator;
+            var maxWeeks = GetWeeksInWeekYear(weekYear, calendar);
+            if (weekOfWeekYear < 1 || weekOfWeekYear > maxWeeks)
+            {
+                throw new ArgumentOutOfRangeException(nameof(weekOfWeekYear));
+            }
+            
+            unchecked
+            {
+                int startOfWeekYear = GetWeekYearDaysSinceEpoch(yearMonthDayCalculator, weekYear);
+                // 0 for "already on the first day of the week" up to 6 "it's the last day of the week".
+                int daysIntoWeek = ((dayOfWeek - firstDayOfWeek) + 7) % 7;
+                int days = startOfWeekYear + (weekOfWeekYear - 1) * 7 + daysIntoWeek;
+                if (days < calendar.MinDays || days > calendar.MaxDays)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(weekYear),
+                        $"The combination of {nameof(weekYear)}, {nameof(weekOfWeekYear)} and {nameof(dayOfWeek)} is invalid");
+                }
+                LocalInstant localInstant = new LocalInstant(days * NodaConstants.TicksPerDay);
+                LocalDate ret = new LocalDate(new LocalDateTime(localInstant, calendar));
+
+                // For rules with irregular weeks, the calculation so far may end up computing a date which isn't
+                // in the right week-year. This will happen if the caller has specified a "short" week (i.e. one
+                // at the start or end of the week-year which is not seven days long due to the week year changing
+                // part way through a week) and a day-of-week which corresponds to the "missing" part of the week.
+                // Examples are in SimpleWeekYearRuleTest.GetLocalDate_Invalid.
+                // The simplest way to find out is just to check what the week year is, but we only need to do
+                // the full check if the requested week-year is different to the calendar year of the result.
+                // We don't need to check for this in regular rules, because the computation we've already performed
+                // will always be right.
+                if (irregularWeeks && weekYear != ret.Year)
+                {
+                    if (GetWeekYear(ret) != weekYear)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(weekYear),
+                            $"The combination of {nameof(weekYear)}, {nameof(weekOfWeekYear)} and {nameof(dayOfWeek)} is invalid");
+                    }
+                }
+                return ret;
+            }
+        }
+
+        /// <inheritdoc />
+        public int GetWeekOfWeekYear(LocalDate date)
+        {
+            YearMonthDayCalculator yearMonthDayCalculator = date.Calendar.YearMonthDayCalculator;
+            // This is a bit inefficient, as we'll be converting forms several times. However, it's
+            // understandable... we might want to optimize in the future if it's reported as a bottleneck.
+            int weekYear = GetWeekYear(date);
+            // Even if this is before the *real* start of the week year due to the rule
+            // having short weeks, that doesn't change the week-of-week-year, as we've definitely
+            // got the right week-year to start with.
+            int startOfWeekYear = GetWeekYearDaysSinceEpoch(yearMonthDayCalculator, weekYear);
+            int daysSinceEpoch = (int) (date.AtMidnight().LocalInstant.Ticks / NodaConstants.TicksPerDay);
+            int zeroBasedDayOfWeekYear = daysSinceEpoch - startOfWeekYear;
+            int zeroBasedWeek = zeroBasedDayOfWeekYear / 7;
+            return zeroBasedWeek + 1;
+        }
+
+        /// <inheritdoc />
+        public int GetWeeksInWeekYear(int weekYear, [NotNull] CalendarSystem calendar)
+        {
+            Preconditions.CheckNotNull(calendar, nameof(calendar));
+            YearMonthDayCalculator yearMonthDayCalculator = calendar.YearMonthDayCalculator;
+            ValidateWeekYear(weekYear, calendar);
+            unchecked
+            {
+                int startOfWeekYear = GetWeekYearDaysSinceEpoch(yearMonthDayCalculator, weekYear);
+                int startOfCalendarYear = (int) (yearMonthDayCalculator.GetStartOfYearInTicks(weekYear) / NodaConstants.TicksPerDay);
+                // The number of days gained or lost in the week year compared with the calendar year.
+                // So if the week year starts on December 31st of the previous calendar year, this will be +1.
+                // If the week year starts on January 2nd of this calendar year, this will be -1.
+                int extraDaysAtStart = startOfCalendarYear - startOfWeekYear;
+
+                // At the end of the year, we may have some extra days too.
+                // In a non-regular rule, we just round up, so assume we effectively have 6 extra days.
+                // In a regular rule, there can be at most minDaysInFirstWeek - 1 days "borrowed"
+                // from the following year - because if there were any more, those days would be in the
+                // the following year instead.
+                int extraDaysAtEnd = irregularWeeks ? 6 : minDaysInFirstWeek - 1;
+
+                int daysInThisYear = yearMonthDayCalculator.GetDaysInYear(weekYear);
+
+                // We can have up to "minDaysInFirstWeek - 1" days of the next year, too.
+                return (daysInThisYear + extraDaysAtStart + extraDaysAtEnd) / 7;
+            }
+        }
+
+        /// <inheritdoc />
+        public int GetWeekYear(LocalDate date)
+        {
+            YearMonthDayCalculator yearMonthDayCalculator = date.Calendar.YearMonthDayCalculator;
+            unchecked
+            {
+                // Let's guess that it's in the same week year as calendar year, and check that.
+                int calendarYear = date.Year;
+                int startOfWeekYear = GetWeekYearDaysSinceEpoch(yearMonthDayCalculator, calendarYear);
+                int daysSinceEpoch = (int) (date.AtMidnight().LocalInstant.Ticks / NodaConstants.TicksPerDay);
+                if (daysSinceEpoch < startOfWeekYear)
+                {
+                    // No, the week-year hadn't started yet. For example, we've been given January 1st 2011...
+                    // and the first week of week-year 2011 starts on January 3rd 2011. Therefore the date
+                    // must belong to the last week of the previous week-year.
+                    return calendarYear - 1;
+                }
+
+                // By now, we know it's either calendarYear or calendarYear + 1.
+
+                // In irregular rules, a day can belong to the *previous* week year, but never the *next* week year.
+                // So at this point, we're done.
+                if (irregularWeeks)
+                {
+                    return calendarYear;
+                }
+
+                // Otherwise, check using the number of
+                // weeks in the year. Note that this will fetch the start of the calendar year and the week year
+                // again, so could be optimized by copying some logic here - but only when we find we need to.
+                int weeksInWeekYear = GetWeeksInWeekYear(calendarYear, date.Calendar);
+
+                // We assume that even for the maximum year, we've got just about enough leeway to get to the
+                // start of the week year. (If not, we should adjust the maximum.)
+                int startOfNextWeekYear = startOfWeekYear + weeksInWeekYear * 7;
+                return daysSinceEpoch < startOfNextWeekYear ? calendarYear : calendarYear + 1;
+            }
+        }
+
+        /// <summary>
+        /// Validate that at least one day in the calendar falls in the given week year.
+        /// </summary>
+        private void ValidateWeekYear(int weekYear, CalendarSystem calendar)
+        {
+            if (weekYear > calendar.MinYear && weekYear < calendar.MaxYear)
+            {
+                return;
+            }
+            int minCalendarYearDays = GetWeekYearDaysSinceEpoch(calendar.YearMonthDayCalculator, calendar.MinYear);
+            // If week year X started after calendar year X, then the first days of the calendar year are in the
+            // previous week year.
+            int minWeekYear = minCalendarYearDays > calendar.MinDays ? calendar.MinYear - 1 : calendar.MinYear;
+            int maxCalendarYearDays = GetWeekYearDaysSinceEpoch(calendar.YearMonthDayCalculator, calendar.MaxYear + 1);
+            // If week year X + 1 started after the last day in the calendar, then everything is within week year X.
+            // For irregular rules, we always just use calendar.MaxYear.
+            int maxWeekYear = irregularWeeks || (maxCalendarYearDays > calendar.MaxDays) ? calendar.MaxYear : calendar.MaxYear + 1;
+            Preconditions.CheckArgumentRange(nameof(weekYear), weekYear, minWeekYear, maxWeekYear);
+        }
+
+        /// <summary>
+        /// Returns the days at the start of the given week-year. The week-year may be
+        /// 1 higher or lower than the max/min calendar year. For non-regular rules (i.e. where some weeks
+        /// can be short) it returns the day when the week-year *would* have started if it were regular.
+        /// So this *always* returns a date on firstDayOfWeek.
+        /// </summary>
+        private int GetWeekYearDaysSinceEpoch(YearMonthDayCalculator yearMonthDayCalculator, int weekYear)
+        {
+            unchecked
+            {
+                // Need to be slightly careful here, as the week-year can reasonably be (just) outside the calendar year range.
+                // However, YearMonthDayCalculator.GetStartOfYearInDays already handles min/max -/+ 1.
+                int startOfCalendarYear = (int) (yearMonthDayCalculator.GetStartOfYearInTicks(weekYear) / NodaConstants.TicksPerDay);
+                int startOfYearDayOfWeek = unchecked(startOfCalendarYear >= -3 ? 1 + ((startOfCalendarYear + 3) % 7)
+                                           : 7 + ((startOfCalendarYear + 4) % 7));
+
+                // How many days have there been from the start of the week containing
+                // the first day of the year, until the first day of the year? To put it another
+                // way, how many days in the week *containing* the start of the calendar year were
+                // in the previous calendar year.
+                // (For example, if the start of the calendar year is Friday and the first day of the week is Monday,
+                // this will be 4.)
+                int daysIntoWeek = ((startOfYearDayOfWeek - (int)firstDayOfWeek) + 7) % 7;
+                int startOfWeekContainingStartOfCalendarYear = startOfCalendarYear - daysIntoWeek;
+
+                bool startOfYearIsInWeek1 = (7 - daysIntoWeek >= minDaysInFirstWeek);
+                return startOfYearIsInWeek1
+                    ? startOfWeekContainingStartOfCalendarYear
+                    : startOfWeekContainingStartOfCalendarYear + 7;
+            }
+        }        
+    }
+}

--- a/src/NodaTime/Calendars/WeekYearRules.cs
+++ b/src/NodaTime/Calendars/WeekYearRules.cs
@@ -1,0 +1,124 @@
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using JetBrains.Annotations;
+using NodaTime.Extensions;
+using NodaTime.Utility;
+using System;
+using System.Globalization;
+using static System.Globalization.CalendarWeekRule;
+
+namespace NodaTime.Calendars
+{
+    /// <summary>
+    /// Factory methods to construct week-year rules supported by Noda Time.
+    /// </summary>
+    public static class WeekYearRules
+    {
+        /// <summary>
+        /// Returns an <see cref="IWeekYearRule"/> consistent with ISO-8601.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// In the standard ISO-8601 week algorithm, the first week of the year
+        /// is that in which at least 4 days are in the year. As a result of this
+        /// definition, day 1 of the first week may be in the previous year. In ISO-8601,
+        /// weeks always begin on a Monday, so this rule is equivalent to the first Thursday
+        /// being in the first Monday-to-Sunday week of the year.
+        /// </para>
+        /// <para>
+        /// For example, January 1st 2011 was a Saturday, so only two days of that week
+        /// (Saturday and Sunday) were in 2011. Therefore January 1st is part of
+        /// week 52 of week-year 2010. Conversely, December 31st 2012 is a Monday,
+        /// so is part of week 1 of week-year 2013.
+        /// </para>
+        /// </remarks>
+        /// <value>A <see cref="IWeekYearRule"/> consistent with ISO-8601.</value>
+        [NotNull] public static IWeekYearRule Iso { get; } = new SimpleWeekYearRule(4, IsoDayOfWeek.Monday, false);
+
+        /// <summary>
+        /// Creates a week year rule where the boundary between one week-year and the next
+        /// is parameterized in terms of how many days of the first week of the week
+        /// year have to be in the new calendar year. In rules created by this method, 
+        /// weeks are always deemed to begin on an Monday.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="minDaysInFirstWeek"/> determines when the first week of the week-year starts.
+        /// For any given calendar year X, consider the Monday-to-Sunday week that includes the first day of the
+        /// calendar year. Usually, some days of that week are in calendar year X, and some are in calendar year 
+        /// X-1. If <paramref name="minDaysInFirstWeek"/> or more of the days are in year X, then the week is
+        /// deemed to be the first week of week-year X. Otherwise, the week is deemed to be the last week of
+        /// week-year X-1, and the first week of week-year X starts on the following Monday.
+        /// </remarks>
+        /// <param name="minDaysInFirstWeek">The minimum number of days in the first Monday-to-Sunday week
+        /// which have to be in the new calendar year for that week to count as being in that week-year.
+        /// Must be in the range 1 to 7 inclusive.
+        /// </param>
+        /// <returns>A <see cref="SimpleWeekYearRule"/> with the specified minimum number of days in the first
+        /// week.</returns>
+        [NotNull] public static IWeekYearRule ForMinDaysInFirstWeek(int minDaysInFirstWeek)
+            => ForMinDaysInFirstWeek(minDaysInFirstWeek, IsoDayOfWeek.Monday);
+
+        /// <summary>
+        /// Creates a week year rule where the boundary between one week-year and the next
+        /// is parameterized in terms of how many days of the first week of the week
+        /// year have to be in the new calendar year, and also by which day is deemed
+        /// to be the first day of the week.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="minDaysInFirstWeek"/> determines when the first week of the week-year starts.
+        /// For any given calendar year X, consider the week that includes the first day of the
+        /// calendar year. Usually, some days of that week are in calendar year X, and some are in calendar year 
+        /// X-1. If <paramref name="minDaysInFirstWeek"/> or more of the days are in year X, then the week is
+        /// deemed to be the first week of week-year X. Otherwise, the week is deemed to be the last week of
+        /// week-year X-1, and the first week of week-year X starts on the following <paramref name="firstDayOfWeek"/>.
+        /// </remarks>
+        /// <param name="minDaysInFirstWeek">The minimum number of days in the first week (starting on
+        /// <paramref name="firstDayOfWeek" />) which have to be in the new calendar year for that week
+        /// to count as being in that week-year. Must be in the range 1 to 7 inclusive.
+        /// </param>
+        /// <param name="firstDayOfWeek">The first day of the week.</param>
+        /// <returns>A <see cref="SimpleWeekYearRule"/> with the specified minimum number of days in the first
+        /// week and first day of the week.</returns>
+        [NotNull] public static IWeekYearRule ForMinDaysInFirstWeek(int minDaysInFirstWeek, IsoDayOfWeek firstDayOfWeek)
+            => new SimpleWeekYearRule(minDaysInFirstWeek, firstDayOfWeek, false);
+
+        /// <summary>
+        /// Creates a rule which behaves the same way as the BCL
+        /// <see cref="Calendar.GetWeekOfYear(DateTime, CalendarWeekRule, DayOfWeek)"/>
+        /// method.
+        /// </summary>
+        /// <remarks>The BCL week year rules are subtly different to the ISO rules.
+        /// In particular, the last few days of the calendar year are always part of the same
+        /// week-year in the BCL rules, whereas in the ISO rules they can fall into the next
+        /// week-year. (The first few days of the calendar year can be part of the previous
+        /// week-year in both kinds of rule.) This means that in the BCL rules, some weeks
+        /// are incomplete, whereas ISO weeks are always exactly 7 days long.
+        /// </remarks>
+        /// <param name="calendarWeekRule">The BCL rule to emulate.</param>
+        /// <param name="firstDayOfWeek">The first day of the week to use in the rule.</param>
+        /// <returns>A rule which behaves the same way as the BCL
+        /// <see cref="Calendar.GetWeekOfYear(DateTime, CalendarWeekRule, DayOfWeek)"/>
+        /// method.</returns>
+        [NotNull] public static IWeekYearRule FromCalendarWeekRule(CalendarWeekRule calendarWeekRule, DayOfWeek firstDayOfWeek)
+        {
+            int minDaysInFirstWeek;
+            switch (calendarWeekRule)
+            {
+                case FirstDay:
+                    minDaysInFirstWeek = 1;
+                    break;
+                case FirstFourDayWeek:
+                    minDaysInFirstWeek = 4;
+                    break;
+                case FirstFullWeek:
+                    minDaysInFirstWeek = 7;
+                    break;
+                default:
+                    throw new ArgumentException($"Unsupported CalendarWeekRule: {calendarWeekRule}", nameof(calendarWeekRule));
+            }
+            return new SimpleWeekYearRule(minDaysInFirstWeek, BclConversions.ToIsoDayOfWeek(firstDayOfWeek), true);
+        }
+    }
+}

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -164,13 +164,16 @@
     <Compile Include="Calendars\IslamicLeapYearPattern.cs" />
     <Compile Include="Calendars\IslamicYearMonthDayCalculator.cs" />
     <Compile Include="Calendars\IsoYearMonthDayCalculator.cs" />
+    <Compile Include="Calendars\IWeekYearRule.cs" />
     <Compile Include="Calendars\JulianYearMonthDayCalculator.cs" />
     <Compile Include="Calendars\NamespaceDoc.cs" />
     <Compile Include="Calendars\PersianYearMonthDayCalculator.cs" />
     <Compile Include="Calendars\RegularYearMonthDayCalculator.cs" />
+    <Compile Include="Calendars\SimpleWeekYearRule.cs" />
     <Compile Include="Calendars\TickArithmetic.cs" />
     <Compile Include="Calendars\TimeOfDayCalculator.cs" />
     <Compile Include="Calendars\WeekYearCalculator.cs" />
+    <Compile Include="Calendars\WeekYearRules.cs" />
     <Compile Include="Calendars\YearMonthDay.cs" />
     <Compile Include="Calendars\YearMonthDayCalculator.cs" />
     <Compile Include="Calendars\YearStartCacheEntry.cs" />


### PR DESCRIPTION
This will allow us to make GetGregorian(int) etc obsolete while
providing 2.0.x-compatible alternatives.

The implementation and tests are as close to 2.0.x as I could make
them - they're not necessarily how I'd normally write them with 1.x,
but I wanted to make as few changes as possible. (Hence the multiple
conversions between ticks and days, because 2.0 is day-based.)

(I'm not sure if there's an easy way of comparing this code with the 2.0 equivalent other than downloading it...)