### PR TITLE
Update TZDB downloads to https

### DIFF
--- a/src/NodaTime.Web/Models/TzdbDownload.cs
+++ b/src/NodaTime.Web/Models/TzdbDownload.cs
@@ -19,7 +19,7 @@ namespace NodaTime.Web.Models
         public TzdbDownload(string storageUrl)
         {
             Name = Path.GetFileName(new Uri(storageUrl).LocalPath);
-            NodaTimeOrgUrl = $"http://nodatime.org/tzdb/{Name}";
+            NodaTimeOrgUrl = $"https://nodatime.org/tzdb/{Name}";
             data = new Lazy<byte[]>(
                 () => httpClient.GetByteArrayAsync(storageUrl).Result,
                 LazyThreadSafetyMode.ExecutionAndPublication);

--- a/src/NodaTime.Web/Program.cs
+++ b/src/NodaTime.Web/Program.cs
@@ -85,7 +85,7 @@ namespace NodaTime.Web
             await ExpectPageText("downloads", "NodaTime-1.0.0.zip");
             await ExpectPageText("1.0.x/userguide/text", "There are two options for text handling");
             await ExpectPageText("1.0.x/api/NodaTime.DateTimeZone.html", "The mapping is unambiguous");
-            await ExpectPageText("tzdb/index.txt", "http://nodatime.org/tzdb/tzdb2013h.nzd");
+            await ExpectPageText("tzdb/index.txt", "https://nodatime.org/tzdb/tzdb2013h.nzd");
             await ExpectBinarySize("tzdb/tzdb2013h.nzd", 125962);
         }
 


### PR DESCRIPTION
I have a slight concern that this may trigger clients to get
confused, thinking that something's changed but then being surprised
when nothing has.

One option would be to use http for anything at or prior to 2017c,
but https from 2017d onwards.

Fixes #999. (I believe this is all there is left.)
