### PR TITLE
Fix Instant documentation

### DIFF
--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -19,14 +19,9 @@ using NodaTime.Utility;
 namespace NodaTime
 {
     /// <summary>
-    /// Represents an instant on the global timeline.
+    /// Represents an instant on the global timeline, with nanosecond resolution.
     /// </summary>
     /// <remarks>
-    /// <para>
-    /// An instant is defined by an integral number of 'ticks' since the Unix epoch (typically described as January 1st
-    /// 1970, midnight, UTC, ISO calendar), where a tick is equal to 100 nanoseconds. There are 10,000 ticks in a
-    /// millisecond.
-    /// </para>
     /// <para>
     /// An <see cref="Instant"/> has no concept of a particular time zone or calendar: it simply represents a point in
     /// time that can be globally agreed-upon.


### PR DESCRIPTION
Instead of changing the ticks to nanoseconds, I've removed the
implementation-specific part of the documentation. The fact that the
internal representation uses the Unix epoch is now hidden as far as
possible - anything relying on the Unix epoch is very explicit in
the name.

(I've checked through Instant for all occurrences of "tick" and it seems okay.)

Fixes #922.