### PR TITLE
Introduce smoke tests and web site autobuild script

### DIFF
--- a/build/autobuildweb.sh
+++ b/build/autobuildweb.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# This script is designed to be run on a scheduled basis, to build and deploy the web site
+# in an automated manner. It takes the following steps, with input as a
+# "web site build root directory" (henceforth known as $root).
+#
+# - Find the latest commit for the main repo
+# - If $root/$commit exists, assume there have been no changes, and abort
+# - Make a shallow clone (--depth 1) of the main repo to $root/$commit/nodatime
+# - Make a shallow clone (--depth 1) of the nodatime.org repo to $root/$commit/nodatime.org
+# - Run $root/$commit/build/buildweb.sh $root/$commit/nodatime.org
+# - In $root/$commit/nodatime.org
+#   - Create a new commit
+#   - Push to nodatime.org repo
+
+set -e
+
+if [[ "$1" = "" ]]
+then
+  echo "Usage: autobuildweb.sh output-directory"
+  echo "e.g. autobuildweb.sh c:\\users\\jon\\NodaTimeWeb"
+  exit 1
+fi
+
+declare -r root=$1
+declare -r commit=$(curl -H Accept:application/vnd.github.VERSION.sha https://api.github.com/repos/nodatime/nodatime/commits/master)
+
+if [[ -d $root/$commit ]]
+then
+  echo "Directory $root/$commit already exists. Aborting."
+  exit 0
+fi
+
+# Clone repos
+git clone https://github.com/nodatime/nodatime.git --depth 1 $root/$commit/nodatime
+git clone https://github.com/nodatime/nodatime.org.git --depth 1 $root/$commit/nodatime.org
+
+# Build site and run smoke tests
+(cd $root/$commit/nodatime/build; ./buildweb.sh ../../nodatime.org)
+
+echo "Build and test successful. Pushing."
+
+# Commit and push
+git -C $root/$commit/nodatime.org add --all
+git -C $root/$commit/nodatime.org commit -a -m "Regenerate from main repo commit $commit"
+git -C $root/$commit/nodatime.org push

--- a/build/buildweb.sh
+++ b/build/buildweb.sh
@@ -36,3 +36,6 @@ mv tmp/old_nodatime.org/.git $WEB_DIR
 
 # Copy the new site into place
 cp -r ../src/NodaTime.Web/bin/Release/netcoreapp1.0/publish/* $WEB_DIR
+
+# Run a smoke test to check it still works
+(cd $WEB_DIR; dotnet NodaTime.Web.dll --smoke-test)

--- a/src/NodaTime.Web/Program.cs
+++ b/src/NodaTime.Web/Program.cs
@@ -1,11 +1,34 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿// Copyright 2016 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.using System;
+
+using Microsoft.AspNetCore.Hosting;
+using System;
 using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace NodaTime.Web
 {
     public class Program
     {
+        private const string SmokeTestArg = "--smoke-test";
+
         public static void Main(string[] args)
+        {
+            if (args.Contains("--smoke-test"))
+            {
+                RunSmokeTests().GetAwaiter().GetResult();
+            }
+            else
+            {
+                Run(CancellationToken.None);
+            }
+        }
+
+        private static void Run(CancellationToken cancellationToken)
         {
             var host = new WebHostBuilder()
                 // Uncomment these lines if startup is failing
@@ -16,8 +39,77 @@ namespace NodaTime.Web
                 .UseIISIntegration()
                 .UseStartup<Startup>()
                 .Build();
+            host.Run(cancellationToken);
+        }
 
-            host.Run();
+        const int TestDurationSeconds = 15;
+        const int ServerStartupSeconds = 5;
+        const int GracefulShutdownSeconds = 5;
+        const string TestUrlBase = "http://localhost:5000";
+
+        private static async Task RunSmokeTests()
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "smoketests");
+            var cts = new CancellationTokenSource();
+            Task serverTask = Task.Run(() => Run(cts.Token));
+
+            // Give it 5 seconds to come up. We probably don't need this long, but it's harmless.
+            Thread.Sleep(ServerStartupSeconds * 1000);
+
+            bool success = false;
+            try
+            {
+                var testTask = FetchSmokePagesAsync();
+                var completed = await Task.WhenAny(testTask, Task.Delay(TimeSpan.FromSeconds(TestDurationSeconds)));
+                if (testTask != completed)
+                {
+                    throw new Exception($"Tests did not complete in {TestDurationSeconds} seconds");
+                }
+                await testTask;
+                success = true;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Failure: {e.Message}");
+            }
+            // Try to let the server shut down gracefully.
+            cts.Cancel();
+            await Task.WhenAny(serverTask, Task.Delay(GracefulShutdownSeconds));
+
+            Console.WriteLine($"Smoke test complete. Result: {success}");
+            Environment.Exit(success ? 0 : 1);
+        }
+
+        private static async Task FetchSmokePagesAsync()
+        {
+            await ExpectPageText("downloads", "NodaTime-1.0.0.zip");
+            await ExpectPageText("1.0.x/userguide/text", "There are two options for text handling");
+            await ExpectPageText("1.0.x/api/NodaTime.DateTimeZone.html", "The mapping is unambiguous");
+            await ExpectPageText("tzdb/index.txt", "http://nodatime.org/tzdb/tzdb2013h.nzd");
+            await ExpectBinarySize("tzdb/tzdb2013h.nzd", 125962);
+        }
+
+        private static async Task ExpectPageText(string relativeUrl, string expectedText)
+        {
+            var client = new HttpClient();
+            string page = await client.GetStringAsync($"{TestUrlBase}/{relativeUrl}");
+            if (!page.Contains(expectedText))
+            {
+                string start = page.Substring(0, Math.Min(40, page.Length));
+                throw new Exception($"Content of {relativeUrl} did not contain {expectedText}. Start of content: {start}. Content length: {page.Length}");
+            }
+            Console.WriteLine($"Smoke test success for {relativeUrl}");
+        }
+
+        private static async Task ExpectBinarySize(string relativeUrl, int expectedSize)
+        {
+            var client = new HttpClient();
+            byte[] data = await client.GetByteArrayAsync($"{TestUrlBase}/{relativeUrl}");
+            if (data.Length != expectedSize)
+            {
+                throw new Exception($"URL {relativeUrl} returned {data.Length} bytes; expected {expectedSize}");
+            }
+            Console.WriteLine($"Smoke test success for {relativeUrl}");
         }
     }
 }

--- a/src/NodaTime.Web/Startup.cs
+++ b/src/NodaTime.Web/Startup.cs
@@ -147,6 +147,8 @@ namespace NodaTime.Web
             app.ApplicationServices.GetRequiredService<IReleaseRepository>().GetReleases();
             // Force the set of benchmarks to be first loaded on startup.
             app.ApplicationServices.GetRequiredService<IBenchmarkRepository>().ListEnvironments();
+            // Force the set of TZDB data to be first loaded on startup.
+            app.ApplicationServices.GetRequiredService<ITzdbRepository>().GetReleases();
         }
 
         /// Sets the Cache-Control header for static content, conditionally allowing the browser to use the content

--- a/src/NodaTime.Web/appsettings.smoketests.json
+++ b/src/NodaTime.Web/appsettings.smoketests.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Warning",
+      "System": "Warning",
+      "Microsoft": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
I will schedule autobuildweb.sh to be run once every half hour
(excluding the benchmark period if I can). With the smoke tests as
part of the buildweb.sh script, we can be reasonably confident that
this won't break the site...

Fixes #916