### PR TITLE
Fix LocalInstant.SafeMinus near start/end of time

### DIFF
--- a/src/NodaTime.Test/InstantTest.cs
+++ b/src/NodaTime.Test/InstantTest.cs
@@ -417,5 +417,58 @@ namespace NodaTime.Test
             TestHelper.AssertValid(Instant.FromUnixTimeTicks, largestValid);
             TestHelper.AssertOutOfRange(Instant.FromUnixTimeTicks, largestValid + 1);
         }
+
+        [Test]
+        public void PlusOffset()
+        {
+            var localInstant = NodaConstants.UnixEpoch.Plus(Offset.FromHours(1));
+            Assert.AreEqual(Duration.FromHours(1), localInstant.TimeSinceLocalEpoch);
+        }
+
+        [Test]
+        public void SafePlus_NormalTime()
+        {
+            var localInstant = NodaConstants.UnixEpoch.SafePlus(Offset.FromHours(1));
+            Assert.AreEqual(Duration.FromHours(1), localInstant.TimeSinceLocalEpoch);
+        }
+
+        [Test]
+        [TestCase(null, 0, null)]
+        [TestCase(null, 1, null)]
+        [TestCase(null, -1, null)]
+        [TestCase(1, -1, 0)]
+        [TestCase(1, -2, null)]
+        [TestCase(2, 1, 3)]
+        public void SafePlus_NearStartOfTime(int? initialOffset, int offsetToAdd, int? finalOffset)
+        {
+            var start = initialOffset == null
+                ? Instant.BeforeMinValue
+                : Instant.MinValue + Duration.FromHours(initialOffset.Value);
+            var expected = finalOffset == null
+                ? LocalInstant.BeforeMinValue
+                : Instant.MinValue.Plus(Offset.FromHours(finalOffset.Value));
+            var actual = start.SafePlus(Offset.FromHours(offsetToAdd));
+            Assert.AreEqual(expected, actual);
+        }
+
+        // A null offset indicates "AfterMaxValue". Otherwise, MaxValue.Plus(offset)
+        [Test]
+        [TestCase(null, 0, null)]
+        [TestCase(null, 1, null)]
+        [TestCase(null, -1, null)]
+        [TestCase(-1, 1, 0)]
+        [TestCase(-1, 2, null)]
+        [TestCase(-2, -1, -3)]
+        public void SafePlus_NearEndOfTime(int? initialOffset, int offsetToAdd, int? finalOffset)
+        {
+            var start = initialOffset == null
+                ? Instant.AfterMaxValue
+                : Instant.MaxValue + Duration.FromHours(initialOffset.Value);
+            var expected = finalOffset == null
+                ? LocalInstant.AfterMaxValue
+                : Instant.MaxValue.Plus(Offset.FromHours(finalOffset.Value));
+            var actual = start.SafePlus(Offset.FromHours(offsetToAdd));
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/src/NodaTime.Test/LocalInstantTest.cs
+++ b/src/NodaTime.Test/LocalInstantTest.cs
@@ -49,5 +49,53 @@ namespace NodaTime.Test
             Assert.AreEqual(InstantPatternParser.BeforeMinValueText, LocalInstant.BeforeMinValue.ToString());
             Assert.AreEqual(InstantPatternParser.AfterMaxValueText, LocalInstant.AfterMaxValue.ToString());
         }
+
+        [Test]
+        public void SafeMinus_NormalTime()
+        {
+            var start = new LocalInstant(0, 0);
+            var end = start.SafeMinus(Offset.FromHours(1));
+            Assert.AreEqual(Duration.FromHours(-1), end.TimeSinceEpoch);
+        }
+
+        // A null offset indicates "BeforeMinValue". Otherwise, MinValue.Plus(offset)
+        [Test]
+        [TestCase(null, 0, null)]
+        [TestCase(null, 1, null)]
+        [TestCase(null, -1, null)]
+        [TestCase(1, 1, 0)]
+        [TestCase(1, 2, null)]
+        [TestCase(2, 1, 1)]
+        public void SafeMinus_NearStartOfTime(int? initialOffset, int offsetToSubtract, int? finalOffset)
+        {
+            var start = initialOffset == null
+                ? LocalInstant.BeforeMinValue
+                : Instant.MinValue.Plus(Offset.FromHours(initialOffset.Value));
+            var expected = finalOffset == null
+                ? Instant.BeforeMinValue
+                : Instant.MinValue + Duration.FromHours(finalOffset.Value);
+            var actual = start.SafeMinus(Offset.FromHours(offsetToSubtract));
+            Assert.AreEqual(expected, actual);
+        }
+
+        // A null offset indicates "AfterMaxValue". Otherwise, MaxValue.Plus(offset)
+        [Test]
+        [TestCase(null, 0, null)]
+        [TestCase(null, 1, null)]
+        [TestCase(null, -1, null)]
+        [TestCase(-1, -1, 0)]
+        [TestCase(-1, -2, null)]
+        [TestCase(-2, -1, -1)]
+        public void SafeMinus_NearEndOfTime(int? initialOffset, int offsetToSubtract, int? finalOffset)
+        {
+            var start = initialOffset == null
+                ? LocalInstant.AfterMaxValue
+                : Instant.MaxValue.Plus(Offset.FromHours(initialOffset.Value));
+            var expected = finalOffset == null
+                ? Instant.AfterMaxValue
+                : Instant.MaxValue + Duration.FromHours(finalOffset.Value);
+            var actual = start.SafeMinus(Offset.FromHours(offsetToSubtract));
+            Assert.AreEqual(expected, actual);
+        }
     }
 }

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -248,6 +248,8 @@ namespace NodaTime
 
         /// <summary>
         /// Adds the given offset to this instant, to return a <see cref="LocalInstant" />.
+        /// A positive offset indicates that the local instant represents a "later local time" than the UTC
+        /// representation of this instant.
         /// </summary>
         /// <remarks>
         /// This was previously an operator+ implementation, but operators can't be internal.

--- a/src/NodaTime/LocalInstant.cs
+++ b/src/NodaTime/LocalInstant.cs
@@ -124,7 +124,7 @@ namespace NodaTime
                 return Instant.AfterMaxValue;
             }
             // Okay, do the arithmetic as a Duration, then check the result for overflow, effectively.
-            var asDuration = duration.PlusSmallNanoseconds(offset.Nanoseconds);
+            var asDuration = duration.MinusSmallNanoseconds(offset.Nanoseconds);
             if (asDuration.FloorDays < Instant.MinDays)
             {
                 return Instant.BeforeMinValue;


### PR DESCRIPTION
Fixes #957.

(Cherry-picked from master.)