### PR TITLE
Make the more info link absolute

### DIFF
--- a/src/NodaTime.Web/Views/Shared/_Layout.cshtml
+++ b/src/NodaTime.Web/Views/Shared/_Layout.cshtml
@@ -93,7 +93,7 @@
                         <a href="/benchmarks">Benchmarks</a>
                     </li>
                     <li class="divider"></li>
-                    <li><a href="../#info">More Info</a></li>
+                    <li><a href="/#info">More Info</a></li>
                     <li class="divider show-for-small"></li>
                     <li class="has-form hide-for-small">
                         <a class="button" href="/#install">Install</a>


### PR DESCRIPTION
Fixes a reported issue around using "More Info" from a user guide or API page