### PR TITLE
Add Deconstruct method to selected types

### DIFF
--- a/src/NodaTime.Test/DateIntervalTest.cs
+++ b/src/NodaTime.Test/DateIntervalTest.cs
@@ -192,5 +192,21 @@ namespace NodaTime.Test
             var candidate = new LocalDate(2000, 1, 1, JulianCalendar);
             Assert.Throws<ArgumentException>(() => interval.Contains(candidate));
         }
+
+        [Test]
+        public void Deconstruction()
+        {
+            var start = new LocalDate(2017, 11, 6);
+            var end = new LocalDate(2017, 11, 10);
+            var value = new DateInterval(start, end);
+
+            var (actualStart, actualEnd) = value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(start, actualStart);
+                Assert.AreEqual(end, actualEnd);
+            });
+        }
     }
 }

--- a/src/NodaTime.Test/IntervalTest.cs
+++ b/src/NodaTime.Test/IntervalTest.cs
@@ -271,5 +271,43 @@ namespace NodaTime.Test
             // This would have been true under Noda Time 1.x
             Assert.IsFalse(interval.Contains(instant));
         }
+
+        [Test]
+        public void Deconstruction()
+        {
+            var start = new Instant();
+            var end = start.PlusTicks(1_000_000);
+            var value = new Interval(start, end);
+
+            (Instant? actualStart, Instant? actualEnd) = value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(start, actualStart);
+                Assert.AreEqual(end, actualEnd);
+            });
+        }
+
+        [Test]
+        public void Deconstruction_NullStart_Throws()
+        {
+            Instant? start = null;
+            var end = new Instant(1000, 1500);
+            var value = new Interval(start, end);
+
+            Assert.That(
+                () => value.Deconstruct(out Instant actualStart, out Instant actualEnd),
+                Throws.TypeOf<InvalidOperationException>());
+        }
+
+        [Test]
+        public void Deconstruction_NullEnding_Throws()
+        {
+            var value = new Interval(new Instant(1500, 2000), null);
+
+            Assert.That(
+                () => value.Deconstruct(out Instant actualStart, out Instant actualEnd),
+                Throws.TypeOf<InvalidOperationException>());
+        }
     }
 }

--- a/src/NodaTime.Test/IntervalTest.cs
+++ b/src/NodaTime.Test/IntervalTest.cs
@@ -287,27 +287,37 @@ namespace NodaTime.Test
                 Assert.AreEqual(end, actualEnd);
             });
         }
-
+        
         [Test]
-        public void Deconstruction_NullStart_Throws()
+        public void Deconstruction_IntervalWithoutStart()
         {
             Instant? start = null;
-            var end = new Instant(1000, 1500);
+            var end = new Instant(1500, 1_000_000);
             var value = new Interval(start, end);
 
-            Assert.That(
-                () => value.Deconstruct(out Instant actualStart, out Instant actualEnd),
-                Throws.TypeOf<InvalidOperationException>());
+            (Instant? actualStart, Instant? actualEnd) = value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(start, actualStart);
+                Assert.AreEqual(end, actualEnd);
+            });
         }
 
         [Test]
-        public void Deconstruction_NullEnding_Throws()
+        public void Deconstruction_IntervalWithoutEnd()
         {
-            var value = new Interval(new Instant(1500, 2000), null);
+            var start = new Instant(1500, 1_000_000);
+            Instant? end = null;
+            var value = new Interval(start, end);
 
-            Assert.That(
-                () => value.Deconstruct(out Instant actualStart, out Instant actualEnd),
-                Throws.TypeOf<InvalidOperationException>());
+            (Instant? actualStart, Instant? actualEnd) = value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(start, actualStart);
+                Assert.AreEqual(end, actualEnd);
+            });
         }
     }
 }

--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -456,5 +456,21 @@ namespace NodaTime.Test
             Assert.AreEqual(ldt2, LocalDateTime.Min(ldt1, ldt2));
             Assert.AreEqual(ldt2, LocalDateTime.Min(ldt2, ldt1));
         }
+
+        [Test]
+        public void Deconstruction()
+        {
+            var value = new LocalDateTime(2017, 10, 15, 21, 30, 0);
+            var expectedDate = new LocalDate(2017, 10, 15);
+            var expectedTime = new LocalTime(21, 30, 0);
+
+            var (actualDate, actualTime) = value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expectedDate, actualDate);
+                Assert.AreEqual(expectedTime, actualTime);
+            });
+        }
     }
 }

