### PR TITLE
Fetch docfx version explicitly

### DIFF
--- a/build/DocfxAnnotationGenerator/Program.cs
+++ b/build/DocfxAnnotationGenerator/Program.cs
@@ -139,6 +139,7 @@ namespace DocfxAnnotationGenerator
                 {
                     using (var writer = File.CreateText(pair.Key))
                     {
+                        writer.WriteLine("### YamlMime:ManagedReference");
                         pair.Value.Save(writer, false);
                     }
                 }

--- a/build/buildapidocs.sh
+++ b/build/buildapidocs.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+source docfx_functions.sh
+install_docfx
+
 if [[ ! -d history ]]
 then
   echo "Cloning history branch"
@@ -36,7 +39,7 @@ cd ../../../..
 
 cp -r docfx/template tmp/docfx
 cp docfx/docfx-unstable.json tmp/docfx/docfx.json
-docfx metadata tmp/docfx/docfx.json -f 
+"$DOCFX" metadata tmp/docfx/docfx.json -f 
 cp docfx/toc.yml tmp/docfx/obj/unstable
 
 # Create diffs between versions and other annotations
@@ -63,5 +66,5 @@ dotnet build ../src/NodaTime-All.sln
 dotnet run -p SnippetExtractor -- ../src/NodaTime.Demo/NodaTime.Demo.csproj tmp/docfx/obj/unstable/overwrite
 
 echo "Running main docfx build"
-docfx build tmp/docfx/docfx.json
+"$DOCFX" build tmp/docfx/docfx.json
 cp docfx/logo.svg tmp/docfx/_site

--- a/build/buildhistory.sh
+++ b/build/buildhistory.sh
@@ -34,6 +34,9 @@
 
 set -e
 
+source docfx_functions.sh
+install_docfx
+
 echo "Removing old history directory"
 rm -rf history
 
@@ -132,7 +135,7 @@ cp packages/NodaTime.Serialization.JsonNet-2.0.x.nupkg packages/NodaTime.Seriali
 for version in 1.0.x 1.1.x 1.2.x 1.3.x 1.4.x 2.0.x 2.1.x 2.2.x; do
   echo "Building docfx metadata for $version"
   cp ../docfx/docfx-$version.json $version/docfx.json
-  docfx metadata $version/docfx.json -f
+  "$DOCFX" metadata $version/docfx.json -f
 done
 
 # We don't need TZDB/CLDR/versionXML, or docs, or

--- a/build/docfx_functions.sh
+++ b/build/docfx_functions.sh
@@ -1,0 +1,23 @@
+# This is intended to be imported using the "source" function from
+# any scripts that use tools.
+
+declare -r BUILD_ROOT=$(realpath $(dirname ${BASH_SOURCE}))
+declare -r DOCFX_VERSION=2.25.2
+
+# Path to the version of docfx to use
+declare -r DOCFX="$BUILD_ROOT/packages/docfx-$DOCFX_VERSION/docfx.exe"
+
+# Function to install docfx if it's not already installed.
+install_docfx() {
+  if [[ ! -f $DOCFX ]]
+  then
+    (echo "Fetching docfx v${DOCFX_VERSION}";
+     mkdir -p $BUILD_ROOT/packages;
+     cd $BUILD_ROOT/packages;
+     mkdir docfx-$DOCFX_VERSION;
+     cd docfx-$DOCFX_VERSION;
+     curl -sSL https://github.com/dotnet/docfx/releases/download/v${DOCFX_VERSION}/docfx.zip -o tmp.zip;
+     unzip -q tmp.zip;
+     rm tmp.zip)
+  fi
+}


### PR DESCRIPTION
The change to the annotation generator is due to a new version of
docfx which expects a comment at the start of each yml file (but the
comment isn't preserved by a load/save cycle).

I've got the history branch ready to push just before I merge this PR.

Fixes #938.