### PR TITLE
Fix issues when TimeZoneInfo.Local is null

### DIFF
--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneSourceTest.cs
@@ -116,9 +116,7 @@ namespace NodaTime.Test.TimeZones
             using (TimeZoneInfoReplacer.Replace(null, systemZone))
             {
                 var source = new BclDateTimeZoneSource();
-                CollectionAssert.AreEqual(new[] { systemZone.Id }, source.GetIds().ToList());
                 Assert.Null(source.GetSystemDefaultId());
-
             }
         }
     }

--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.cs
@@ -209,6 +209,16 @@ namespace NodaTime.Test.TimeZones
                 zoneIntervalAfter);
         }
 
+        [Test]
+        public void LocalZoneIsNull()
+        {
+            var systemZone = TimeZoneInfo.CreateCustomTimeZone("Normal zone", TimeSpan.Zero, "Display", "Standard");
+            using (TimeZoneInfoReplacer.Replace(null, systemZone))
+            {
+                Assert.Throws<InvalidOperationException>(() => BclDateTimeZone.ForSystemDefault());
+            }
+        }
+
 #if NET451
         [Test]
         public void FakeDaylightSavingTime()

--- a/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
@@ -276,6 +276,17 @@ namespace NodaTime.Test.TimeZones
                 lastIncorrectDate, lastIncorrectBclOffset, lastIncorrectTzdbOffset);
         }
 
+        [Test]
+        public void LocalZoneIsNull()
+        {
+            // Use the existing system time zones, but just make TimeZoneInfo.Local return null.
+            using (TimeZoneInfoReplacer.Replace(null, TimeZoneInfo.GetSystemTimeZones().ToArray()))
+            {
+                // If we have no system time zone, we have no ID to map it to.
+                Assert.Null(TzdbDateTimeZoneSource.Default.GetSystemDefaultId());
+            }
+        }
+
 #if !NETCORE // CreateCustomTimeZone isn't available :(
         [Test]
         [TestCase("Pacific Standard Time", 0, "America/Los_Angeles", Description = "Windows ID")]

--- a/src/NodaTime/TimeZones/BclDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZone.cs
@@ -300,11 +300,16 @@ namespace NodaTime.TimeZones
         /// though this behaviour is not guaranteed.
         /// </para>
         /// </remarks>
+        /// <exception cref="InvalidOperationException">The system does not provide a time zone.</exception>
         /// <returns>A <see cref="BclDateTimeZone"/> wrapping the "local" (system) time zone as returned by
         /// <see cref="TimeZoneInfo.Local"/>.</returns>
         [NotNull] public static BclDateTimeZone ForSystemDefault()
         {
             TimeZoneInfo local = TimeZoneInfoInterceptor.Local;
+            if (local == null)
+            {
+                throw new InvalidOperationException("No system default time zone is available");
+            }
             BclDateTimeZone currentSystemDefault = systemDefault;
 
             // Cached copy is out of date - wrap a new one

--- a/src/NodaTime/TimeZones/TzdbDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/TzdbDateTimeZoneSource.cs
@@ -197,9 +197,14 @@ namespace NodaTime.TimeZones
         /// <inheritdoc />
         [CanBeNull] public string GetSystemDefaultId() => MapTimeZoneInfoId(TimeZoneInfoInterceptor.Local);
 
-        [VisibleForTesting]
-        internal string MapTimeZoneInfoId(TimeZoneInfo timeZone)
+        [VisibleForTesting, CanBeNull]
+        internal string MapTimeZoneInfoId([CanBeNull] TimeZoneInfo timeZone)
         {
+            // Unusual, but can happen in some Mono installations.
+            if (timeZone == null)
+            {
+                return null;
+            }
             string id = timeZone.Id;
             // First see if it's a Windows time zone ID.
             if (source.WindowsMapping.PrimaryMapping.TryGetValue(id, out string result))


### PR DESCRIPTION
This was found when trying out C# 8 nullable references.
TimeZoneInfo.Local has been observed to return null in some Mono
installations. We should handle that as reasonably as we can. We
already did for BclDateTimeZoneSource, but now we do in
TzdbDateTimeZoneSource too. Added tests for everywhere we need to
use TimeZoneInfo.Local (via the interceptor).