### PR TITLE
Fix markdown bullet formatting within core concepts page

### DIFF
--- a/src/NodaTime.Web/Markdown/1.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/concepts.md
@@ -144,18 +144,20 @@ change occurs - usually for daylight saving changes.
 Most of the time when you use a `DateTimeZone` you won't need
 worry about that - the main purpose is usually to convert between a
 [`ZonedDateTime`][ZonedDateTime] and a [`LocalDateTime`][LocalDateTime]
-- where the names mean exactly what you expect them to. There's a slight
+, where the names mean exactly what you expect them to. There's a slight
 twist to this: converting from an `Instant` or a `ZonedDateTime` to a
 `LocalDateTime` is unambiguous; at any point in time, all the (accurate)
 clocks in a particular time zone will show the same time... but the
 reverse isn't true. Any one local time can map to:
 
 - A single instant in time: this is the case for almost all the time.
+
 - Two instants in time: this occurs around a time zone transition
 which goes from one offset to an earlier one, e.g. turning clocks
 back in the fall. If the clocks go back at 2am local time to 1am
 local time, then 1.30am occurs twice... so you need to tell Noda
 Time which of the possibilities you want to account for.
+
 - Zero instants in time: this occurs around a time zone transition
 which goes from one offset to a later one, e.g. turning clocks
 forward in the spring. If the clocks go forward at 1am local time to

--- a/src/NodaTime.Web/Markdown/1.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/concepts.md
@@ -143,8 +143,8 @@ change occurs - usually for daylight saving changes.
 
 Most of the time when you use a `DateTimeZone` you won't need
 worry about that - the main purpose is usually to convert between a
-[`ZonedDateTime`][ZonedDateTime] and a [`LocalDateTime`][LocalDateTime]
-, where the names mean exactly what you expect them to. There's a slight
+[`ZonedDateTime`][ZonedDateTime] and a [`LocalDateTime`][LocalDateTime], 
+where the names mean exactly what you expect them to. There's a slight
 twist to this: converting from an `Instant` or a `ZonedDateTime` to a
 `LocalDateTime` is unambiguous; at any point in time, all the (accurate)
 clocks in a particular time zone will show the same time... but the

--- a/src/NodaTime.Web/Markdown/1.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/concepts.md
@@ -151,13 +151,11 @@ clocks in a particular time zone will show the same time... but the
 reverse isn't true. Any one local time can map to:
 
 - A single instant in time: this is the case for almost all the time.
-
 - Two instants in time: this occurs around a time zone transition
 which goes from one offset to an earlier one, e.g. turning clocks
 back in the fall. If the clocks go back at 2am local time to 1am
 local time, then 1.30am occurs twice... so you need to tell Noda
 Time which of the possibilities you want to account for.
-
 - Zero instants in time: this occurs around a time zone transition
 which goes from one offset to a later one, e.g. turning clocks
 forward in the spring. If the clocks go forward at 1am local time to

--- a/src/NodaTime.Web/Markdown/1.3.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/concepts.md
@@ -146,8 +146,8 @@ change occurs - usually for daylight saving changes.
 
 Most of the time when you use a `DateTimeZone` you won't need
 worry about that - the main purpose is usually to convert between a
-[`ZonedDateTime`][ZonedDateTime] and a [`LocalDateTime`][LocalDateTime]
-, where the names mean exactly what you expect them to. There's a slight
+[`ZonedDateTime`][ZonedDateTime] and a [`LocalDateTime`][LocalDateTime], 
+where the names mean exactly what you expect them to. There's a slight
 twist to this: converting from an `Instant` or a `ZonedDateTime` to a
 `LocalDateTime` is unambiguous; at any point in time, all the (accurate)
 clocks in a particular time zone will show the same time... but the

--- a/src/NodaTime.Web/Markdown/1.3.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/concepts.md
@@ -154,13 +154,11 @@ clocks in a particular time zone will show the same time... but the
 reverse isn't true. Any one local time can map to:
 
 - A single instant in time: this is the case for almost all the time.
-
 - Two instants in time: this occurs around a time zone transition
 which goes from one offset to an earlier one, e.g. turning clocks
 back in the fall. If the clocks go back at 2am local time to 1am
 local time, then 1.30am occurs twice... so you need to tell Noda
 Time which of the possibilities you want to account for.
-
 - Zero instants in time: this occurs around a time zone transition
 which goes from one offset to a later one, e.g. turning clocks
 forward in the spring. If the clocks go forward at 1am local time to

