### PR TITLE
Run release builds on Travis

### DIFF
--- a/build/travis.sh
+++ b/build/travis.sh
@@ -2,13 +2,12 @@
 
 set -e
 
-dotnet build src/NodaTime -f netstandard1.3
-dotnet build src/NodaTime.Testing -f netstandard1.3
-dotnet build src/NodaTime.Benchmarks -f netcoreapp1.1
-dotnet build src/NodaTime.Demo -f netcoreapp1.0
-dotnet build src/NodaTime.Test -f netcoreapp1.0
-dotnet run -p src/NodaTime.Test -f netcoreapp1.0 -- --where=cat!=Slow
-dotnet run -p src/NodaTime.Test -f netcoreapp2.0 -- --where=cat!=Slow
+dotnet build -c Release src/NodaTime -f netstandard1.3
+dotnet build -c Release src/NodaTime.Testing -f netstandard1.3
+dotnet build -c Release src/NodaTime.Benchmarks -f netcoreapp1.1
+dotnet build -c Release src/NodaTime.Demo -f netcoreapp1.0
+dotnet run -c Release -p src/NodaTime.Test -f netcoreapp1.0 -- --where=cat!=Slow
+dotnet run -c Release -p src/NodaTime.Test -f netcoreapp2.0 -- --where=cat!=Slow
 dotnet build src/NodaTime.Web -f netcoreapp1.0
 dotnet build src/NodaTime.Web.Test -f netcoreapp1.0
 dotnet run -p src/NodaTime.Web.Test -f netcoreapp1.0


### PR DESCRIPTION
(Also, don't manually build the tests before running them. We were
doing so inconsistently anyway, and the important point is to build
NodaTime first so we see any issues there early.)