### PR TITLE
Tweaks to the Wondrous calendar system

### DIFF
--- a/src/NodaTime.Test/Calendars/WondrousCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/WondrousCalendarSystemTest.cs
@@ -1,26 +1,26 @@
-// Copyright 2011 The Noda Time Authors. All rights reserved.
+// Copyright 2017 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
 using NodaTime.Calendars;
+using NodaTime.Utility;
 using NUnit.Framework;
 using System;
 
 namespace NodaTime.Test.Calendars
 {
-    public static class WondrousCalendarHelper {
+    public static class WondrousCalendarHelper
+    {
         /// <summary>
         /// Get a text representation of the date.
         /// </summary>
-        /// <param name="input"></param>
-        /// <returns></returns>
         public static string AsWondrousString(this LocalDate input)
         {
             // minimal formatting
 
             var year = input.Year;
-            var month = WondrousYearMonthDayCalculator.WondrousMonth(input);
-            var day = WondrousYearMonthDayCalculator.WondrousDay(input);
+            var month = WondrousCalendarSystemTest.WondrousMonth(input);
+            var day = WondrousCalendarSystemTest.WondrousDay(input);
 
             return $"{year}-{month}-{day}";
         }
@@ -31,21 +31,25 @@ namespace NodaTime.Test.Calendars
     /// </summary>
     public class WondrousCalendarSystemTest
     {
+        // For use with CreateWondrousDate, this is a notional "month"
+        // containing Ayyam-i-Ha. The days here are represented in month
+        // 18 in LocalDate etc.
         const int AyyamiHaMonth = 0;
 
         [Test]
-        public void ExtensionMethod() {
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(180, 10, 10).AsWondrousString(), "180-10-10");
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(180, 18, 19).AsWondrousString(), "180-18-19");
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(180, 0, 3).AsWondrousString(), "180-0-3");
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(180, 19, 1).AsWondrousString(), "180-19-1");
+        public void ExtensionMethod()
+        {
+            Assert.AreEqual(CreateWondrousDate(180, 10, 10).AsWondrousString(), "180-10-10");
+            Assert.AreEqual(CreateWondrousDate(180, 18, 19).AsWondrousString(), "180-18-19");
+            Assert.AreEqual(CreateWondrousDate(180, 0, 3).AsWondrousString(), "180-0-3");
+            Assert.AreEqual(CreateWondrousDate(180, 19, 1).AsWondrousString(), "180-19-1");
         }
 
         [Test]
         public void WondrousEpoch()
         {
             CalendarSystem wondrous = CalendarSystem.Wondrous;
-            LocalDate wondrousEpoch = WondrousYearMonthDayCalculator.CreateWondrousDate(1, 1, 1);
+            LocalDate wondrousEpoch = CreateWondrousDate(1, 1, 1);
 
             CalendarSystem gregorian = CalendarSystem.Gregorian;
             LocalDate converted = wondrousEpoch.WithCalendar(gregorian);
@@ -60,7 +64,7 @@ namespace NodaTime.Test.Calendars
         {
             CalendarSystem wondrous = CalendarSystem.Wondrous;
             LocalDate unixEpochInWondrousCalendar = NodaConstants.UnixEpoch.InZone(DateTimeZone.Utc, wondrous).LocalDateTime.Date;
-            LocalDate expected = WondrousYearMonthDayCalculator.CreateWondrousDate(126, 16, 2);
+            LocalDate expected = CreateWondrousDate(126, 16, 2);
             Assert.AreEqual(expected, unixEpochInWondrousCalendar);
         }
 
@@ -71,7 +75,7 @@ namespace NodaTime.Test.Calendars
             LocalDate iso = new LocalDate(2017, 3, 4);
             LocalDate wondrous = iso.WithCalendar(wondrousCalendar);
 
-            Assert.AreEqual(19, WondrousYearMonthDayCalculator.WondrousMonth(wondrous));
+            Assert.AreEqual(19, WondrousMonth(wondrous));
 
             Assert.AreEqual(Era.BahaiEra, wondrous.Era);
             Assert.AreEqual(173, wondrous.YearOfEra);
@@ -79,7 +83,7 @@ namespace NodaTime.Test.Calendars
             Assert.AreEqual(173, wondrous.Year);
             Assert.IsFalse(wondrousCalendar.IsLeapYear(173));
 
-            Assert.AreEqual(4, WondrousYearMonthDayCalculator.WondrousDay(wondrous));
+            Assert.AreEqual(4, WondrousDay(wondrous));
 
             Assert.AreEqual(IsoDayOfWeek.Saturday, wondrous.DayOfWeek);
         }
@@ -143,7 +147,7 @@ namespace NodaTime.Test.Calendars
         public void GeneralConversionNearNawRuz(int gYear, int gMonth, int gDay, int wYear, int wMonth, int wDay)
         {
             // create in the Wondrous calendar
-            var wDate = WondrousYearMonthDayCalculator.CreateWondrousDate(wYear, wMonth, wDay);
+            var wDate = CreateWondrousDate(wYear, wMonth, wDay);
             var gDate = wDate.WithCalendar(CalendarSystem.Gregorian);
             Assert.AreEqual(gYear, gDate.Year);
             Assert.AreEqual(gMonth, gDate.Month);
@@ -152,8 +156,8 @@ namespace NodaTime.Test.Calendars
             // convert to the Wondrous calendar
             var wDate2 = new LocalDate(gYear, gMonth, gDay).WithCalendar(CalendarSystem.Wondrous);
             Assert.AreEqual(wYear, wDate2.Year);
-            Assert.AreEqual(wMonth, WondrousYearMonthDayCalculator.WondrousMonth(wDate2));
-            Assert.AreEqual(wDay, WondrousYearMonthDayCalculator.WondrousDay(wDate2));
+            Assert.AreEqual(wMonth, WondrousMonth(wDate2));
+            Assert.AreEqual(wDay, WondrousDay(wDate2));
         }
 
         [Test]
@@ -173,7 +177,7 @@ namespace NodaTime.Test.Calendars
         public void SpecialCases(int gYear, int gMonth, int gDay, int wYear, int wMonth, int wDay)
         {
             // create in test calendar
-            var wDate = WondrousYearMonthDayCalculator.CreateWondrousDate(wYear, wMonth, wDay);
+            var wDate = CreateWondrousDate(wYear, wMonth, wDay);
 
             // convert to gregorian
             var gDate = wDate.WithCalendar(CalendarSystem.Gregorian);
@@ -185,7 +189,7 @@ namespace NodaTime.Test.Calendars
             var gDate2 = new LocalDate(gYear, gMonth, gDay);
             var wDate2 = gDate2.WithCalendar(CalendarSystem.Wondrous);
 
-            Assert.AreEqual($"{wYear}-{wMonth}-{wDay}", $"{wDate2.Year}-{WondrousYearMonthDayCalculator.WondrousMonth(wDate2)}-{WondrousYearMonthDayCalculator.WondrousDay(wDate2)}");
+            Assert.AreEqual($"{wYear}-{wMonth}-{wDay}", $"{wDate2.Year}-{WondrousMonth(wDate2)}-{WondrousDay(wDate2)}");
         }
 
         [Test]
@@ -257,7 +261,7 @@ namespace NodaTime.Test.Calendars
         public void GeneralWtoG(int wYear, int wMonth, int wDay, int gYear, int gMonth, int gDay)
         {
             // create in this calendar
-            var wDate = WondrousYearMonthDayCalculator.CreateWondrousDate(wYear, wMonth, wDay);
+            var wDate = CreateWondrousDate(wYear, wMonth, wDay);
             var gDate = wDate.WithCalendar(CalendarSystem.Gregorian);
             Assert.AreEqual(gYear, gDate.Year);
             Assert.AreEqual(gMonth, gDate.Month);
@@ -266,8 +270,8 @@ namespace NodaTime.Test.Calendars
             // convert to this calendar
             var wDate2 = new LocalDate(gYear, gMonth, gDay).WithCalendar(CalendarSystem.Wondrous);
             Assert.AreEqual(wYear, wDate2.Year);
-            Assert.AreEqual(wMonth, WondrousYearMonthDayCalculator.WondrousMonth(wDate2));
-            Assert.AreEqual(wDay, WondrousYearMonthDayCalculator.WondrousDay(wDate2));
+            Assert.AreEqual(wMonth, WondrousMonth(wDate2));
+            Assert.AreEqual(wDay, WondrousDay(wDate2));
         }
 
         [Test]
@@ -323,8 +327,7 @@ namespace NodaTime.Test.Calendars
         [TestCase(221, 4)]
         public void DaysInAyyamiHa(int wYear, int days)
         {
-            var wondrous = new WondrousYearMonthDayCalculator();
-            Assert.AreEqual(days, wondrous.DaysInAyyamiHa(wYear));
+            Assert.AreEqual(days, WondrousYearMonthDayCalculator.GetDaysInAyyamiHa(wYear));
         }
 
         [Test]
@@ -342,36 +345,25 @@ namespace NodaTime.Test.Calendars
         public void DayOfYear(int wYear, int wMonth, int wDay, int dayOfYear)
         {
             var wondrous = new WondrousYearMonthDayCalculator();
-            Assert.AreEqual(dayOfYear, wondrous.GetDayOfYear(WondrousYearMonthDayCalculator.CreateWondrousDate(wYear, wMonth, wDay).YearMonthDay));
+            Assert.AreEqual(dayOfYear, wondrous.GetDayOfYear(CreateWondrousDate(wYear, wMonth, wDay).YearMonthDay));
         }
 
+        // Cannot use EndOfMonth with Ayyam-i-Ha because they are internally stored as days in month 18.
+        // In Ayyam-i-Ha, EndOfMonth should throw an exception or return the last day of Ayyam-i-Ha.
+        // In this implementation, it will always return the last day of the month 18.
         [Test]
-        [TestCase(173, 1, 1, 19)]
-        [TestCase(173, 18, 1, 19)]
-        [TestCase(173, 19, 1, 19)]
-        [TestCase(220, 19, 1, 19)]
-        [TestCase(220, 4, 5, 19)]
-        public void EndOfMonth(int year, int month, int day, int eomDay)
+        [TestCase(173, 1, 1, 1, 19)]
+        [TestCase(173, 18, 1, AyyamiHaMonth, 4)]
+        [TestCase(173, AyyamiHaMonth, 1, AyyamiHaMonth, 4)]
+        [TestCase(173, 19, 1, 19, 19)]
+        [TestCase(220, 19, 1, 19, 19)]
+        [TestCase(220, 4, 5, 4, 19)]
+        [TestCase(220, 18, 1, AyyamiHaMonth, 5)]
+        [TestCase(220, AyyamiHaMonth, 1, AyyamiHaMonth, 5)]
+        public void EndOfMonth(int year, int month, int day, int eomMonth, int eomDay)
         {
-            var start = WondrousYearMonthDayCalculator.CreateWondrousDate(year, month, day);
-            var end = WondrousYearMonthDayCalculator.CreateWondrousDate(year, month, eomDay);
-            Assert.AreEqual(end.AsWondrousString(), DateAdjusters.EndOfMonth(start).AsWondrousString());
-        }
-
-        [Test]
-        [TestCase(173, AyyamiHaMonth, 1)]
-        [TestCase(220, AyyamiHaMonth, 1)]
-        public void EndOfMonthInAyyamiHa(int year, int month, int day)
-        {
-            /* 
-            Cannot use EndOfMonth with Ayyam-i-Ha because they are internally stored as days in month 18.
-            
-            In Ayyam-i-Ha, EndOfMonth should throw an exception or return the last day of Ayyam-i-Ha.
-
-            In this implementation, it will always return the last day of the month 18.
-            */
-            var start = WondrousYearMonthDayCalculator.CreateWondrousDate(year, month, day);
-            var end = WondrousYearMonthDayCalculator.CreateWondrousDate(year, 18, 19);
+            var start = CreateWondrousDate(year, month, day);
+            var end = CreateWondrousDate(year, eomMonth, eomDay);
             Assert.AreEqual(end.AsWondrousString(), DateAdjusters.EndOfMonth(start).AsWondrousString());
         }
 
@@ -393,23 +385,22 @@ namespace NodaTime.Test.Calendars
         }
 
         [Test]
