### PR TITLE
Early-out for benchmarking

### DIFF
--- a/build/runbenchmarks.sh
+++ b/build/runbenchmarks.sh
@@ -15,18 +15,22 @@ fi
 declare -r REPO=$1
 declare -r RESULTS=$(realpath $2)
 
-shift 2
-
-rm -rf $REPO
-git clone https://github.com/nodatime/nodatime.git $REPO --depth=1
-
-declare -r COMMIT=$(git -C $REPO rev-parse HEAD)
+# We're assuming that the commit doesn't change between this and the clone.
+# There's no obvious way of cloning a repository *at* a particular commit,
+# and as we're only cloning to depth 1, if another commit has been merged,
+# we couldn't check out the original commit anyway.
+declare -r COMMIT=$(curl -H Accept:application/vnd.github.VERSION.sha https://api.github.com/repos/nodatime/nodatime/commits/master)
 
 if [[ -d $RESULTS/$COMMIT ]]
 then
   echo "Benchmarks for commit $COMMIT already run. Exiting."
   exit 0
 fi
+
+shift 2
+
+rm -rf $REPO
+git clone https://github.com/nodatime/nodatime.git $REPO --depth=1
 
 cd $REPO/src
 dotnet restore NodaTime-All.sln


### PR DESCRIPTION
This way we don't clone a repo for no reason.
Fixes #917.