### PR TITLE
Fix .NET Core on Unix handling of TimeZoneInfo as far as possible

### DIFF
--- a/src/NodaTime.Test/TestHelper.cs
+++ b/src/NodaTime.Test/TestHelper.cs
@@ -20,7 +20,8 @@ namespace NodaTime.Test
     /// </summary>
     public static class TestHelper
     {
-        public static readonly bool IsRunningOnMono = Type.GetType("Mono.Runtime") != null;
+        public static bool IsRunningOnMono => Type.GetType("Mono.Runtime") != null;
+        public static bool IsRunningOnDotNetCoreUnix => !Environment.OSVersion.VersionString.Contains("Windows") && !IsRunningOnMono;
 
         /// <summary>
         /// Does nothing other than let us prove method or constructor calls don't throw.

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -411,15 +411,22 @@ namespace NodaTime.Test
         [Test]
         public void XmlSerialization_Bcl()
         {
-            // Skip this on Mono, which will have different BCL time zones. We can't easily
-            // guess which will be available :(
-            if (!TestHelper.IsRunningOnMono)
+            DateTimeZone zone;
+            try
             {
-                DateTimeZoneProviders.Serialization = DateTimeZoneProviders.Bcl;
-                var zone = DateTimeZoneProviders.Bcl["Eastern Standard Time"];
-                var value = new ZonedDateTime(new LocalDateTime(2013, 4, 12, 17, 53, 23).WithOffset(Offset.FromHours(-4)), zone);
-                TestHelper.AssertXmlRoundtrip(value, "<value zone=\"Eastern Standard Time\">2013-04-12T17:53:23-04</value>");
+                zone = DateTimeZoneProviders.Bcl["Eastern Standard Time"];
             }
+            catch (TimeZoneNotFoundException)
+            {
+                // This may occur on Mono, for example.
+                Assert.Ignore("Test assumes existence of BCL zone with ID of Eastern Standard Time");
+                // We won't get here.
+                return;
+            }
+
+            DateTimeZoneProviders.Serialization = DateTimeZoneProviders.Bcl;
+            var value = new ZonedDateTime(new LocalDateTime(2013, 4, 12, 17, 53, 23).WithOffset(Offset.FromHours(-4)), zone);
+            TestHelper.AssertXmlRoundtrip(value, "<value zone=\"Eastern Standard Time\">2013-04-12T17:53:23-04</value>");
         }
 
         [Test]

--- a/src/NodaTime.Tools.DumpTimeZoneInfo/Program.cs
+++ b/src/NodaTime.Tools.DumpTimeZoneInfo/Program.cs
@@ -31,7 +31,7 @@ namespace NodaTime.Tools.DumpTimeZoneInfo
         {
             foreach (var zone in TimeZoneInfo.GetSystemTimeZones().OrderBy(x => x.Id))
             {
-                Console.WriteLine(zone.Id);
+                Console.WriteLine($"{zone.Id} ({zone.DisplayName})");
             }
         }
 
@@ -60,21 +60,10 @@ namespace NodaTime.Tools.DumpTimeZoneInfo
         {
             var start = rule.DateStart.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var end = rule.DateEnd.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-            var stdOffset = FormatOffset(DetectStandardOffset(zone, rule));
             var delta = FormatOffset(rule.DaylightDelta);
             var startTransition = FormatTransition(rule.DaylightTransitionStart);
             var endTransition = FormatTransition(rule.DaylightTransitionEnd);
-            Console.WriteLine($"{start} - {end}: Standard offset: {stdOffset}; Daylight delta: {delta}; DST starts {startTransition} and ends {endTransition}");
-        }
-
-        private static TimeSpan DetectStandardOffset(TimeZoneInfo zone, TimeZoneInfo.AdjustmentRule rule)
-        {
-            var offset = zone.GetUtcOffset(rule.DateStart);
-            if (zone.IsDaylightSavingTime(rule.DateStart))
-            {
-                offset -= rule.DaylightDelta;
-            }
-            return offset;
+            Console.WriteLine($"{start} - {end}: Daylight delta: {delta}; DST starts {startTransition} and ends {endTransition}");
         }
 
         private static string FormatOffset(TimeSpan offset)
@@ -95,8 +84,8 @@ namespace NodaTime.Tools.DumpTimeZoneInfo
         private static string FormatTransition(TimeZoneInfo.TransitionTime transition)
         {
             return transition.IsFixedDateRule ?
-                string.Format("{0:MMMM dd} at {1:HH:mm}", new DateTime(2000, transition.Month, transition.Day), transition.TimeOfDay) :
-                string.Format("{0} {1} of {2:MMMM}; {3:HH:mm}", OrdinalWeeks[transition.Week], transition.DayOfWeek, new DateTime(2000, transition.Month, 1), transition.TimeOfDay);
+                string.Format("{0:MMMM dd} at {1:HH:mm:ss}", new DateTime(2000, transition.Month, transition.Day), transition.TimeOfDay) :
+                string.Format("{0} {1} of {2:MMMM}; {3:HH:mm:ss}", OrdinalWeeks[transition.Week], transition.DayOfWeek, new DateTime(2000, transition.Month, 1), transition.TimeOfDay);
         }
     }
 }

--- a/src/NodaTime/Utility/Preconditions.cs
+++ b/src/NodaTime/Utility/Preconditions.cs
@@ -184,7 +184,7 @@ namespace NodaTime.Utility
     /// </summary>
     internal class DebugPreconditionException : Exception
     {
-        internal DebugPreconditionException(string message)
+        internal DebugPreconditionException(string message) : base(message)
         {
         }
     }


### PR DESCRIPTION
This is mostly just a starting point to see if the test failures go down...

(Fixing #1140)