-        public void GetDaysInMonth()
+        [TestCase(180, 1, 19)]
+        [TestCase(180, 18, 23)]
+        public void GetDaysInMonth(int year, int month, int expectedDays)
         {
             var calendar = CalendarSystem.Wondrous;
-            Assert.AreEqual(19, calendar.GetDaysInMonth(180, 1));
-
-            Assert.AreEqual(4, calendar.GetDaysInMonth(180, AyyamiHaMonth));
+            Assert.AreEqual(expectedDays, calendar.GetDaysInMonth(year, month));
         }
 
         [Test]
         public void CreateDate_InAyyamiHa()
         {
-            var d1 = WondrousYearMonthDayCalculator.CreateWondrousDate(180, 0, 3);
-            var d3 = WondrousYearMonthDayCalculator.CreateWondrousDate(180, 18, 22);
+            var d1 = CreateWondrousDate(180, 0, 3);
+            var d3 = CreateWondrousDate(180, 18, 22);
 
             Assert.AreEqual(d1, d3);
         }
-
 
         [Test]
         [TestCase(180, -1, 1)]
@@ -422,14 +413,14 @@ namespace NodaTime.Test.Calendars
         [TestCase(180, 20, 1)]
         public void CreateDate_Invalid(int year, int month, int day)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => WondrousYearMonthDayCalculator.CreateWondrousDate(year, month, day));