--- a/src/NodaTime.Test/LocalTimeTest.cs
+++ b/src/NodaTime.Test/LocalTimeTest.cs
@@ -101,6 +101,24 @@ namespace NodaTime.Test
         }
 
         [Test]
+        public void Deconstruction()
+        {
+            var value = new LocalTime(15, 8, 20);
+            var expectedHour = 15;
+            var expectedMinute = 8;
+            var expectedSecond = 20;
+
+            var (actualHour, actualMinute, actualSecond) = value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expectedHour, actualHour);
+                Assert.AreEqual(expectedMinute, actualMinute);
+                Assert.AreEqual(expectedSecond, actualSecond);
+            });
+        }
+
+        [Test]
         public void WithOffset()
         {
             var time = new LocalTime(3, 45, 12, 34);

--- a/src/NodaTime.Test/LocalTimeTest.cs
+++ b/src/NodaTime.Test/LocalTimeTest.cs
@@ -126,23 +126,5 @@ namespace NodaTime.Test
             var expected = new OffsetTime(time, offset);
             Assert.AreEqual(expected, time.WithOffset(offset));
         }
-
-        [Test]
-        public void Deconstruction()
-        {
-            var value = new LocalTime(15, 8, 20);
-            var expectedHour = 15;
-            var expectedMinute = 8;
-            var expectedSecond = 20;
-
-            var (actualHour, actualMinute, actualSecond) = value;
-
-            Assert.Multiple(() =>
-            {
-                Assert.AreEqual(expectedHour, actualHour);
-                Assert.AreEqual(expectedMinute, actualMinute);
-                Assert.AreEqual(expectedSecond, actualSecond);
-            });
-        }
     }
 }

--- a/src/NodaTime.Test/LocalTimeTest.cs
+++ b/src/NodaTime.Test/LocalTimeTest.cs
@@ -126,5 +126,23 @@ namespace NodaTime.Test
             var expected = new OffsetTime(time, offset);
             Assert.AreEqual(expected, time.WithOffset(offset));
         }
+
+        [Test]
+        public void Deconstruction()
+        {
+            var value = new LocalTime(15, 8, 20);
+            var expectedHour = 15;
+            var expectedMinute = 8;
+            var expectedSecond = 20;
+
+            var (actualHour, actualMinute, actualSecond) = value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expectedHour, actualHour);
+                Assert.AreEqual(expectedMinute, actualMinute);
+                Assert.AreEqual(expectedSecond, actualSecond);
+            });
+        }
     }
 }

--- a/src/NodaTime.Test/OffsetDateTest.cs
+++ b/src/NodaTime.Test/OffsetDateTest.cs
@@ -132,5 +132,21 @@ namespace NodaTime.Test
                 Assert.AreEqual("2012-10-06+01", offsetDate.ToString());
             }
         }
+
+        [Test]
+        public void Deconstruction()
+        {
+            LocalDate date = new LocalDate(2015, 3, 28);
+            Offset offset = Offset.FromHours(-2);
+            OffsetDate offsetDate = new OffsetDate(date, offset);
+
+            var (actualDate, actualOffset) = offsetDate;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(date, actualDate);
+                Assert.AreEqual(offset, actualOffset);
+            });
+        }
     }
 }

--- a/src/NodaTime.Test/OffsetDateTimeTest.cs
+++ b/src/NodaTime.Test/OffsetDateTimeTest.cs
@@ -504,6 +504,41 @@ namespace NodaTime.Test
         }
 
         [Test]
+        public void Deconstruction()
+        {
+            var dateTime = new LocalDateTime(2017, 10, 15, 21, 30);
+            var offset = Offset.FromHours(-2);
+            var value = new OffsetDateTime(dateTime, offset);
+
+            var (actualDateTime, actualOffset) = value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(dateTime, actualDateTime);
+                Assert.AreEqual(offset, actualOffset);
+            });
+        }
+
+        [Test]
+        public void MoreGranularDeconstruction()
+        {
+            var date = new LocalDate(2017, 10, 15);
+            var time = new LocalTime(21, 30, 15);
+            var offset = Offset.FromHours(-2);
+
+            var value = new OffsetDateTime(date.At(time), offset);
+
+            var (actualDate, actualTime, actualOffset) = value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(date, actualDate);
+                Assert.AreEqual(time, actualTime);
+                Assert.AreEqual(offset, actualOffset);
+            });
+        }
+
+        [Test]
         public void ToOffsetDate()
         {
             var offset = Offset.FromHoursAndMinutes(2, 30);

--- a/src/NodaTime.Test/OffsetTimeTest.cs
+++ b/src/NodaTime.Test/OffsetTimeTest.cs
@@ -121,5 +121,21 @@ namespace NodaTime.Test
                 Assert.AreEqual("14:15:12+01", offsetDate.ToString());
             }
         }
