### PR TITLE
More coverage of time zone code

### DIFF
--- a/src/NodaTime.Test/Extensions/ClockExtensionsTest.cs
+++ b/src/NodaTime.Test/Extensions/ClockExtensionsTest.cs
@@ -3,8 +3,10 @@
 // as found in the LICENSE.txt file.
 
 using NodaTime.Extensions;
+using NodaTime.Test.TimeZones;
 using NodaTime.Testing;
 using NUnit.Framework;
+using System;
 
 namespace NodaTime.Test.Extensions
 {
@@ -39,6 +41,34 @@ namespace NodaTime.Test.Extensions
             Assert.AreEqual(zonedEpoch, zoned.GetCurrentZonedDateTime());
         }
 
-        // No tests for system default
+#if !NETCOREAPP1_0
+        [Test]
+        public void InTzdbSystemDefaultZone()
+        {
+            var fakeGreenlandZone = TimeZoneInfo.CreateCustomTimeZone("Greenland Standard Time", TimeSpan.FromHours(-3), "Godthab", "Godthab");
+            using (TimeZoneInfoReplacer.Replace(fakeGreenlandZone, fakeGreenlandZone))
+            {
+                var clock = new FakeClock(NodaConstants.UnixEpoch);
+                var zonedClock = clock.InTzdbSystemDefaultZone();
+                var expected = NodaConstants.UnixEpoch.InZone(DateTimeZoneProviders.Tzdb["America/Godthab"]);
+                Assert.AreEqual(expected, zonedClock.GetCurrentZonedDateTime());
+            }
+        }
+#endif
+
+#if NET451
+        [Test]
+        public void InBclSystemDefaultZone()
+        {
+            // We can't replace DateTimeZoneProviders.Bcl with TimeZoneInfoReplacer, so we have to
+            // just trust that there's a suitable system default zone.
+
+            var zone = DateTimeZoneProviders.Bcl.GetSystemDefault();
+            var clock = new FakeClock(NodaConstants.UnixEpoch);
+            var zonedClock = clock.InBclSystemDefaultZone();
+            var expected = NodaConstants.UnixEpoch.InZone(zone);
+            Assert.AreEqual(expected, zonedClock.GetCurrentZonedDateTime());
+        }
+#endif
     }
 }

--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneSourceTest.cs
@@ -93,6 +93,34 @@ namespace NodaTime.Test.TimeZones
             var nonBclZones = provider.Ids.Select(id => provider[id]).Where(zone => !(zone is BclDateTimeZone));
             Assert.IsEmpty(nonBclZones);
         }
+
+        [Test]
+        public void LocalZoneIsNotSystemZone()
+        {
+            var systemZone = TimeZoneInfo.CreateCustomTimeZone("Normal zone", TimeSpan.Zero, "Display", "Standard");
+            var localZone = TimeZoneInfo.CreateCustomTimeZone("Local zone not in system zones", TimeSpan.FromHours(5), "Foo", "Bar");
+            using (TimeZoneInfoReplacer.Replace(localZone, systemZone))
+            {
+                var source = new BclDateTimeZoneSource();
+                CollectionAssert.AreEqual(new[] { systemZone.Id }, source.GetIds().ToList());
+
+                // We can't look it up later, but we can still find it...
+                Assert.AreEqual(localZone.Id, source.GetSystemDefaultId());
+            }
+        }
+
+        [Test]
+        public void LocalZoneIsNull()
+        {
+            var systemZone = TimeZoneInfo.CreateCustomTimeZone("Normal zone", TimeSpan.Zero, "Display", "Standard");
+            using (TimeZoneInfoReplacer.Replace(null, systemZone))
+            {
+                var source = new BclDateTimeZoneSource();
+                CollectionAssert.AreEqual(new[] { systemZone.Id }, source.GetIds().ToList());
+                Assert.Null(source.GetSystemDefaultId());
+
+            }
+        }
     }
 }
 #endif

