### PR TITLE
More text tests

### DIFF
--- a/src/NodaTime.Test/Text/DurationPatternTest.cs
+++ b/src/NodaTime.Test/Text/DurationPatternTest.cs
@@ -36,6 +36,7 @@ namespace NodaTime.Test.Text
         internal static readonly Data[] InvalidPatternData = {
             new Data { Pattern = "", Message = Messages.Parse_FormatStringEmpty },
             new Data { Pattern = "HH:MM", Message = Messages.Parse_MultipleCapitalDurationFields },
+            new Data { Pattern = "HH D", Message = Messages.Parse_MultipleCapitalDurationFields },
             new Data { Pattern = "MM mm", Message = Messages.Parse_RepeatedFieldInPattern, Parameters = { 'm' } },
             new Data { Pattern = "G", Message = Messages.Parse_UnknownStandardFormat, Parameters = { 'G', typeof(Duration) } },
         };
@@ -72,6 +73,7 @@ namespace NodaTime.Test.Text
                 Message = Messages.Parse_OverallValueOutOfRange, Parameters = { typeof(Duration) } },
             new Data(Duration.MinValue) { Pattern = "-S.fffffffff", Text = "1449551462400.000000000",
                 Message = Messages.Parse_OverallValueOutOfRange, Parameters = { typeof(Duration) } },
+            new Data(Duration.MinValue) { Pattern = "'x'S", Text = "x", Message = Messages.Parse_MismatchedNumber, Parameters = { "S" } },
         };
 
         /// <summary>

--- a/src/NodaTime.Test/Text/LocalTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalTimePatternTest.cs
@@ -49,6 +49,7 @@ namespace NodaTime.Test.Text
         internal static Data[] ParseFailureData = {
             new Data { Text = "17 6", Pattern = "HH h", Message = Messages.Parse_InconsistentValues2, Parameters = {'H', 'h', typeof(LocalTime).FullName}},
             new Data { Text = "17 AM", Pattern = "HH tt", Message = Messages.Parse_InconsistentValues2, Parameters = {'H', 't', typeof(LocalTime).FullName}},
+            new Data { Text = "5 foo", Pattern = "h t", Message = Messages.Parse_MissingAmPmDesignator},
             new Data { Text = "04.", Pattern = "ss.FF", Message = Messages.Parse_MismatchedNumber, Parameters = { "FF" } },
             new Data { Text = "04.", Pattern = "ss.ff", Message = Messages.Parse_MismatchedNumber, Parameters = { "ff" } },
             new Data { Text = "05 Foo", Pattern = "HH tt", Message = Messages.Parse_MissingAmPmDesignator }
@@ -256,6 +257,8 @@ namespace NodaTime.Test.Text
             new Data(6, 0, 0) { Culture = Cultures.EnUs, Text = "6", Pattern = "%h" },
             new Data(0, 0, 0) { Culture = Cultures.EnUs, Text = "AM", Pattern = "tt" },
             new Data(12, 0, 0) { Culture = Cultures.EnUs, Text = "PM", Pattern = "tt" },
+            new Data(0, 0, 0) { Culture = Cultures.EnUs, Text = "A", Pattern = "%t" },
+            new Data(12, 0, 0) { Culture = Cultures.EnUs, Text = "P", Pattern = "%t" },
 
             // Pattern specifies nothing - template value is passed through
             new Data(LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5)) { Culture = Cultures.EnUs, Text = "*", Pattern = "%*", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },

--- a/src/NodaTime.Test/Text/OffsetDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/OffsetDateTimePatternTest.cs
@@ -116,6 +116,9 @@ namespace NodaTime.Test.Text
 
             // Check that unquoted T still works.
             new Data(2012, 1, 31, 17, 36, 45) { Text = "2012-01-31T17:36:45", Pattern = "yyyy-MM-ddTHH:mm:ss" },
+
+            // Fields not otherwise covered
+            new Data(MsdnStandardExample) { Pattern = "d MMMM yyyy (g) h:mm:ss.FF tt o<g>", Text = "15 June 2009 (A.D.) 1:45:30.09 PM +01" },
         };
 
         internal static IEnumerable<Data> ParseData = ParseOnlyData.Concat(FormatAndParseData);

--- a/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
@@ -229,6 +229,9 @@ namespace NodaTime.Test.Text
 
             // Check that unquoted T still works.
             new Data(2012, 1, 31, 17, 36, 45) { Text = "2012-01-31T17:36:45", Pattern = "yyyy-MM-ddTHH:mm:ss" },
+
+            // Fields not otherwise covered (according to tests running on AppVeyor...)
+            new Data(MsdnStandardExample) { Pattern = "d MMMM yyyy (g) h:mm:ss.FF tt", Text = "15 June 2009 (A.D.) 1:45:30.09 PM" },
         };
 
         internal static IEnumerable<Data> ParseData = ParseOnlyData.Concat(FormatAndParseData);


### PR DESCRIPTION
Locally I see full coverage (as far as possible) for the Text
and Text.Patterns namespace. On AppVeyor it's different, and I'm not
sure why. These should help a bit...