### PR TITLE
Remaining 1.4 obsolete attributes

### DIFF
--- a/src/NodaTime.Testing/FakeClock.cs
+++ b/src/NodaTime.Testing/FakeClock.cs
@@ -189,6 +189,7 @@ namespace NodaTime.Testing
         /// If the value of the <see cref="AutoAdvance"/> property is non-zero, then every
         /// call to this method will advance the current time by that value.
         /// </remarks>
+        [Obsolete("Use the GetCurrentInstant() extension method for compatibility with 2.0")]
         public Instant Now
         {
             get

--- a/src/NodaTime.Testing/TimeZones/FakeDateTimeZoneSource.cs
+++ b/src/NodaTime.Testing/TimeZones/FakeDateTimeZoneSource.cs
@@ -64,6 +64,7 @@ namespace NodaTime.Testing.TimeZones
         }
 
         /// <inheritdoc />
+        [Obsolete("Only the system default time zone can be mapped in 2.0, using GetSystemDefaultId. For other time zones, use source-specific members.")]
         public string MapTimeZoneId(TimeZoneInfo timeZone)
         {
             Preconditions.CheckNotNull(timeZone, "timeZone");

--- a/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
+++ b/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
@@ -68,6 +68,7 @@ namespace NodaTime.Testing.TimeZones
         }
 
         /// <inheritdoc />
