### PR TITLE
Automatic project changes

### DIFF
--- a/src/NodaTime.Demo/NodaTime.Demo.csproj
+++ b/src/NodaTime.Demo/NodaTime.Demo.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="NUnitLite" Version="3.6.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -62,4 +62,8 @@
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
+++ b/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
@@ -17,4 +17,8 @@
     <PackageReference Include="NUnitLite" Version="3.8.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/src/NodaTime.Web.Test/NodaTime.Web.Test.csproj
+++ b/src/NodaTime.Web.Test/NodaTime.Web.Test.csproj
@@ -14,5 +14,9 @@
     <PackageReference Include="NUnit" Version="3.6.1" />
     <PackageReference Include="NUnitLite" Version="3.6.1" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   
 </Project>


### PR DESCRIPTION
These are provided by Visual Studio. I believe they should be
removable in VS15.7, but until then it's simpler to have a single
commit that we can revert later than to let the changes accidentally
end up in other commits.