### PR TITLE
Copy the docfx directory instead of moving it

### DIFF
--- a/build/buildweb.sh
+++ b/build/buildweb.sh
@@ -18,7 +18,7 @@ if [[ "$2" != "--skip-api" ]]
 then
   ./buildapidocs.sh
   rm -rf ../src/NodaTime.Web/docfx
-  mv tmp/docfx/_site ../src/NodaTime.Web/docfx
+  cp -r tmp/docfx/_site ../src/NodaTime.Web/docfx
 fi
 
 # Build the web site ASP.NET Core


### PR DESCRIPTION
Sometimes moving fails spuriously - this should be more reliable
(though more time-consuming).