### PR TITLE
Add NuGet config for MSBuild

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>		
+<configuration>		
+  <packageSources>		
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->		
+    <clear />		
+    <add key="api.nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <!-- Needed for docfx packages in SnippetExtractor :( -->
+    <add key="MyGet MSBuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />		
+  </packageSources>		
+</configuration>


### PR DESCRIPTION
This is unfortunate, and I'll ask the docfx team if they can avoid this in future, but it'll fix things for now.