+        [Obsolete("General DateTimeZone equality is not supported in 2.0")]
         protected override bool EqualsImpl(DateTimeZone zone)
         {
             // Just use reference equality...

--- a/src/NodaTime.Testing/TimeZones/SingleTransitionDateTimeZone.cs
+++ b/src/NodaTime.Testing/TimeZones/SingleTransitionDateTimeZone.cs
@@ -3,6 +3,7 @@
 // as found in the LICENSE.txt file.
 
 using NodaTime.TimeZones;
+using System;
 
 namespace NodaTime.Testing.TimeZones
 {
@@ -76,6 +77,7 @@ namespace NodaTime.Testing.TimeZones
         }
 
         /// <inheritdoc />
+        [Obsolete("General DateTimeZone equality is not supported in 2.0")]
         protected override bool EqualsImpl(DateTimeZone zone)
         {
             SingleTransitionDateTimeZone otherZone = (SingleTransitionDateTimeZone)zone;

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -236,6 +236,7 @@ namespace NodaTime
         /// used to decide at what point the week year changes.</param>
         /// <returns>A suitable Gregorian calendar reference; the same reference may be returned by several
         /// calls as the object is immutable and thread-safe.</returns>
+        [Obsolete("Use the Gregorian property, then WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public static CalendarSystem GetGregorianCalendar(int minDaysInFirstWeek)
         {
             Preconditions.CheckArgumentRange("minDaysInFirstWeek", minDaysInFirstWeek, 1, 7);
@@ -258,6 +259,7 @@ namespace NodaTime
         /// used to decide at what point the week year changes.</param>
         /// <returns>A suitable Julian calendar reference; the same reference may be returned by several
         /// calls as the object is immutable and thread-safe.</returns>
+        [Obsolete("Use the Julian property, then WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public static CalendarSystem GetJulianCalendar(int minDaysInFirstWeek)
         {
             Preconditions.CheckArgumentRange("minDaysInFirstWeek", minDaysInFirstWeek, 1, 7);
@@ -288,6 +290,7 @@ namespace NodaTime
         /// used to decide at what point the week year changes.</param>
         /// <returns>A suitable Coptic calendar reference; the same reference may be returned by several
         /// calls as the object is immutable and thread-safe.</returns>
+        [Obsolete("Use the Coptic property, then WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public static CalendarSystem GetCopticCalendar(int minDaysInFirstWeek)
         {
             Preconditions.CheckArgumentRange("minDaysInFirstWeek", minDaysInFirstWeek, 1, 7);
@@ -469,6 +472,7 @@ namespace NodaTime
         /// can use the <see cref="IsoDayOfWeek" /> property to avoid using magic numbers.
         /// This defaults to true, but can be overridden by specific calendars.
         /// </summary>
+        [Obsolete("Removed in 2.0 as all calendar systems are deemed to use ISO days.")]
         public bool UsesIsoDayOfWeek { get { return true; } }
 
         /// <summary>

--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -573,6 +573,7 @@ namespace NodaTime
         /// <c>true</c> if the specified <see cref="DateTimeZone"/> is equal to this instance;
         /// otherwise, <c>false</c>.
         /// </returns>
+        [Obsolete("General DateTimeZone equality is not supported in 2.0")]
         public bool Equals(DateTimeZone obj)
         {
             if (ReferenceEquals(this, obj))
@@ -591,6 +592,7 @@ namespace NodaTime
         /// <c>true</c> if the specified <see cref="DateTimeZone"/> is equal to this instance;
         /// otherwise, <c>false</c>.
         /// </returns>
+        [Obsolete("General DateTimeZone equality is not supported in 2.0")]
         protected abstract bool EqualsImpl(DateTimeZone zone);
 
         /// <summary>

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -504,6 +504,7 @@ namespace NodaTime
         /// </summary>
         /// <param name="weeks">The number of weeks.</param>
         /// <returns>A <see cref="Duration"/> representing the given number of weeks.</returns>
+        [Obsolete("No equivalent exists in 2.0; use FromDays, multiplying the number of days by 7.")]
         public static Duration FromStandardWeeks(long weeks)
         {
             return OneStandardWeek * weeks;

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -166,6 +166,7 @@ namespace NodaTime
 
         /// <summary>Gets the year of this local date within the century.</summary>
         /// <remarks>This always returns a value in the range 0 to 99 inclusive.</remarks>
+        [Obsolete("Century-based properties have been removed in 2.0")]
         public int YearOfCentury { get { return localTime.YearOfCentury; } }
 
         /// <summary>Gets the year of this local date within the era.</summary>

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -157,9 +157,11 @@ namespace NodaTime
         /// so is part of week 1 of WeekYear 2013.
         /// </para>
         /// </remarks>
+        [Obsolete("Use WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public int WeekYear { get { return localTime.WeekYear; } }
 
         /// <summary>Gets the week within the WeekYear. See <see cref="WeekYear"/> for more details.</summary>
+        [Obsolete("Use WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public int WeekOfWeekYear { get { return localTime.WeekOfWeekYear; } }
 
         /// <summary>Gets the year of this local date within the century.</summary>

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -234,6 +234,7 @@ namespace NodaTime
         }
 
         /// <summary>Gets the century within the era of this local date and time.</summary>
+        [Obsolete("Century-based properties have been removed in 2.0")]
         public int CenturyOfEra { get { return Calendar.GetCenturyOfEra(localInstant); } }
 
         /// <summary>Gets the year of this local date and time.</summary>
@@ -243,6 +244,7 @@ namespace NodaTime
 
         /// <summary>Gets the year of this local date and time within its century.</summary>
         /// <remarks>This always returns a value in the range 0 to 99 inclusive.</remarks>
+        [Obsolete("Century-based properties have been removed in 2.0")]
         public int YearOfCentury { get { return Calendar.GetYearOfCentury(localInstant); } }
 
         /// <summary>Gets the year of this local date and time within its era.</summary>

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -198,6 +198,7 @@ namespace NodaTime
         /// <param name="tickWithinMillisecond">The tick within millisecond.</param>
         /// <returns>The resulting date/time.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The parameters do not form a valid date/time.</exception>
+        [Obsolete("Construct with a LocalDate + LocalTime or construct to the millisecond and use PlusTicks for compatibiltiy with 2.0")]
         public LocalDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int tickWithinMillisecond)
             : this(year, month, day, hour, minute, second, millisecond, tickWithinMillisecond, CalendarSystem.Iso)
         {
@@ -218,6 +219,7 @@ namespace NodaTime
         /// <param name="calendar">The calendar.</param>
         /// <returns>The resulting date/time.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The parameters do not form a valid date/time.</exception>
+        [Obsolete("Construct with a LocalDate + LocalTime or construct to the millisecond and use PlusTicks for compatibiltiy with 2.0")]
         public LocalDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int tickWithinMillisecond, [NotNull] CalendarSystem calendar)
         {
             Preconditions.CheckNotNull(calendar, "calendar");

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -269,6 +269,7 @@ namespace NodaTime
         /// so is part of week 1 of WeekYear 2013.
         /// </para>
         /// </remarks>
+        [Obsolete("Use WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public int WeekYear { get { return Calendar.GetWeekYear(localInstant); } }
 
         /// <summary>
@@ -279,6 +280,7 @@ namespace NodaTime
         /// <summary>
         /// Gets the week within the WeekYear. See <see cref="WeekYear"/> for more details.
         /// </summary>
+        [Obsolete("Use WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public int WeekOfWeekYear { get { return Calendar.GetWeekOfWeekYear(localInstant); } }
 
         /// <summary>

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -260,6 +260,7 @@ namespace NodaTime
         /// Returns a <see cref="T:NodaTime.LocalDateTime"/> with this local time, on January 1st 1970 in the ISO
         /// calendar.
         /// </summary>
+        [Obsolete("Use the + operator or the On method to combine with a LocalDate, for 2.0 compatibility.")]
         public LocalDateTime LocalDateTime { get { return new LocalDateTime(new LocalInstant(ticks)); } }
 
         /// <summary>

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -257,6 +257,7 @@
     <Compile Include="TimeZones\Cldr\WindowsZones.cs" />
     <Compile Include="TimeZones\DateTimeZoneCache.cs" />
     <Compile Include="TimeZones\DateTimeZoneNotFoundException.cs" />
+    <Compile Include="TimeZones\DateTimeZoneSourceExtensions.cs" />
     <Compile Include="TimeZones\Delegates.cs" />
     <Compile Include="TimeZones\PartialZoneIntervalMap.cs" />
     <Compile Include="TimeZones\SingleZoneIntervalMap.cs" />

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -100,9 +100,11 @@ namespace NodaTime
         /// so is part of week 1 of WeekYear 2013.
         /// </para>
         /// </remarks>
+        [Obsolete("Use WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public int WeekYear { get { return localDateTime.WeekYear; } }
 
         /// <summary>Gets the week within the WeekYear. See <see cref="WeekYear"/> for more details.</summary>
+        [Obsolete("Use WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public int WeekOfWeekYear { get { return localDateTime.WeekOfWeekYear; } }
 
         /// <summary>Gets the year of this offset date and time within the century.</summary>

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -109,6 +109,7 @@ namespace NodaTime
 
         /// <summary>Gets the year of this offset date and time within the century.</summary>
         /// <remarks>This always returns a value in the range 0 to 99 inclusive.</remarks>
+        [Obsolete("Century-based properties have been removed in 2.0")]
         public int YearOfCentury { get { return localDateTime.YearOfCentury; } }
 
         /// <summary>Gets the year of this offset date and time within the era.</summary>

--- a/src/NodaTime/SystemClock.cs
+++ b/src/NodaTime/SystemClock.cs
@@ -34,6 +34,7 @@ namespace NodaTime
         /// Gets the current time as an <see cref="Instant"/>.
         /// </summary>
         /// <value>The current time in ticks as an <see cref="Instant"/>.</value>
+        [Obsolete("Use the GetCurrentInstant() extension method for compatibility with 2.0")]
         public Instant Now { get { return NodaConstants.BclEpoch.PlusTicks(DateTime.UtcNow.Ticks); } }
     }
 }

--- a/src/NodaTime/Text/InstantPattern.cs
+++ b/src/NodaTime/Text/InstantPattern.cs
@@ -220,6 +220,7 @@ namespace NodaTime.Text
         /// <param name="cultureInfo">The culture to use in the pattern</param>
         /// <param name="includeThousandsSeparators">True to include thousands separators when parsing or formatting; false to omit them.</param>
         /// <returns>A numeric pattern for the configuration</returns>
+        [Obsolete("Numeric patterns are not supported in 2.0")]
         public static InstantPattern CreateNumericPattern(CultureInfo cultureInfo, bool includeThousandsSeparators)
         {
             return Create(includeThousandsSeparators ? "n" : "d", cultureInfo);
@@ -255,6 +256,7 @@ namespace NodaTime.Text
         /// <param name="maxLabel">Text to use for <see cref="Instant.MaxValue"/>. Must be non-empty, and not the same as <paramref name="minLabel"/></param>
         /// <returns>A new pattern with the given min/max labels.</returns>
         /// <exception cref="ArgumentException"></exception>
+        [Obsolete("Start/end of time instants are not supported in 2.0")]
         public InstantPattern WithMinMaxLabels(string minLabel, string maxLabel)
         {
             return Create(patternText, formatInfo, minLabel, maxLabel);

--- a/src/NodaTime/TimeZones/BclDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZone.cs
@@ -291,6 +291,7 @@ namespace NodaTime.TimeZones
         /// This implementation simply compares the underlying `TimeZoneInfo` values for
         /// reference equality.
         /// </remarks>
+        [Obsolete("General DateTimeZone equality is not supported in 2.0")]
         protected override bool EqualsImpl(DateTimeZone zone)
         {
             return ReferenceEquals(OriginalZone, ((BclDateTimeZone) zone).OriginalZone);

--- a/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
@@ -123,6 +123,7 @@ namespace NodaTime.TimeZones
         /// The ID for the given BCL time zone for this source; that is, the value of the <c>Id</c> property of the
         /// passed-in <see cref="TimeZoneInfo"/>.
         /// </returns>
+        [Obsolete("Only the system default time zone can be mapped in 2.0, using GetSystemDefaultId. For other time zones, use source-specific members.")]
         public string MapTimeZoneId(TimeZoneInfo timeZone)
         {
             return timeZone.Id;

--- a/src/NodaTime/TimeZones/CachedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/CachedDateTimeZone.cs
@@ -4,6 +4,7 @@
 
 using NodaTime.TimeZones.IO;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime.TimeZones
 {
@@ -97,6 +98,7 @@ namespace NodaTime.TimeZones
             return ForZone(timeZone);
         }
 
+        [Obsolete("General DateTimeZone equality is not supported in 2.0")]
         protected override bool EqualsImpl(DateTimeZone zone)
         {
             return TimeZone.Equals(((CachedDateTimeZone) zone).TimeZone);

--- a/src/NodaTime/TimeZones/DateTimeZoneSourceExtensions.cs
+++ b/src/NodaTime/TimeZones/DateTimeZoneSourceExtensions.cs
@@ -7,7 +7,7 @@ using System;
 namespace NodaTime.TimeZones
 {
     /// <summary>
-    /// Extension methods for <see cref="IClock"/> to enable migration to Noda Time 2.0.
+    /// Extension methods for <see cref="IDateTimeZoneSource"/> to enable migration to Noda Time 2.0.
     /// </summary>
     public static class DateTimeZoneSourceExtensions
     {

--- a/src/NodaTime/TimeZones/DateTimeZoneSourceExtensions.cs
+++ b/src/NodaTime/TimeZones/DateTimeZoneSourceExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.using System;
+using NodaTime.Utility;
+using System;
+
+namespace NodaTime.TimeZones
+{
+    /// <summary>
+    /// Extension methods for <see cref="IClock"/> to enable migration to Noda Time 2.0.
+    /// </summary>
+    public static class DateTimeZoneSourceExtensions
+    {
+        /// <summary>
+        /// Returns this source's ID for the system default time zone.
+        /// </summary>
+        /// <param name="source">The source to consult its ID for the system default time zone</param>
+        /// <returns>The ID for the system default time zone for this source, or null if the system default time zone has no mapping in this source.</returns>
+        public static string GetSystemDefaultId(this IDateTimeZoneSource source) =>
+            Preconditions.CheckNotNull(source, nameof(source)).MapTimeZoneId(TimeZoneInfo.Local);
+    }
+}

--- a/src/NodaTime/TimeZones/DaylightSavingsDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/DaylightSavingsDateTimeZone.cs
@@ -60,6 +60,7 @@ namespace NodaTime.TimeZones
             standardRecurrence = standard;
         }
 
+        [Obsolete("General DateTimeZone equality is not supported in 2.0")]
         protected override bool EqualsImpl(DateTimeZone other)
         {
             DaylightSavingsDateTimeZone otherZone = (DaylightSavingsDateTimeZone)other;

--- a/src/NodaTime/TimeZones/FixedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/FixedDateTimeZone.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using NodaTime.Text;
 using NodaTime.TimeZones.IO;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime.TimeZones
 {
@@ -134,7 +135,7 @@ namespace NodaTime.TimeZones
             return new FixedDateTimeZone(id, offset);
         }
 
-
+        [Obsolete("General DateTimeZone equality is not supported in 2.0")]
         protected override bool EqualsImpl(DateTimeZone other)
         {
             FixedDateTimeZone otherZone = (FixedDateTimeZone) other;

--- a/src/NodaTime/TimeZones/IDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/IDateTimeZoneSource.cs
@@ -100,6 +100,7 @@ namespace NodaTime.TimeZones
         /// The ID for the given system time zone for this source, or null if the system time
         /// zone has no mapping in this source.
         /// </returns>
+        [Obsolete("Only the system default time zone can be mapped in 2.0, using GetSystemDefaultId. For other time zones, use source-specific members.")]
         string MapTimeZoneId(TimeZoneInfo timeZone);
     }
 }

--- a/src/NodaTime/TimeZones/PrecalculatedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/PrecalculatedDateTimeZone.cs
@@ -289,6 +289,7 @@ namespace NodaTime.TimeZones
         }
         #endregion
 
+        [Obsolete("General DateTimeZone equality is not supported in 2.0")]
         protected override bool EqualsImpl(DateTimeZone zone)
         {
             PrecalculatedDateTimeZone otherZone = (PrecalculatedDateTimeZone)zone;

--- a/src/NodaTime/TimeZones/TzdbDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/TzdbDateTimeZoneSource.cs
@@ -204,6 +204,7 @@ namespace NodaTime.TimeZones
 
         /// <inheritdoc />
         /// <param name="zone">The BCL time zone, which must be a known system time zone.</param>
+        [Obsolete("Only the system default time zone can be mapped in 2.0, using GetSystemDefaultId. For other time zones, use source-specific members.")]
         public string MapTimeZoneId(TimeZoneInfo zone)
         {
 #if PCL

--- a/src/NodaTime/ZonedClock.cs
+++ b/src/NodaTime/ZonedClock.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using NodaTime.Annotations;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime
 {
@@ -36,6 +37,7 @@ namespace NodaTime
         /// Explicit interface implementation of <see cref="IClock.Now"/>; use
         /// <see cref="GetCurrentInstant()"/> in preference.
         /// </summary>
+        [Obsolete("Use the GetCurrentInstant() extension method for compatibility with 2.0")]
         Instant IClock.Now => GetCurrentInstant();
 
         /// <summary>

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -194,12 +194,14 @@ namespace NodaTime
         /// so is part of week 1 of WeekYear 2013.
         /// </para>
         /// </remarks>
+        [Obsolete("Use WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public int WeekYear { get { return LocalDateTime.WeekYear; } }
 
         /// <summary>Gets the month of this zoned date and time within the year.</summary>
         public int Month { get { return LocalDateTime.Month; } }
 
         /// <summary>Gets the week within the WeekYear. See <see cref="WeekYear"/> for more details.</summary>
+        [Obsolete("Use WeekYearRules for specific week-year rules for compatibility with 2.0.")]
         public int WeekOfWeekYear { get { return LocalDateTime.WeekOfWeekYear; } }
 
         /// <summary>Gets the day of this zoned date and time within the year.</summary>

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -162,6 +162,7 @@ namespace NodaTime
         public Era Era { get { return LocalDateTime.Era; } }
 
         /// <summary>Gets the century within the era of this zoned date and time.</summary>
+        [Obsolete("Century-based properties have been removed in 2.0")]
         public int CenturyOfEra { get { return LocalDateTime.CenturyOfEra; } }
 
         /// <summary>Gets the year of this zoned date and time.</summary>
@@ -171,6 +172,7 @@ namespace NodaTime
 
         /// <summary>Gets the year of this zoned date and time within its century.</summary>
         /// <remarks>This always returns a value in the range 0 to 99 inclusive.</remarks>
+        [Obsolete("Century-based properties have been removed in 2.0")]
         public int YearOfCentury { get { return LocalDateTime.YearOfCentury; } }
 
         /// <summary>Gets the year of this zoned date and time within its era.</summary>

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -378,6 +378,7 @@ namespace NodaTime
         /// <param name="lhs">First operand of the comparison</param>
         /// <param name="rhs">Second operand of the comparison</param>
         /// <returns>true if the <paramref name="lhs"/> is strictly earlier than <paramref name="rhs"/>, false otherwise.</returns>
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0, and compare calendars and zones explicitly.")]
         public static bool operator <(ZonedDateTime lhs, ZonedDateTime rhs)
         {
             return lhs.ToInstant() < rhs.ToInstant() && Equals(lhs.LocalDateTime.Calendar, rhs.LocalDateTime.Calendar) && Equals(lhs.Zone, rhs.Zone);
@@ -394,6 +395,7 @@ namespace NodaTime
         /// <param name="lhs">First operand of the comparison</param>
         /// <param name="rhs">Second operand of the comparison</param>
         /// <returns>true if the <paramref name="lhs"/> is earlier than or equal to <paramref name="rhs"/>, false otherwise.</returns>
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0, and compare calendars and zones explicitly.")]
         public static bool operator <=(ZonedDateTime lhs, ZonedDateTime rhs)
         {
             return lhs.ToInstant() <= rhs.ToInstant() && Equals(lhs.LocalDateTime.Calendar, rhs.LocalDateTime.Calendar) && Equals(lhs.Zone, rhs.Zone);
@@ -410,6 +412,7 @@ namespace NodaTime
         /// <param name="lhs">First operand of the comparison</param>
         /// <param name="rhs">Second operand of the comparison</param>
         /// <returns>true if the <paramref name="lhs"/> is strictly later than <paramref name="rhs"/>, false otherwise.</returns>
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0, and compare calendars and zones explicitly.")]
         public static bool operator >(ZonedDateTime lhs, ZonedDateTime rhs)
         {
             return lhs.ToInstant() > rhs.ToInstant() && Equals(lhs.LocalDateTime.Calendar, rhs.LocalDateTime.Calendar) && Equals(lhs.Zone, rhs.Zone);
@@ -426,6 +429,7 @@ namespace NodaTime
         /// <param name="lhs">First operand of the comparison</param>
         /// <param name="rhs">Second operand of the comparison</param>
         /// <returns>true if the <paramref name="lhs"/> is later than or equal to <paramref name="rhs"/>, false otherwise.</returns>
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0, and compare calendars and zones explicitly.")]
         public static bool operator >=(ZonedDateTime lhs, ZonedDateTime rhs)
         {
             return lhs.ToInstant() >= rhs.ToInstant() && Equals(lhs.LocalDateTime.Calendar, rhs.LocalDateTime.Calendar) && Equals(lhs.Zone, rhs.Zone);
@@ -441,6 +445,7 @@ namespace NodaTime
         /// <returns>A value less than zero if the instant represented by this zoned date/time is earlier than the one in
         /// <paramref name="other"/>; zero if the instant is the same as the one in <paramref name="other"/>;
         /// a value greater than zero if the instant is later than the one in <paramref name="other"/>.</returns>
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0")]
         public int CompareTo(ZonedDateTime other)
         {
             return ToInstant().CompareTo(other.ToInstant());
@@ -457,6 +462,7 @@ namespace NodaTime
         /// <returns>The result of comparing this ZonedDateTime with another one; see <see cref="CompareTo(NodaTime.ZonedDateTime)"/> for general details.
         /// If <paramref name="obj"/> is null, this method returns a value greater than 0.
         /// </returns>
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0")]
         int IComparable.CompareTo(object obj)
         {
             if (obj == null)

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -378,7 +378,7 @@ namespace NodaTime
         /// <param name="lhs">First operand of the comparison</param>
         /// <param name="rhs">Second operand of the comparison</param>
         /// <returns>true if the <paramref name="lhs"/> is strictly earlier than <paramref name="rhs"/>, false otherwise.</returns>
-        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0, and compare calendars and zones explicitly.")]
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0. If calendar and time zone comparison is required, make those comparisons explicitly.")]
         public static bool operator <(ZonedDateTime lhs, ZonedDateTime rhs)
         {
             return lhs.ToInstant() < rhs.ToInstant() && Equals(lhs.LocalDateTime.Calendar, rhs.LocalDateTime.Calendar) && Equals(lhs.Zone, rhs.Zone);
@@ -395,7 +395,7 @@ namespace NodaTime
         /// <param name="lhs">First operand of the comparison</param>
         /// <param name="rhs">Second operand of the comparison</param>
         /// <returns>true if the <paramref name="lhs"/> is earlier than or equal to <paramref name="rhs"/>, false otherwise.</returns>
-        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0, and compare calendars and zones explicitly.")]
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0. If calendar and time zone comparison is required, make those comparisons explicitly.")]
         public static bool operator <=(ZonedDateTime lhs, ZonedDateTime rhs)
         {
             return lhs.ToInstant() <= rhs.ToInstant() && Equals(lhs.LocalDateTime.Calendar, rhs.LocalDateTime.Calendar) && Equals(lhs.Zone, rhs.Zone);
@@ -412,7 +412,7 @@ namespace NodaTime
         /// <param name="lhs">First operand of the comparison</param>
         /// <param name="rhs">Second operand of the comparison</param>
         /// <returns>true if the <paramref name="lhs"/> is strictly later than <paramref name="rhs"/>, false otherwise.</returns>
-        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0, and compare calendars and zones explicitly.")]
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0. If calendar and time zone comparison is required, make those comparisons explicitly.")]
         public static bool operator >(ZonedDateTime lhs, ZonedDateTime rhs)
         {
             return lhs.ToInstant() > rhs.ToInstant() && Equals(lhs.LocalDateTime.Calendar, rhs.LocalDateTime.Calendar) && Equals(lhs.Zone, rhs.Zone);
@@ -429,7 +429,7 @@ namespace NodaTime
         /// <param name="lhs">First operand of the comparison</param>
         /// <param name="rhs">Second operand of the comparison</param>
         /// <returns>true if the <paramref name="lhs"/> is later than or equal to <paramref name="rhs"/>, false otherwise.</returns>
-        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0, and compare calendars and zones explicitly.")]
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0. If calendar and time zone comparison is required, make those comparisons explicitly.")]
         public static bool operator >=(ZonedDateTime lhs, ZonedDateTime rhs)
         {
             return lhs.ToInstant() >= rhs.ToInstant() && Equals(lhs.LocalDateTime.Calendar, rhs.LocalDateTime.Calendar) && Equals(lhs.Zone, rhs.Zone);
@@ -445,7 +445,7 @@ namespace NodaTime
         /// <returns>A value less than zero if the instant represented by this zoned date/time is earlier than the one in
         /// <paramref name="other"/>; zero if the instant is the same as the one in <paramref name="other"/>;
         /// a value greater than zero if the instant is later than the one in <paramref name="other"/>.</returns>
-        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0")]
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0.")]
         public int CompareTo(ZonedDateTime other)
         {
             return ToInstant().CompareTo(other.ToInstant());
@@ -462,7 +462,7 @@ namespace NodaTime
         /// <returns>The result of comparing this ZonedDateTime with another one; see <see cref="CompareTo(NodaTime.ZonedDateTime)"/> for general details.
         /// If <paramref name="obj"/> is null, this method returns a value greater than 0.
         /// </returns>
-        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0")]
+        [Obsolete("Use ZonedDateTime.Comparer.Instant to compare values by instant for compatibility with 2.0.")]
         int IComparable.CompareTo(object obj)
         {
             if (obj == null)


### PR DESCRIPTION
If I've got this right, this (with #875) should complete the 1.4 work, I think...

We're left with the following which have been removed in 2.0 but can't be made obsolete in 1.4:

- The `IsoDayOfWeek` property in various types, which has been renamed to `DayOfWeek` in 2.0, but there's already a `DayOfWeek` property of type `int`
- Overriding `Equals/GetHashCode` from `object` in `DateTimeZone`
- The `ZoneInterval` constructor, which will be source compatible as it now takes `Instant?` values instead of `Instant` (with a slight wrinkle that `Instant.MinValue` and` Instant.MaxValue` are now "regular" extreme values rather than sentinel values for "beginning and end of time"

Each commit is self-contained - I'd suggest reviewing one commit at a time.