### PR TITLE
Remove AllowPartiallyTrustedCallersAttribute (APTCA)

### DIFF
--- a/src/NodaTime/AssemblyInfo.cs
+++ b/src/NodaTime/AssemblyInfo.cs
@@ -6,9 +6,6 @@ using System;
 using System.Resources;
 using System.Runtime.CompilerServices;
 
-// TODO: Check whether this is still a good idea
-[assembly: System.Security.AllowPartiallyTrustedCallers]
-
 [assembly: CLSCompliant(true)]
 [assembly: NeutralResourcesLanguage("en")]
 


### PR DESCRIPTION
This causes issues with C# 7.2 features (readonly struct) when
running on the desktop framework. Advice seems to be that CAS (Code
Access Security) is pretty much a thing of the past, but we may wish
to revisit this before 3.0.0 is released. I'll raise an issue for
that. In the mean time, this will at least allow our desktop
framework benchmarks to run again.

Fixes #1151 and #1153.