--- a/src/NodaTime.Test/TimeZones/TimeZoneInfoReplacer.cs
+++ b/src/NodaTime.Test/TimeZones/TimeZoneInfoReplacer.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2012 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.TimeZones;
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace NodaTime.Test.TimeZones
+{
+    /// <summary>
+    /// Class used to temporarily replace the shim used by <see cref="TimeZoneInfoInterceptor"/>,
+    /// for test purposes. On disposal, the original is restored.
+    /// </summary>
+    internal class TimeZoneInfoReplacer : IDisposable, TimeZoneInfoInterceptor.ITimeZoneInfoShim
+    {
+        private readonly TimeZoneInfoInterceptor.ITimeZoneInfoShim originalShim;
+        private readonly ReadOnlyCollection<TimeZoneInfo> zones;
+
+        public TimeZoneInfo Local { get; }
+
+        private TimeZoneInfoReplacer(TimeZoneInfo local, ReadOnlyCollection<TimeZoneInfo> zones)
+        {
+            originalShim = TimeZoneInfoInterceptor.Shim;
+            Local = local;
+            this.zones = zones;
+            TimeZoneInfoInterceptor.Shim = this;
+
+        }
+
+        internal static IDisposable Replace(TimeZoneInfo local, params TimeZoneInfo[] allZones) =>
+            new TimeZoneInfoReplacer(local, allZones.ToList().AsReadOnly());
+
+        public TimeZoneInfo FindSystemTimeZoneById(string id)
+        {
+            var zone = zones.FirstOrDefault(z => z.Id == id);
+            if (zone != null)
+            {
+                return zone;
+            }
+#if NETCORE
+            // TimeZoneNotFoundException doesn't exist in netstandard. We're unlikely to use
+            // this method in non-NET45 tests anyway, as it's only used in BclDateTimeZoneSource.
+            throw new Exception($"No such time zone: {id}");
+#else
+            throw new TimeZoneNotFoundException($"No such time zone: {id}");
+#endif
+        }
+
+        public ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones() => zones;
+
+        public void Dispose() => TimeZoneInfoInterceptor.Shim = originalShim;
+    }
+}

--- a/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
@@ -277,9 +277,14 @@ namespace NodaTime.Test.TimeZones
         public void MapTimeZoneInfoId(string timeZoneInfoId, int standardUtc, string expectedId)
         {
             var zoneInfo = TimeZoneInfo.CreateCustomTimeZone(timeZoneInfoId, TimeSpan.FromHours(standardUtc),
-                "Ignored display name", "Ignored standard display name");
+                "Ignored display name", "Standard name for " + timeZoneInfoId);
             var mappedId = TzdbDateTimeZoneSource.Default.MapTimeZoneInfoId(zoneInfo);
             Assert.AreEqual(expectedId, mappedId);
+
+            // Do it again, and expect to get the same result again.
+            // In the case of the "Lilo and Stitch" zone, this means hitting the cache rather than guessing
+            // via transitions again.
+            Assert.AreEqual(mappedId, TzdbDateTimeZoneSource.Default.MapTimeZoneInfoId(zoneInfo));
         }
 #endif
     }

--- a/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
+++ b/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
     <ProjectReference Include="..\NodaTime.TzdbCompiler\NodaTime.TzdbCompiler.csproj" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="NUnitLite" Version="3.6.1" />
+    <PackageReference Include="NUnit" Version="3.8.0" />
+    <PackageReference Include="NUnitLite" Version="3.8.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NodaTime/TimeZones/BclDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZone.cs
@@ -304,7 +304,7 @@ namespace NodaTime.TimeZones
         /// <see cref="TimeZoneInfo.Local"/>.</returns>
         [NotNull] public static BclDateTimeZone ForSystemDefault()
         {
-            TimeZoneInfo local = TimeZoneInfo.Local;
+            TimeZoneInfo local = TimeZoneInfoInterceptor.Local;
             BclDateTimeZone currentSystemDefault = systemDefault;
 
             // Cached copy is out of date - wrap a new one

--- a/src/NodaTime/TimeZones/IO/TzdbStreamData.cs
+++ b/src/NodaTime/TimeZones/IO/TzdbStreamData.cs
@@ -102,7 +102,7 @@ namespace NodaTime.TimeZones.IO
                     case DateTimeZoneWriter.DateTimeZoneType.Precalculated:
                         return CachedDateTimeZone.ForZone(PrecalculatedDateTimeZone.Read(reader, id));
                     default:
-                            throw new InvalidNodaDataException("Unknown time zone type " + type);
+                        throw new InvalidNodaDataException("Unknown time zone type " + type);
                 }
             }
         }