+
+        [Test]
+        public void Deconstruction()
+        {
+            var time = new LocalTime(15, 33);
+            var offset = Offset.FromHours(-2);
+            var offsetTime = new OffsetTime(time, offset);
+
+            var (actualTime, actualOffset) = offsetTime;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(time, actualTime);
+                Assert.AreEqual(offset, actualOffset);
+            });
+        }
     }
 }

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -578,5 +578,24 @@ namespace NodaTime.Test
             Assert.IsFalse(comparer.Equals(losAngelesAfternoon, londonEvening));
             Assert.AreNotEqual(comparer.GetHashCode(losAngelesAfternoon), comparer.GetHashCode(londonEvening));
         }
+
+        [Test]
+        public void Deconstruction()
+        {
+            var saoPaulo = DateTimeZoneProviders.Tzdb["America/Sao_Paulo"];
+            ZonedDateTime value = new LocalDateTime(2017, 10, 15, 21, 30, 15).InZoneStrictly(saoPaulo);
+            var expectedDateTime = new LocalDateTime(2017, 10, 15, 21, 30, 15);
+            var expectedZone = saoPaulo;
+            var expectedOffset = Offset.FromHours(-2);
+
+            var (actualDateTime, actualZone, actualOffset) = value;
+
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(expectedDateTime, actualDateTime);
+                Assert.AreEqual(expectedZone, actualZone);
+                Assert.AreEqual(expectedOffset, actualOffset);
+            });
+        }
     }
 }

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -158,11 +158,11 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// Deconstruct the current instance into is components.
+        /// Deconstruct this date interval into its components.
         /// </summary>
-        /// <param name="start">The <see cref="LocalDate"/> representing the start of the range.</param>
-        /// <param name="end">The <see cref="LocalDate"/> representing the end of the range.</param>
-        public void Deconstruct(out LocalDate start, out LocalDate end)
+        /// <param name="start">The <see cref="LocalDate"/> representing the start of the interval.</param>
+        /// <param name="end">The <see cref="LocalDate"/> representing the end of the interval.</param>
+        public void Deconstruct(out LocalDate? start, out LocalDate? end)
         {
             start = Start;
             end = End;

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -156,5 +156,16 @@ namespace NodaTime
             string end = LocalDatePattern.Iso.Format(End);
             return $"[{start}, {end}]";
         }
+
+        /// <summary>
+        /// Deconstruct the current instance into is components.
+        /// </summary>
+        /// <param name="start">The <see cref="LocalDate"/> representing the start of the range.</param>
+        /// <param name="end">The <see cref="LocalDate"/> representing the end of the range.</param>
+        public void Deconstruct(out LocalDate start, out LocalDate end)
+        {
+            start = Start;
+            end = End;
+        }
     }
 }

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -162,7 +162,7 @@ namespace NodaTime
         /// </summary>
         /// <param name="start">The <see cref="LocalDate"/> representing the start of the interval.</param>
         /// <param name="end">The <see cref="LocalDate"/> representing the end of the interval.</param>
-        public void Deconstruct(out LocalDate? start, out LocalDate? end)
+        public void Deconstruct(out LocalDate start, out LocalDate end)
         {
             start = Start;
             end = End;

--- a/src/NodaTime/Interval.cs
+++ b/src/NodaTime/Interval.cs
@@ -155,6 +155,18 @@ namespace NodaTime
         [Pure]
         public bool Contains(Instant instant) => instant >= start && instant < end;
 
+        /// <summary>
+        /// Deconstruct this value into its components.
+        /// </summary>
+        /// <param name="start">The start of the interval.</param>
+        /// <param name="end">The end of the interval.</param>
+        [Pure]
+        public void Deconstruct(out Instant start, out Instant end)
+        {
+            start = Start;
+            end = End;
+        }
+
         #region Implementation of IEquatable<Interval>
         /// <summary>
         /// Indicates whether the value of this interval is equal to the value of the specified interval.

--- a/src/NodaTime/Interval.cs
+++ b/src/NodaTime/Interval.cs
@@ -161,11 +161,16 @@ namespace NodaTime
         /// <param name="start">The start of the interval.</param>
         /// <param name="end">The end of the interval.</param>
         [Pure]
-        public void Deconstruct(out Instant start, out Instant end)
+        public void Deconstruct(out Instant? start, out Instant? end)
         {
-            start = Start;
-            end = End;
-        }
+            start = this.start.IsValid
+                ? Start
+                : (Instant?)null;
+
+            end = this.end.IsValid
+                ? End
+                : (Instant?)null;
+          }
 
         #region Implementation of IEquatable<Interval>
         /// <summary>

