### PR TITLE
Document exception behavior for Period

### DIFF
--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -111,6 +111,14 @@ namespace NodaTime.Test
         }
 
         [Test]
+        public void BetweenLocalDates_DifferentCalendarSystems_Throws()
+        {
+            LocalDate start = new LocalDate(2017, 11, 1, CalendarSystem.Coptic);
+            LocalDate end = new LocalDate(2017, 11, 5, CalendarSystem.Gregorian);    
+            Assert.Throws<ArgumentException>(() => Period.Between(start, end));
+        }
+
+        [Test]
         [TestCase("2016-05-16", "2019-03-13", PeriodUnits.Years, 2)]
         [TestCase("2016-05-16", "2017-07-13", PeriodUnits.Months, 13)]
         [TestCase("2016-05-16", "2016-07-13", PeriodUnits.Weeks, 8)]

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -368,7 +368,7 @@ namespace NodaTime
         /// <param name="rhs">The date to subtract</param>
         /// <returns>The result of subtracting one date from another.</returns>
         /// <exception cref="ArgumentException">
-        /// <paramref name="lhs"/> and <paramref name="rhs"/> don't have the same calendar system.
+        /// <paramref name="lhs"/> and <paramref name="rhs"/> are not in the same calendar system.
         /// </exception>
         [NotNull] public static Period operator -(LocalDate lhs, LocalDate rhs) => Period.Between(rhs, lhs);
 

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -362,11 +362,14 @@ namespace NodaTime
         /// </summary>
         /// <remarks>
         /// This is simply a convenience operator for calling <see cref="Period.Between(NodaTime.LocalDate,NodaTime.LocalDate)"/>.
-        /// The calendar systems of the two dates must be the same.
+        /// The calendar systems of the two dates must be the same; an exception will be thrown otherwise.
         /// </remarks>
         /// <param name="lhs">The date to subtract from</param>
         /// <param name="rhs">The date to subtract</param>
         /// <returns>The result of subtracting one date from another.</returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="lhs"/> and <paramref name="rhs"/> don't have the same calendar system.
+        /// </exception>
         [NotNull] public static Period operator -(LocalDate lhs, LocalDate rhs) => Period.Between(rhs, lhs);
 
         /// <summary>

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -661,7 +661,7 @@ namespace NodaTime
         /// <param name="end">End date</param>
         /// <returns>The period between the two dates, using year, month and day units.</returns>
         /// <exception cref="ArgumentException">
-        /// When <paramref name="start"/> and <paramref name="end"/> don't have the same calendar system.
+        /// <paramref name="start"/> and <paramref name="end"/> are not in the same calendar system.
         /// </exception>
         [Pure]
         [NotNull]

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -655,10 +655,14 @@ namespace NodaTime
         /// <remarks>
         /// If <paramref name="end"/> is before <paramref name="start" />, each property in the returned period
         /// will be negative.
+        /// The calendar systems of the two dates must be the same; an exception will be thrown otherwise.
         /// </remarks>
         /// <param name="start">Start date</param>
         /// <param name="end">End date</param>
         /// <returns>The period between the two dates, using year, month and day units.</returns>
+        /// <exception cref="ArgumentException">
+        /// When <paramref name="start"/> and <paramref name="end"/> don't have the same calendar system.
+        /// </exception>
         [Pure]
         [NotNull]
         public static Period Between(LocalDate start, LocalDate end) => Between(start, end, PeriodUnits.YearMonthDay);


### PR DESCRIPTION
Ok, trying to address #299.

I've just edited the xml documentation for the `Between` method in `Period` and for the "-" operator in `LocalDate`, and also added a small unit test asserting that the exception is being thrown.