### PR TITLE
Remove NotNull annotation from DateInterval.GetEnumerator

### DIFF
--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -270,6 +270,6 @@ namespace NodaTime
         }
 
         /// <inheritdoc />
-        [NotNull] IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }


### PR DESCRIPTION
The documentation is inherited, and the build couldn't find the UID
to add it to. It's possible that it should be able to, but this is a
simple fix for now.