### PR TITLE
Don't add exception docs for NotNull out parameters

### DIFF
--- a/build/DocfxAnnotationGenerator/ReflectionMember.cs
+++ b/build/DocfxAnnotationGenerator/ReflectionMember.cs
@@ -90,7 +90,7 @@ namespace DocfxAnnotationGenerator
         {
             DocfxUid = GetUid(method);
             NotNullReturn = HasNotNullAttribute(method);
-            NotNullParameters = method.Parameters.Where(p => HasNotNullAttribute(p)).Select(p => p.Name).ToList();
+            NotNullParameters = method.Parameters.Where(p => HasNotNullAttribute(p) && !p.IsOut).Select(p => p.Name).ToList();
         }
 
         private ReflectionMember(FieldDefinition field)


### PR DESCRIPTION
At some point we *may* want to automatically append something in the
parameter doc (to say that it won't be null on return) but that's
pretty low priority.

Fixes #1019.