### PR TITLE
Provide Min/Max for all suitable types

### DIFF
--- a/src/NodaTime.Test/DurationTest.cs
+++ b/src/NodaTime.Test/DurationTest.cs
@@ -350,5 +350,31 @@ namespace NodaTime.Test
             // of the min value.
             Assert.AreEqual(Duration.MinValue, -Duration.MaxValue - Duration.Epsilon);
         }
+
+        [Test]
+        public void Max()
+        {
+            Duration x = Duration.FromNanoseconds(100);
+            Duration y = Duration.FromNanoseconds(200);
+            Assert.AreEqual(y, Duration.Max(x, y));
+            Assert.AreEqual(y, Duration.Max(y, x));
+            Assert.AreEqual(x, Duration.Max(x, Duration.MinValue));
+            Assert.AreEqual(x, Duration.Max(Duration.MinValue, x));
+            Assert.AreEqual(Duration.MaxValue, Duration.Max(Duration.MaxValue, x));
+            Assert.AreEqual(Duration.MaxValue, Duration.Max(x, Duration.MaxValue));
+        }
+
+        [Test]
+        public void Min()
+        {
+            Duration x = Duration.FromNanoseconds(100);
+            Duration y = Duration.FromNanoseconds(200);
+            Assert.AreEqual(x, Duration.Min(x, y));
+            Assert.AreEqual(x, Duration.Min(y, x));
+            Assert.AreEqual(Duration.MinValue, Duration.Min(x, Duration.MinValue));
+            Assert.AreEqual(Duration.MinValue, Duration.Min(Duration.MinValue, x));
+            Assert.AreEqual(x, Duration.Min(Duration.MaxValue, x));
+            Assert.AreEqual(x, Duration.Min(x, Duration.MaxValue));
+        }
     }
 }

--- a/src/NodaTime.Test/LocalDateTest.Comparison.cs
+++ b/src/NodaTime.Test/LocalDateTest.Comparison.cs
@@ -172,5 +172,27 @@ namespace NodaTime.Test
                 i_instance.CompareTo(arg);
             });
         }
+
+        [Test]
+        public void MinMax_DifferentCalendars_Throws()
+        {
+            LocalDate date1 = new LocalDate(2011, 1, 2);
+            LocalDate date2 = new LocalDate(1500, 1, 1, CalendarSystem.Julian);
+
+            Assert.Throws<ArgumentException>(() => LocalDate.Max(date1, date2));
+            Assert.Throws<ArgumentException>(() => LocalDate.Min(date1, date2));
+        }
+
+        [Test]
+        public void MinMax_SameCalendar()
+        {
+            LocalDate date1 = new LocalDate(1500, 1, 2, CalendarSystem.Julian);
+            LocalDate date2 = new LocalDate(1500, 1, 1, CalendarSystem.Julian);
+
+            Assert.AreEqual(date1, LocalDate.Max(date1, date2));
+            Assert.AreEqual(date1, LocalDate.Max(date2, date1));
+            Assert.AreEqual(date2, LocalDate.Min(date1, date2));
+            Assert.AreEqual(date2, LocalDate.Min(date2, date1));
+        }
     }
 }

--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -450,5 +450,27 @@ namespace NodaTime.Test
         {
             TestHelper.AssertXmlInvalid<LocalDateTime>(xml, expectedExceptionType);
         }
+
+        [Test]
+        public void MinMax_DifferentCalendars_Throws()
+        {
+            LocalDateTime ldt1 = new LocalDateTime(2011, 1, 2, 2, 20);
+            LocalDateTime ldt2 = new LocalDateTime(1500, 1, 1, 5, 10, CalendarSystem.Julian);
+
+            Assert.Throws<ArgumentException>(() => LocalDateTime.Max(ldt1, ldt2));
+            Assert.Throws<ArgumentException>(() => LocalDateTime.Min(ldt1, ldt2));
+        }
+
+        [Test]
+        public void MinMax_SameCalendar()
+        {
+            LocalDateTime ldt1 = new LocalDateTime(1500, 1, 1, 7, 20, CalendarSystem.Julian);
+            LocalDateTime ldt2 = new LocalDateTime(1500, 1, 1, 5, 10, CalendarSystem.Julian);
+
+            Assert.AreEqual(ldt1, LocalDateTime.Max(ldt1, ldt2));
+            Assert.AreEqual(ldt1, LocalDateTime.Max(ldt2, ldt1));
+            Assert.AreEqual(ldt2, LocalDateTime.Min(ldt1, ldt2));
+            Assert.AreEqual(ldt2, LocalDateTime.Min(ldt2, ldt1));
+        }
     }
 }