+            Assert.Throws<ArgumentOutOfRangeException>(() => CreateWondrousDate(year, month, day));
         }
 
         // Period related tests
-        private static readonly LocalDate TestDate1_167_5_15 = WondrousYearMonthDayCalculator.CreateWondrousDate(167, 5, 15);
-        private static readonly LocalDate TestDate1_167_6_7 = WondrousYearMonthDayCalculator.CreateWondrousDate(167, 6, 7);
-        private static readonly LocalDate TestDate2_167_Ayyam_4 = WondrousYearMonthDayCalculator.CreateWondrousDate(167, AyyamiHaMonth, 4);
-        private static readonly LocalDate TestDate3_168_Ayyam_5 = WondrousYearMonthDayCalculator.CreateWondrousDate(168, AyyamiHaMonth, 5);
+        private static readonly LocalDate TestDate1_167_5_15 = CreateWondrousDate(167, 5, 15);
+        private static readonly LocalDate TestDate1_167_6_7 = CreateWondrousDate(167, 6, 7);
+        private static readonly LocalDate TestDate2_167_Ayyam_4 = CreateWondrousDate(167, AyyamiHaMonth, 4);
+        private static readonly LocalDate TestDate3_168_Ayyam_5 = CreateWondrousDate(168, AyyamiHaMonth, 5);
 
         [Test]
         public void BetweenLocalDates_InvalidUnits()
@@ -444,7 +435,7 @@ namespace NodaTime.Test.Calendars
         public void SetYear()
         {
             // crafted to test SetYear with 0 
-            var d1 = WondrousYearMonthDayCalculator.CreateWondrousDate(180, 1, 1);
+            var d1 = CreateWondrousDate(180, 1, 1);
             LocalDate result = d1 + Period.FromYears(0);
             Assert.AreEqual(180, result.Year);
         }