--- a/src/NodaTime.Web/Markdown/1.3.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/1.3.x/concepts.md
@@ -147,18 +147,20 @@ change occurs - usually for daylight saving changes.
 Most of the time when you use a `DateTimeZone` you won't need
 worry about that - the main purpose is usually to convert between a
 [`ZonedDateTime`][ZonedDateTime] and a [`LocalDateTime`][LocalDateTime]
-- where the names mean exactly what you expect them to. There's a slight
+, where the names mean exactly what you expect them to. There's a slight
 twist to this: converting from an `Instant` or a `ZonedDateTime` to a
 `LocalDateTime` is unambiguous; at any point in time, all the (accurate)
 clocks in a particular time zone will show the same time... but the
 reverse isn't true. Any one local time can map to:
 
 - A single instant in time: this is the case for almost all the time.
+
 - Two instants in time: this occurs around a time zone transition
 which goes from one offset to an earlier one, e.g. turning clocks
 back in the fall. If the clocks go back at 2am local time to 1am
 local time, then 1.30am occurs twice... so you need to tell Noda
 Time which of the possibilities you want to account for.
+
 - Zero instants in time: this occurs around a time zone transition
 which goes from one offset to a later one, e.g. turning clocks
 forward in the spring. If the clocks go forward at 1am local time to

--- a/src/NodaTime.Web/Markdown/2.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/concepts.md
@@ -146,8 +146,8 @@ change occurs - usually for daylight saving changes.
 
 Most of the time when you use a `DateTimeZone` you won't need
 worry about that - the main purpose is usually to convert between a
-[`ZonedDateTime`][ZonedDateTime] and a [`LocalDateTime`][LocalDateTime]
-, where the names mean exactly what you expect them to. There's a slight
+[`ZonedDateTime`][ZonedDateTime] and a [`LocalDateTime`][LocalDateTime], 
+where the names mean exactly what you expect them to. There's a slight
 twist to this: converting from an `Instant` or a `ZonedDateTime` to a
 `LocalDateTime` is unambiguous; at any point in time, all the (accurate)
 clocks in a particular time zone will show the same time... but the

--- a/src/NodaTime.Web/Markdown/2.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/concepts.md
@@ -154,13 +154,11 @@ clocks in a particular time zone will show the same time... but the
 reverse isn't true. Any one local time can map to:
 
 - A single instant in time: this is the case for almost all the time.
-
 - Two instants in time: this occurs around a time zone transition
 which goes from one offset to an earlier one, e.g. turning clocks
 back in the fall. If the clocks go back at 2am local time to 1am
 local time, then 1.30am occurs twice... so you need to tell Noda
 Time which of the possibilities you want to account for.
-
 - Zero instants in time: this occurs around a time zone transition
 which goes from one offset to a later one, e.g. turning clocks
 forward in the spring. If the clocks go forward at 1am local time to

--- a/src/NodaTime.Web/Markdown/2.0.x/concepts.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/concepts.md
@@ -147,18 +147,20 @@ change occurs - usually for daylight saving changes.
 Most of the time when you use a `DateTimeZone` you won't need
 worry about that - the main purpose is usually to convert between a
 [`ZonedDateTime`][ZonedDateTime] and a [`LocalDateTime`][LocalDateTime]
-- where the names mean exactly what you expect them to. There's a slight
+, where the names mean exactly what you expect them to. There's a slight
 twist to this: converting from an `Instant` or a `ZonedDateTime` to a
 `LocalDateTime` is unambiguous; at any point in time, all the (accurate)
 clocks in a particular time zone will show the same time... but the
 reverse isn't true. Any one local time can map to:
 
 - A single instant in time: this is the case for almost all the time.
+
 - Two instants in time: this occurs around a time zone transition
 which goes from one offset to an earlier one, e.g. turning clocks
 back in the fall. If the clocks go back at 2am local time to 1am
 local time, then 1.30am occurs twice... so you need to tell Noda
 Time which of the possibilities you want to account for.
+
 - Zero instants in time: this occurs around a time zone transition
 which goes from one offset to a later one, e.g. turning clocks
 forward in the spring. If the clocks go forward at 1am local time to


### PR DESCRIPTION
While browsing the (excellent!) [core concepts docs](https://nodatime.org/2.2.x/userguide/concepts), I saw the following:

> ![image](https://user-images.githubusercontent.com/2148318/36069844-a0717d00-0ebe-11e8-9a56-4f1ddb3a4376.png)

It appears that the bullet points started unintentionally early due to the formatting.

I adjusted the formatting to remove the first bullet point (replacing it with a comma), and adding spacing between the other bullet points. I did this for all instances of this particular issue across the `1.0.x`, `1.3.x`, and `2.0.x` branches.