--- a/src/NodaTime.Test/LocalTimeTest.cs
+++ b/src/NodaTime.Test/LocalTimeTest.cs
@@ -61,5 +61,31 @@ namespace NodaTime.Test
         {
             TestHelper.AssertXmlInvalid<LocalTime>(xml, expectedExceptionType);
         }
+
+        [Test]
+        public void Max()
+        {
+            LocalTime x = new LocalTime(5, 10);
+            LocalTime y = new LocalTime(6, 20);
+            Assert.AreEqual(y, LocalTime.Max(x, y));
+            Assert.AreEqual(y, LocalTime.Max(y, x));
+            Assert.AreEqual(x, LocalTime.Max(x, LocalTime.MinValue));
+            Assert.AreEqual(x, LocalTime.Max(LocalTime.MinValue, x));
+            Assert.AreEqual(LocalTime.MaxValue, LocalTime.Max(LocalTime.MaxValue, x));
+            Assert.AreEqual(LocalTime.MaxValue, LocalTime.Max(x, LocalTime.MaxValue));
+        }
+
+        [Test]
+        public void Min()
+        {
+            LocalTime x = new LocalTime(5, 10);
+            LocalTime y = new LocalTime(6, 20);
+            Assert.AreEqual(x, LocalTime.Min(x, y));
+            Assert.AreEqual(x, LocalTime.Min(y, x));
+            Assert.AreEqual(LocalTime.MinValue, LocalTime.Min(x, LocalTime.MinValue));
+            Assert.AreEqual(LocalTime.MinValue, LocalTime.Min(LocalTime.MinValue, x));
+            Assert.AreEqual(x, LocalTime.Min(LocalTime.MaxValue, x));
+            Assert.AreEqual(x, LocalTime.Min(x, LocalTime.MaxValue));
+        }
     }
 }

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -1190,6 +1190,35 @@ namespace NodaTime
         [Pure]
         internal decimal ToDecimalNanoseconds() => IsInt64Representable ? ToInt64NanosecondsUnchecked() : ((decimal)days) * NanosecondsPerDay + nanoOfDay;
 
+        /// <summary>
+        /// Returns the larger duration of the given two.
+        /// </summary>
+        /// <remarks>
+        /// A "larger" duration is one that advances time by more than a "smaller" one. This means
+        /// that a positive duration is always larger than a negative one, for example. (This is the same
+        /// comparison used by the binary comparison operators.)
+        /// </remarks>
+        /// <param name="x">The first duration to compare.</param>
+        /// <param name="y">The second duration to compare.</param>
+        /// <returns>The larger duration of <paramref name="x"/> or <paramref name="y"/>.</returns>
+        public static Duration Max(Duration x, Duration y)
+        {
+            return x > y ? x : y;
+        }
+
+        /// <summary>
+        /// Returns the smaller duration of the given two.
+        /// </summary>
+        /// <remarks>
+        /// A "larger" duration is one that advances time by more than a "smaller" one. This means
+        /// that a positive duration is always larger than a negative one, for example. (This is the same
+        /// comparison used by the binary comparison operators.)
+        /// </remarks>
+        /// <param name="x">The first duration to compare.</param>
+        /// <param name="y">The second duration to compare.</param>
+        /// <returns>The smaller duration of <paramref name="x"/> or <paramref name="y"/>.</returns>
+        public static Duration Min(Duration x, Duration y) => x < y ? x : y;
+
 #if !NETSTANDARD1_3
         #region Binary serialization
         /// <summary>

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -530,6 +530,32 @@ namespace NodaTime
         }
 
         /// <summary>