@@ -512,8 +503,8 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void BetweenLocalDates_AsymmetricForwardAndBackward()
         {
-            LocalDate d1 = WondrousYearMonthDayCalculator.CreateWondrousDate(166, 18, 4);
-            LocalDate d2 = WondrousYearMonthDayCalculator.CreateWondrousDate(167, 1, 10);
+            LocalDate d1 = CreateWondrousDate(166, 18, 4);
+            LocalDate d2 = CreateWondrousDate(167, 1, 10);
 
             // spanning Ayyam-i-Ha - not counted as a month
             Assert.AreEqual(Period.FromMonths(2) + Period.FromDays(6), Period.Between(d1, d2));
@@ -523,8 +514,8 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void BetweenLocalDates_EndOfMonth()
         {
-            LocalDate d1 = WondrousYearMonthDayCalculator.CreateWondrousDate(171, 5, 19);
-            LocalDate d2 = WondrousYearMonthDayCalculator.CreateWondrousDate(171, 6, 19);
+            LocalDate d1 = CreateWondrousDate(171, 5, 19);
+            LocalDate d2 = CreateWondrousDate(171, 6, 19);
             Assert.AreEqual(Period.FromMonths(1), Period.Between(d1, d2));
             Assert.AreEqual(Period.FromMonths(-1), Period.Between(d2, d1));
         }
@@ -544,8 +535,8 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void BetweenLocalDates_AfterLeapYear()
         {
-            LocalDate d1 = WondrousYearMonthDayCalculator.CreateWondrousDate(180, 19, 5);
-            LocalDate d2 = WondrousYearMonthDayCalculator.CreateWondrousDate(181, 19, 5);
+            LocalDate d1 = CreateWondrousDate(180, 19, 5);
+            LocalDate d2 = CreateWondrousDate(181, 19, 5);
             Assert.AreEqual(Period.FromYears(1), Period.Between(d1, d2));
             Assert.AreEqual(Period.FromYears(-1), Period.Between(d2, d1));
         }
@@ -554,48 +545,48 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void Addition_DayCrossingMonthBoundary()
         {
-            LocalDate start = WondrousYearMonthDayCalculator.CreateWondrousDate(182, 4, 13);
+            LocalDate start = CreateWondrousDate(182, 4, 13);
             LocalDate result = start + Period.FromDays(10);
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(182, 5, 4), result);
+            Assert.AreEqual(CreateWondrousDate(182, 5, 4), result);
         }
 
         [Test]
         public void Addition()
         {
-            var start = WondrousYearMonthDayCalculator.CreateWondrousDate(182, 1, 1);
+            var start = CreateWondrousDate(182, 1, 1);
 
             var result = start + Period.FromDays(3);
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(182, 1, 4), result);
+            Assert.AreEqual(CreateWondrousDate(182, 1, 4), result);
 
             result = start + Period.FromDays(20);
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(182, 2, 2), result);
+            Assert.AreEqual(CreateWondrousDate(182, 2, 2), result);
         }
 
         [Test]
         public void Addition_DayCrossingMonthBoundaryFromAyyamiHa()
         {
-            var start = WondrousYearMonthDayCalculator.CreateWondrousDate(182, AyyamiHaMonth, 3);
+            var start = CreateWondrousDate(182, AyyamiHaMonth, 3);
 
             var result = start + Period.FromDays(10);
             // in 182, Ayyam-i-Ha has 5 days
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(182, 19, 8), result);
+            Assert.AreEqual(CreateWondrousDate(182, 19, 8), result);
         }
 
         [Test]
         public void Addition_OneYearOnLeapDay()
         {
-            LocalDate start = WondrousYearMonthDayCalculator.CreateWondrousDate(182, AyyamiHaMonth, 5);
+            LocalDate start = CreateWondrousDate(182, AyyamiHaMonth, 5);
             LocalDate result = start + Period.FromYears(1);
             // Ayyam-i-Ha 5 becomes Ayyam-i-Ha 4
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(183, AyyamiHaMonth, 4), result);
+            Assert.AreEqual(CreateWondrousDate(183, AyyamiHaMonth, 4), result);
         }
 
         [Test]
         public void Addition_FiveYearsOnLeapDay()
         {
-            LocalDate start = WondrousYearMonthDayCalculator.CreateWondrousDate(182, AyyamiHaMonth, 5);
+            LocalDate start = CreateWondrousDate(182, AyyamiHaMonth, 5);
             LocalDate result = start + Period.FromYears(5);
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(187, AyyamiHaMonth, 5), result);
+            Assert.AreEqual(CreateWondrousDate(187, AyyamiHaMonth, 5), result);
         }
 
         [Test]