--- a/src/NodaTime/Interval.cs
+++ b/src/NodaTime/Interval.cs
@@ -163,13 +163,8 @@ namespace NodaTime
         [Pure]
         public void Deconstruct(out Instant? start, out Instant? end)
         {
-            start = this.start.IsValid
-                ? Start
-                : (Instant?)null;
-
-            end = this.end.IsValid
-                ? End
-                : (Instant?)null;
+            start = this.start.IsValid ? Start : (Instant?)null;
+            end = this.end.IsValid ? End : (Instant?)null;
           }
 
         #region Implementation of IEquatable<Interval>

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -869,6 +869,18 @@ namespace NodaTime
         }
 
         /// <summary>
+        /// Deconstruct this <see cref="LocalDate"/> into its components.
+        /// </summary>
+        /// <param name="date">The date portion of the value.</param>
+        /// <param name="time">The time portion of the value</param>
+        [Pure]
+        public void Deconstruct(out LocalDate date, out LocalTime time)
+        {
+            date = Date;
+            time = TimeOfDay;
+        }
+
+        /// <summary>
         /// Returns the later date/time of the given two.
         /// </summary>
         /// <param name="x">The first date/time to compare.</param>

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -869,10 +869,10 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// Deconstruct this <see cref="LocalDate"/> into its components.
+        /// Deconstruct this <see cref="LocalDateTime"/> into its components.
         /// </summary>
         /// <param name="date">The date portion of the value.</param>
-        /// <param name="time">The time portion of the value</param>
+        /// <param name="time">The time portion of the value.</param>
         [Pure]
         public void Deconstruct(out LocalDate date, out LocalTime time)
         {

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -700,6 +700,20 @@ namespace NodaTime
         public LocalDateTime On(LocalDate date) => date + this;
 
         /// <summary>
+        /// Deconstruct this time into its components.
+        /// </summary>
+        /// <param name="hour">The hour of the time.</param>
+        /// <param name="minute">The minute of the hour.</param>
+        /// <param name="second">The second of the hour.</param>
+        [Pure]
+        public void Deconstruct(out int hour, out int minute, out int second)
+        {
+            hour = Hour;
+            minute = Minute;
+            second = Second;
+        }
+        
+        /// <summary>
         /// Returns the later time of the given two.
         /// </summary>
         /// <param name="x">The first time to compare.</param>

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -704,7 +704,7 @@ namespace NodaTime
         /// </summary>
         /// <param name="hour">The hour of the time.</param>
         /// <param name="minute">The minute of the hour.</param>
-        /// <param name="second">The second of the hour.</param>
+        /// <param name="second">The second within the minute.</param>
         [Pure]
         public void Deconstruct(out int hour, out int minute, out int second)
         {

--- a/src/NodaTime/OffsetDate.cs
+++ b/src/NodaTime/OffsetDate.cs
@@ -185,5 +185,17 @@ namespace NodaTime
         /// <filterpriority>2</filterpriority>
         public string ToString(string patternText, IFormatProvider formatProvider) =>
             OffsetDatePattern.Patterns.BclSupport.Format(this, patternText, formatProvider);
+
+        /// <summary>
+        /// Deconstruct this value into its components.
+        /// </summary>
+        /// <param name="localDate">The <see cref="LocalDate"/> component.</param>
+        /// <param name="offset">The <see cref="Offset"/> component.</param>
+        [Pure]
+        public void Deconstruct(out LocalDate localDate, out Offset offset)
+        {
+            localDate = Date;
+            offset = Offset.Plus(Offset.FromTicks(34));
+        }
     }
 }

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -531,6 +531,32 @@ namespace NodaTime
         public bool Equals(OffsetDateTime other) =>
             this.yearMonthDayCalendar == other.yearMonthDayCalendar && this.nanosecondsAndOffset == other.nanosecondsAndOffset;
 
