### PR TITLE
Add benchmark for LocalDateTime.ToLocalInstant

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateTimeBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateTimeBenchmarks.cs
@@ -147,11 +147,14 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public LocalDateTime MinusMixedPeriod() => (Sample - SampleMixedPeriod);
 
 #if !NO_INTERNALS
-        //        [Benchmark]
-        //        public LocalInstant ToLocalInstant()
-        //        {
-        //            return Sample.ToLocalInstant();
-        //        }
+        [Benchmark]
+        public LocalInstantWrapper ToLocalInstant() => new LocalInstantWrapper(Sample.ToLocalInstant());
+
+        public struct LocalInstantWrapper
+        {
+            private readonly LocalInstant value;
+            internal LocalInstantWrapper(LocalInstant value) => this.value = value;
+        }
 #endif
     }
 }


### PR DESCRIPTION
This has to return a wrapper as LocalInstant is internal.