@@ -603,13 +594,62 @@ namespace NodaTime.Test.Calendars
         {
             // One year, one month, two days
             Period period = Period.FromYears(1) + Period.FromMonths(1) + Period.FromDays(2);
-            LocalDate start = WondrousYearMonthDayCalculator.CreateWondrousDate(171, 1, 19);
+            LocalDate start = CreateWondrousDate(171, 1, 19);
             // Periods are added in order, so this becomes...
             // Add one year: 172.1.19
             // Add one month: 172.2.19
             // Add two days: 172.3.2
             LocalDate result = start + period;
-            Assert.AreEqual(WondrousYearMonthDayCalculator.CreateWondrousDate(172, 3, 2), result);
+            Assert.AreEqual(CreateWondrousDate(172, 3, 2), result);
+        }
+
+        /// <summary>
+        /// Create a <see cref="LocalDate"/> in the Wondrous calendar, treating 0
+        /// as the month containing Ayyam-i-Ha.
+        /// </summary>
+        /// <param name="year">Year in the Wondrous calendar</param>
+        /// <param name="month">Month (use 0 for Ayyam-i-Ha)</param>
+        /// <param name="day">Day in month</param>
+        private static LocalDate CreateWondrousDate(int year, int month, int day)
+        {
+            if (month == AyyamiHaMonth)
+            {
+                Preconditions.CheckArgumentRange(nameof(day), day, 1, WondrousYearMonthDayCalculator.GetDaysInAyyamiHa(year));
+                // Move Ayyam-i-Ha days to fall after the last day of month 18.
+                month = WondrousYearMonthDayCalculator.Month18;
+                day += WondrousYearMonthDayCalculator.DaysInMonth;
+            }
+            return new LocalDate(year, month, day, CalendarSystem.Wondrous);
+        }
+
+        /// <summary>
+        /// Return the day of this month, treating Ayyam-i-Ha as a separate month.
+        /// </summary>
+        internal static int WondrousDay(LocalDate input)
+        {
+            Preconditions.CheckArgument(input.Calendar == CalendarSystem.Wondrous, nameof(input), "Only valid when using the Wondrous calendar");
+
+            if (input.Month == WondrousYearMonthDayCalculator.Month18 &&
+                input.Day > WondrousYearMonthDayCalculator.DaysInMonth)
+            {
+                return input.Day - WondrousYearMonthDayCalculator.DaysInMonth;
+            }
+            return input.Day;
+        }
+
+        /// <summary>
+        /// Return the month of this date. If in Ayyam-i-Ha, returns 0.
+        /// </summary>
+        internal static int WondrousMonth(LocalDate input)
+        {
+            Preconditions.CheckArgument(input.Calendar == CalendarSystem.Wondrous, nameof(input), "Only valid when using the Wondrous calendar");
+
+            if (input.Month == WondrousYearMonthDayCalculator.Month18 &&
+                input.Day > WondrousYearMonthDayCalculator.DaysInMonth)
+            {
+                return AyyamiHaMonth;
+            }
+            return input.Month;
         }
     }
 }