+        /// <summary>
+        /// Deconstruct this <see cref="OffsetDateTime"/> into its components.
+        /// </summary>
+        /// <param name="localDateTime">The <see cref="LocalDateTime"/> component.</param>
+        /// <param name="offset">The <see cref="Offset"/> component.</param>
+        [Pure]
+        public void Deconstruct(out LocalDateTime localDateTime, out Offset offset)
+        {
+            localDateTime = LocalDateTime;
+            offset = Offset;
+        }
+
+        /// <summary>
+        /// Deconstruct this <see cref="OffsetDateTime"/> into its components.
+        /// </summary>
+        /// <param name="localDate">The <see cref="LocalDate"/> component.</param>
+        /// <param name="localTime">The <see cref="LocalTime"/> component.</param>
+        /// <param name="offset">The <see cref="Offset"/> component.</param>
+        [Pure]
+        public void Deconstruct(out LocalDate localDate, out LocalTime localTime, out Offset offset)
+        {
+            localDate = LocalDateTime.Date;
+            localTime = LocalDateTime.TimeOfDay;
+            offset = Offset;
+        }
+
         #region Formatting
         /// <summary>
         /// Returns a <see cref="System.String" /> that represents this instance.

--- a/src/NodaTime/OffsetTime.cs
+++ b/src/NodaTime/OffsetTime.cs
@@ -203,7 +203,7 @@ namespace NodaTime
 
 
         ///<summary>
-        ///Deconstruct this value into its components.
+        /// Deconstruct this value into its components.
         /// </summary>
         /// <param name="localTime">
         /// The <see cref="LocalTime"/> component.

--- a/src/NodaTime/OffsetTime.cs
+++ b/src/NodaTime/OffsetTime.cs
@@ -200,5 +200,22 @@ namespace NodaTime
         /// <filterpriority>2</filterpriority>
         public string ToString(string patternText, IFormatProvider formatProvider) =>
             OffsetTimePattern.Patterns.BclSupport.Format(this, patternText, formatProvider);
+
+
+        ///<summary>
+        ///Deconstruct this value into its components.
+        /// </summary>
+        /// <param name="localTime">
+        /// The <see cref="LocalTime"/> component.
+        /// </param>
+        /// <param name="offset">
+        /// The <see cref="Offset"/> component.
+        /// </param>
+        [Pure]
+        public void Deconstruct(out LocalTime localTime, out Offset offset)
+        {
+            localTime = TimeOfDay;
+            offset = Offset;
+        }
     }
 }

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -635,7 +635,7 @@ namespace NodaTime
         /// <param name="dateTimeZone">The <see cref="DateTimeZone"/> component.</param>
         /// <param name="offset">The <see cref="Offset"/> component.</param>
         [Pure]
-        public void Deconstruct(out LocalDateTime localDateTime, [NotNull]out DateTimeZone dateTimeZone, out Offset offset)
+        public void Deconstruct(out LocalDateTime localDateTime, [NotNull] out DateTimeZone dateTimeZone, out Offset offset)
         {
             localDateTime = LocalDateTime;
             dateTimeZone = Zone;

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -628,6 +628,20 @@ namespace NodaTime
         [Pure]
         public OffsetDateTime ToOffsetDateTime() => offsetDateTime;
 
+        /// <summary>
+        /// Deconstruct this <see cref="ZonedDateTime"/> into its components.
+        /// </summary>
+        /// <param name="localDateTime">The <see cref="LocalDateTime"/> component.</param>
+        /// <param name="dateTimeZone">The <see cref="DateTimeZone"/> component.</param>
+        /// <param name="offset">The <see cref="Offset"/> component.</param>
+        [Pure]
+        public void Deconstruct(out LocalDateTime localDateTime, [NotNull]out DateTimeZone dateTimeZone, out Offset offset)
+        {
+            localDateTime = LocalDateTime;
+            dateTimeZone = Zone;
+            offset = Offset;
+        }
+
         #region Comparers
         /// <summary>
         /// Base class for <see cref="ZonedDateTime"/> comparers.


### PR DESCRIPTION
As discussed in #585.

I didn't implement the non-nullable overload on `Interval`, though. It seems the compiler isn't able to disambiguate between the two overloads when I try to use the deconstruction syntax.