--- a/src/NodaTime/TimeZones/TimeZoneInfoInterceptor.cs
+++ b/src/NodaTime/TimeZones/TimeZoneInfoInterceptor.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+using System.Collections.ObjectModel;
+
+namespace NodaTime.TimeZones
+{
+    /// <summary>
+    /// Interception for TimeZoneInfo static methods. These are still represented as
+    /// static methods in this class, but they're implemented via a replacable shim, which
+    /// by default delegates to the static methods in TimeZoneInfo.
+    /// </summary>
+    internal static class TimeZoneInfoInterceptor
+    {
+        /// <summary>
+        /// The shim to use for all the static methods. We don't care about thread safety here,
+        /// beyond "it must be correct when used in production" - it's only ever changed in tests,
+        /// which are single-threaded anyway.
+        /// </summary>
+        internal static ITimeZoneInfoShim Shim { get; set; } = new BclShim();
+
+        internal static TimeZoneInfo Local => Shim.Local;
+        internal static TimeZoneInfo FindSystemTimeZoneById(string id) => Shim.FindSystemTimeZoneById(id);
+        internal static ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones() => Shim.GetSystemTimeZones();
+
+        internal interface ITimeZoneInfoShim
+        {
+            TimeZoneInfo Local { get; }
+            TimeZoneInfo FindSystemTimeZoneById(string id);
+            ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones();
+        }
+
+        /// <summary>
+        /// Implementation that just delegates in a simple manner.
+        /// </summary>
+        private class BclShim : ITimeZoneInfoShim
+        {
+            public TimeZoneInfo Local => TimeZoneInfo.Local;
+
+            public TimeZoneInfo FindSystemTimeZoneById(string id) => TimeZoneInfo.FindSystemTimeZoneById(id);
+
+            public ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones() => TimeZoneInfo.GetSystemTimeZones();
+        }
+    }
+}

--- a/src/NodaTime/TimeZones/TzdbDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/TzdbDateTimeZoneSource.cs
@@ -196,7 +196,7 @@ namespace NodaTime.TimeZones
         [NotNull] public IEnumerable<string> GetIds() => CanonicalIdMap.Keys;
 
         /// <inheritdoc />
-        [CanBeNull] public string GetSystemDefaultId() => MapTimeZoneInfoId(TimeZoneInfo.Local);
+        [CanBeNull] public string GetSystemDefaultId() => MapTimeZoneInfoId(TimeZoneInfoInterceptor.Local);
 
         [VisibleForTesting]
         internal string MapTimeZoneInfoId(TimeZoneInfo timeZone)


### PR DESCRIPTION
The important change introduced here is an interceptor for TimeZoneInfo calls.
Is this too heavy-weight given that there aren't many tests that rely on it?
(Many of the tests introduced in this PR *don't* depend on the introduction of the interceptor. Let me know if you'd like me to split them out into separate commits.)

This PR also fixes a bug where if you ask for the system default time zone in an environment where TimeZoneInfo.Local returns null, we blew up with a NullReferenceException instead of a DateTimeZoneNotFoundException. I think it's sufficiently corner-casey that we don't need to patch 2.2.

The remaining uncovered lines are pretty much all for time zone IO. We have the time zone *reading* code in NodaTime.dll, but the *writing* code is all in NodaTime.TzdbCompiler. We could move just FieldCollection and Field into NodaTime.dll, at which point it would be easier to test TzdbDateTimeZoneSource.Validate and TzdbStreamData.