--- a/src/NodaTime/Calendars/WondrousYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/WondrousYearMonthDayCalculator.cs
@@ -1,16 +1,14 @@
-﻿// Copyright 2014 The Noda Time Authors. All rights reserved.
+﻿// Copyright 2017 The Noda Time Authors. All rights reserved.
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
 using NodaTime.Utility;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace NodaTime.Calendars
 {
     /// <summary>
-    ///     See <see cref="CalendarSystem.Wondrous" /> for details.
+    /// See <see cref="CalendarSystem.Wondrous" /> for details.
     /// </summary>
     internal sealed class WondrousYearMonthDayCalculator : YearMonthDayCalculator
     {
@@ -19,11 +17,16 @@ namespace NodaTime.Calendars
         private const int DaysInAyyamiHaInLeapYear = 5;
         private const int DaysInAyyamiHaInNormalYear = 4;
 
-        private const int DaysInMonth = 19;
+        internal const int DaysInMonth = 19;
         private const int FirstYearOfStandardizedCalendar = 172;
         private const int GregorianYearOfFirstWondrousYear = 1844;
 
-        private const int Month18 = 18;
+        /// <remarks>
+        /// There are 19 months in a year. Between the 18th and 19th month are the "days of Ha" (Ayyam-i-Ha).
+        /// In order to make everything else in Noda Time work appropriately, Ayyam-i-Ha are counted as
+        /// extra days at the end of month 18.
+        /// </remarks>
+        internal const int Month18 = 18;
         private const int Month19 = 19;
         private const int MonthsInYear = 19;
 
@@ -31,26 +34,14 @@ namespace NodaTime.Calendars
         private const int WondrousMaxYear = 1000; // current lookup tables are pre-calculated for a thousand years
         private const int WondrousMinYear = 1;
 
-        private static Dictionary<int, WondrousYearInfo> _calculatedYears;
-
-        /// <remarks>
-        ///     There are 19 months in a year. Between the 18th and 19th month are the "days of Ha" (Ayyam-i-Ha).
-        ///     Options for numbering the months:
-        ///     - treat Ayyam-i-Ha as month 0. This will cause problems if 0 is treated as unknown. When stored internally,
-        ///       NodaTime months are converted to 0-based numbers, so this would by -1 which is not supported.
-        ///     - treat Ayyam-i-Ha as month -1. This would be a problem if the base classes convert to 0 based months
-        ///     - treat Ayyam-i-Ha as month 19. This is confusing because the 19th month would be displayed as month #20.
-        ///     - treat Ayyam-i-Ha as month 20. This will cause problems if months are sorted naively.
-        ///     - treat Ayyam-i-Ha as extra days in month 18. This would require special handling to sometimes display
-        ///       days in "month 18" as being Ayyam-i-Ha, but we have no direct control over display.
-        ///       
-        /// This version will treat Ayyam-i-Ha days as extra days in month 18.
-        /// 
-        /// Users interacting with the system should use 0 as Ayyam-i-Ha.
-        /// </remarks>
-        public const int AyyamiHaMonth0 = 0;
-
-        static byte[] YearInfoRaw = Convert.FromBase64String("AgELAgIBCwICAQsCAgEBCwIBAQsCAQELAgEBCwIBAQsCAQELAgEBCwIBAQELAQEBCwEBAQsBAQELAQEB" +
+        /// <summary>
+        /// This is the base64 representation of information for years 172 to 1000.
+        /// NazRuzDate falls on March 19, 20, 21, or 22.
+        /// DaysInAyymiHa can be 4,5.
+        /// For each year, the value in the array is (NawRuzDate - 19) + 10 * (DaysInAyyamiHa - 4)
+        /// </summary>
+        static byte[] YearInfoRaw = Convert.FromBase64String(
+            "AgELAgIBCwICAQsCAgEBCwIBAQsCAQELAgEBCwIBAQsCAQELAgEBCwIBAQELAQEBCwEBAQsBAQELAQEB" +
             "CwEBAQsBAQELAQEBCwEBAQEKAQEBCgEBAQsCAgILAgICCwICAgsCAgILAgICCwICAgELAgIBCwICAQsC" +
             "AgELAgIBCwICAQsCAgELAgIBCwICAQELAgEBCwIBAQsCAQELAgEBCwIBAQsCAQELAgEBCwIBAQELAQEB" +
             "CwEBAQsCAgIMAgICDAICAgwCAgIMAgICDAICAgILAgICCwICAgsCAgILAgICCwICAgsCAgILAgICCwIC" +
@@ -67,103 +58,53 @@ namespace NodaTime.Calendars
 
         static WondrousYearMonthDayCalculator()
         {
-            Preconditions.CheckState(FirstYearOfStandardizedCalendar + YearInfoRaw.Length == WondrousMaxYear + 1, "Invalid compressed data. Length: " + YearInfoRaw.Length);
+            Preconditions.DebugCheckState(
+                FirstYearOfStandardizedCalendar + YearInfoRaw.Length == WondrousMaxYear + 1,
+                "Invalid compressed data. Length: " + YearInfoRaw.Length);
         }
-
 
         internal WondrousYearMonthDayCalculator()
             : base(WondrousMinYear,
                 WondrousMaxYear - 1,
                 AverageDaysPer10Years,
                 UnixEpochDayAtStartOfYear1)
-        { }
-
-        private int DayOfYearOfStartOfMonth19(int year)
         {
-            var dayOfYearOfStartOfMonth19 = 1 + DaysInMonth * Month18 + GetYearInfo(year).DaysInAyyamiHa;
-            return dayOfYearOfStartOfMonth19;
         }
 
-        static WondrousYearInfo GetYearInfo(int year)
+        internal static int GetDaysInAyyamiHa(int year)
         {
-            // Considered preloading this knowledge from the byte array into an array of 1000 years, but in typical use, only one or two of the years may be used. 
-            // Calculated results are cached in a dictionary in case they are re-used.
-
             Preconditions.CheckArgumentRange(nameof(year), year, WondrousMinYear, WondrousMaxYear);
-
-            if (_calculatedYears == null)
-            {
-                _calculatedYears = new Dictionary<int, WondrousYearInfo>();
-            }
-            else if (_calculatedYears.ContainsKey(year))
-            {
-                return _calculatedYears[year];
-            }
-
-            WondrousYearInfo wondrousYearInfo;
-
             if (year < FirstYearOfStandardizedCalendar)
             {
-                // Feb 29 is near the end of the Wondrous year in the next Gregorian year
-                wondrousYearInfo = new WondrousYearInfo(CalendarSystem.Iso.YearMonthDayCalculator.IsLeapYear(year + GregorianYearOfFirstWondrousYear)
-                                    ? DaysInAyyamiHaInLeapYear : DaysInAyyamiHaInNormalYear,
-                                    21);
-                _calculatedYears.Add(year, wondrousYearInfo);
-                return wondrousYearInfo;
+                return CalendarSystem.Iso.YearMonthDayCalculator.IsLeapYear(year + GregorianYearOfFirstWondrousYear)
+                    ? DaysInAyyamiHaInLeapYear : DaysInAyyamiHaInNormalYear;
             }
-
-            /*
-            Base64 string only has information for years 172 to 1000.
-                NazRuzDate falls on March 19,20,21, or 22
-                DaysInAyymiHa can be 4,5
-
-                For each year, num = (NawRuzDate - 19) + 10 * (DaysInAyyamiHa - 4)
-                ... DaysInAyyamiHa are 4 or 5, so we add 10 only when there are 5 days
-
-                string = Convert.ToBase64String(new byte[] { num, num, ...})
-            */
-
-            int info = YearInfoRaw[year - FirstYearOfStandardizedCalendar];
-            int daysInAyyamiHa;
-            if (info > 10)
-            {
-                daysInAyyamiHa = DaysInAyyamiHaInLeapYear;
-                info -= 10;
-            }
-            else
-            {
-                daysInAyyamiHa = DaysInAyyamiHaInNormalYear;
-            }
-
-            const int dayInMarchForOffsetToNawRuz = 19;
-            wondrousYearInfo = new WondrousYearInfo(daysInAyyamiHa, dayInMarchForOffsetToNawRuz + info);
-
-            _calculatedYears.Add(year, wondrousYearInfo);
-
-            return wondrousYearInfo;
+            int num = YearInfoRaw[year - FirstYearOfStandardizedCalendar];
+            return num > 10 ? DaysInAyyamiHaInLeapYear : DaysInAyyamiHaInNormalYear;
         }
 
-        private DateTime GregorianDateOfNawRuz(int year)
+        private static int GetNawRuzDayInMarch(int year)
         {
             Preconditions.CheckArgumentRange(nameof(year), year, WondrousMinYear, WondrousMaxYear);
-
-            var gregorianDateOfNawRuz = new DateTime(GregorianYearOfFirstWondrousYear - 1 + year, 3, GetYearInfo(year).NawRuzDayInMarch);
-
-            return gregorianDateOfNawRuz;
-        }
+            if (year < FirstYearOfStandardizedCalendar)
+            {
+                return 21;
+            }
+            const int dayInMarchForOffsetToNawRuz = 19;
+            int num = YearInfoRaw[year - FirstYearOfStandardizedCalendar];
+            return dayInMarchForOffsetToNawRuz + (num % 10);
+        }        
 
         protected override int CalculateStartOfYearDays(int year)
         {
             Preconditions.CheckArgumentRange(nameof(year), year, WondrousMinYear, WondrousMaxYear);
 
-            // leverage Noda Time's Iso knowledge of when Jan 1 is, then add days to Naw Ruz
+            // The epoch is the same regardless of calendar system, so if we work out when the
+            // start of the Wondrous year is in terms of the Gregorian year, we can just use that
+            // date's days-since-epoch value.
             var gregorianYear = year + GregorianYearOfFirstWondrousYear - 1;
-            var gregorianStart = CalendarSystem.Iso.YearMonthDayCalculator.GetStartOfYearInDays(gregorianYear);
-
-            var nawRuz = GregorianDateOfNawRuz(year);
-            var firstDay = gregorianStart + nawRuz.DayOfYear - 1;
-
-            return firstDay;
+            var nawRuz = new LocalDate(gregorianYear, 3, GetNawRuzDayInMarch(year));
+            return nawRuz.DaysSinceEpoch;
         }
 
         protected override int GetDaysFromStartOfYearToStartOfMonth(int year, int month)
@@ -172,7 +113,7 @@ namespace NodaTime.Calendars
 
             if (month == Month19)
             {
-                daysFromStartOfYearToStartOfMonth += GetYearInfo(year).DaysInAyyamiHa;
+                daysFromStartOfYearToStartOfMonth += GetDaysInAyyamiHa(year);
             }
 
             return daysFromStartOfYearToStartOfMonth;
@@ -228,21 +169,10 @@ namespace NodaTime.Calendars
         internal override int GetDaysInMonth(int year, int month)
         {
             Preconditions.CheckArgumentRange(nameof(year), year, WondrousMinYear, WondrousMaxYear);
-
-            if (month == AyyamiHaMonth0)
-            {
-                return GetYearInfo(year).DaysInAyyamiHa;
-            }
-
-            return DaysInMonth;
+            return month == Month18 ? DaysInMonth + GetDaysInAyyamiHa(year) : DaysInMonth;
         }
 
-        internal override int GetDaysInYear(int year)
-        {
-            var daysInYear = 361 + GetYearInfo(year).DaysInAyyamiHa;
-
-            return daysInYear;
-        }
+        internal override int GetDaysInYear(int year) => 361 + GetDaysInAyyamiHa(year);
 
         internal override int GetDaysSinceEpoch(YearMonthDay target)
         {
@@ -257,22 +187,19 @@ namespace NodaTime.Calendars
 
             if (month == Month19)
             {
-                daysSinceEpoch += DaysInAyyamiHa(year);
+                daysSinceEpoch += GetDaysInAyyamiHa(year);
             }
 
             return daysSinceEpoch;
         }
 
-        internal override int GetMonthsInYear(int year)
-        {
-            return MonthsInYear;
-        }
+        internal override int GetMonthsInYear(int year) => MonthsInYear;
 
         internal override YearMonthDay GetYearMonthDay(int year, int dayOfYear)
         {
             Preconditions.CheckArgumentRange(nameof(dayOfYear), dayOfYear, 1, GetDaysInYear(year));
 
-            var firstOfLoftiness = DayOfYearOfStartOfMonth19(year);
+            var firstOfLoftiness = 1 + DaysInMonth * Month18 + GetDaysInAyyamiHa(year);
 
             if (dayOfYear >= firstOfLoftiness)
             {
@@ -285,15 +212,9 @@ namespace NodaTime.Calendars
             return new YearMonthDay(year, month, day);
         }
 
-        internal bool IsInAyyamiHa(YearMonthDay ymd)
-        {
-            return ymd.Month == Month18 && ymd.Day > DaysInMonth;
-        }
+        internal bool IsInAyyamiHa(YearMonthDay ymd) => ymd.Month == Month18 && ymd.Day > DaysInMonth;
 
-        internal override bool IsLeapYear(int year)
-        {
-            return GetYearInfo(year).DaysInAyyamiHa != DaysInAyyamiHaInNormalYear;
-        }
+        internal override bool IsLeapYear(int year) => GetDaysInAyyamiHa(year) != DaysInAyyamiHaInNormalYear;
 
         internal override int MonthsBetween(YearMonthDay start, YearMonthDay end)
         {
@@ -335,7 +256,7 @@ namespace NodaTime.Calendars
             {
                 // Moving a year while within Ayyam-i-Ha is not well defined.
                 // In this implementation, if starting on day 5, end on day 4 (stay in Ayyam-i-Ha)
-                var daysInThisAyyamiHa = DaysInAyyamiHa(newYear);
+                var daysInThisAyyamiHa = GetDaysInAyyamiHa(newYear);
                 return new YearMonthDay(newYear, month, Math.Min(day, DaysInMonth + daysInThisAyyamiHa));
             }
 
@@ -345,95 +266,10 @@ namespace NodaTime.Calendars
         internal override void ValidateYearMonthDay(int year, int month, int day)
         {
             Preconditions.CheckArgumentRange(nameof(year), year, WondrousMinYear, WondrousMaxYear);
+            Preconditions.CheckArgumentRange(nameof(month), month, 1, MonthsInYear);
 
-            switch (month)
-            {
-                case AyyamiHaMonth0:
-                    Preconditions.CheckArgumentRange(nameof(day), day, 1, DaysInAyyamiHa(year));
-                    break;
-                case Month18:
-                    // allow Ayyam-i-Ha days in this month
-                    Preconditions.CheckArgumentRange(nameof(day), day, 1, DaysInMonth + DaysInAyyamiHa(year));
-                    break;
-                default:
-                    Preconditions.CheckArgumentRange(nameof(month), month, 1, MonthsInYear);
-                    Preconditions.CheckArgumentRange(nameof(day), day, 1, DaysInMonth);
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Create a <see cref="LocalDate"/> in the Wondrous calendar
-        /// </summary>
-        /// <param name="year">Year in the Wondrous calendar</param>
-        /// <param name="month">Month (use 0 for Ayyam-i-Ha)</param>
-        /// <param name="day">Day in month</param>
-        /// <returns></returns>
-        public static LocalDate CreateWondrousDate(int year, int month, int day)
-        {
-            if (month == AyyamiHaMonth0)
-            {
-                var maxDay = GetYearInfo(year).DaysInAyyamiHa;
-
-                Preconditions.CheckArgumentRange(nameof(day), day, 1, maxDay);
-
-                // move Ayyam-i-Ha days to fall after the last day of month 18.
-                month = Month18;
-                day += DaysInMonth;
-            }
-            return new LocalDate(year, month, day, CalendarSystem.Wondrous);
-        }
-
-        public int DaysInAyyamiHa(int year)
-        {
-            return GetYearInfo(year).DaysInAyyamiHa;
-        }
-
-        /// <summary>
-        /// Return the day of this month. 
-        /// </summary>
-        /// <remarks>Deals with days in Ayyam-i-Ha.</remarks>
-        /// <param name="input"></param>
-        /// <returns></returns>
-        public static int WondrousDay(LocalDate input)
-        {
-            Preconditions.CheckArgument(input.Calendar == CalendarSystem.Wondrous, nameof(input), "Only valid when using the Wondrous calendar");
-
-            if (input.Month == Month18 && input.Day > DaysInMonth)
-            {
-                return input.Day - DaysInMonth;
-            }
-            return input.Day;
-        }
-
-        /// <summary>
-        /// Return the month of this date. If in Ayyam-i-Ha, returns 0.
-        /// </summary>
-        /// <remarks>Deals with Ayyam-i-Ha.</remarks>
-        /// <param name="input"></param>
-        /// <returns></returns>
-        public static int WondrousMonth(LocalDate input)
-        {
-            Preconditions.CheckArgument(input.Calendar == CalendarSystem.Wondrous, nameof(input), "Only valid when using the Wondrous calendar");
-
-            if (input.Month == Month18 && input.Day > DaysInMonth)
-            {
-                return 0;
-            }
-            return input.Month;
-        }
-
-        [DebuggerDisplay("{DaysInAyyamiHa}-{NawRuzDayInMarch}")]
-        public struct WondrousYearInfo
-        {
-            public int NawRuzDayInMarch;
-            public int DaysInAyyamiHa;
-
-            public WondrousYearInfo(int daysInAyyamiHa, int nawRuzDayInMarch)
-            {
-                NawRuzDayInMarch = nawRuzDayInMarch;
-                DaysInAyyamiHa = daysInAyyamiHa;
-            }
-        }
+            int daysInMonth = month == Month18 ? DaysInMonth + GetDaysInAyyamiHa(year) : DaysInMonth;
+            Preconditions.CheckArgumentRange(nameof(day), day, 1, daysInMonth);
+        } 
     }
 }


### PR DESCRIPTION
- Remove WondrousYearInfo: we never need both parts together,
  so just use two separate methods instead.
- Remove the cache: a dictionary is going to be more involved
  than the simple array lookup anyway, and it's not thread-safe.
- Simplify CalculateStartOfYearDays - aside from anything else,
  now we don't need to use DateTime :)
- Change WondrousYearMonthDayCalculator to *only* use the
  "Ayyam-i-Ha are part of month 18" model, e.g. for GetDaysInMonth.
  The alternative model of "Ayyam-i-Ha are in month 0" is used
  extensively in WondrousCalendarSystemTest. Fixes #1044.

@glittle Please could you review? It's nice to see that the calculator is now only 276 lines :)