+        /// Returns the later date of the given two.
+        /// </summary>
+        /// <param name="x">The first date to compare.</param>
+        /// <param name="y">The second date to compare.</param>
+        /// <exception cref="ArgumentException">The two dates have different calendar systems.</exception>
+        /// <returns>The later date of <paramref name="x"/> or <paramref name="y"/>.</returns>
+        public static LocalDate Max(LocalDate x, LocalDate y)
+        {
+            Preconditions.CheckArgument(x.Calendar.Equals(y.Calendar), nameof(y), "Only values with the same calendar system can be compared");
+            return x > y ? x : y;
+        }
+
+        /// <summary>
+        /// Returns the earlier date of the given two.
+        /// </summary>
+        /// <param name="x">The first date to compare.</param>
+        /// <param name="y">The second date to compare.</param>
+        /// <exception cref="ArgumentException">The two dates have different calendar systems.</exception>
+        /// <returns>The earlier date of <paramref name="x"/> or <paramref name="y"/>.</returns>
+        public static LocalDate Min(LocalDate x, LocalDate y)
+        {
+            Preconditions.CheckArgument(x.Calendar.Equals(y.Calendar), nameof(y), "Only values with the same calendar system can be compared");
+            return x < y ? x : y;
+        }
+
+        /// <summary>
         /// Returns a hash code for this local date.
         /// </summary>
         /// <returns>A hash code for this local date.</returns>

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -868,6 +868,32 @@ namespace NodaTime
             return zone.ResolveLocal(this, resolver);
         }
 
+        /// <summary>
+        /// Returns the later date/time of the given two.
+        /// </summary>
+        /// <param name="x">The first date/time to compare.</param>
+        /// <param name="y">The second date/time to compare.</param>
+        /// <exception cref="ArgumentException">The two date/times have different calendar systems.</exception>
+        /// <returns>The later date/time of <paramref name="x"/> or <paramref name="y"/>.</returns>
+        public static LocalDateTime Max(LocalDateTime x, LocalDateTime y)
+        {
+            Preconditions.CheckArgument(x.Calendar.Equals(y.Calendar), nameof(y), "Only values with the same calendar system can be compared");
+            return x > y ? x : y;
+        }
+
+        /// <summary>
+        /// Returns the earlier date/time of the given two.
+        /// </summary>
+        /// <param name="x">The first date/time to compare.</param>
+        /// <param name="y">The second date/time to compare.</param>
+        /// <exception cref="ArgumentException">The two date/times have different calendar systems.</exception>
+        /// <returns>The earlier date/time of <paramref name="x"/> or <paramref name="y"/>.</returns>
+        public static LocalDateTime Min(LocalDateTime x, LocalDateTime y)
+        {
+            Preconditions.CheckArgument(x.Calendar.Equals(y.Calendar), nameof(y), "Only values with the same calendar system can be compared");
+            return x < y ? x : y;
+        }
+
         #region Formatting
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -690,6 +690,25 @@ namespace NodaTime
         [Pure]
         public LocalDateTime On(LocalDate date) => date + this;
 
+        /// <summary>
+        /// Returns the later time of the given two.
+        /// </summary>
+        /// <param name="x">The first time to compare.</param>
+        /// <param name="y">The second time to compare.</param>
+        /// <returns>The later instant of <paramref name="x"/> or <paramref name="y"/>.</returns>
+        public static LocalTime Max(LocalTime x, LocalTime y)
+        {
+            return x > y ? x : y;
+        }
+
+        /// <summary>
+        /// Returns the earlier time of the given two.
+        /// </summary>
+        /// <param name="x">The first time to compare.</param>
+        /// <param name="y">The second time to compare.</param>
+        /// <returns>The earlier time of <paramref name="x"/> or <paramref name="y"/>.</returns>
+        public static LocalTime Min(LocalTime x, LocalTime y) => x < y ? x : y;
+
         #region Formatting
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.


### PR DESCRIPTION
- Duration
- LocalDate
- LocalDateTime
- LocalTime

These join Offset and Instant that already have the same methods.

OffsetDateTime and ZonedDateTime don't have these as they make less
sense; this mirrors which types have `<` and `>` operators.

Fixes #900.