### PR TITLE
Remove Blazor from deployed site

### DIFF
--- a/build/buildweb.sh
+++ b/build/buildweb.sh
@@ -37,7 +37,8 @@ mv tmp/old_nodatime.org/.git $WEB_DIR
 cp -r ../src/NodaTime.Web/bin/Release/netcoreapp2.1/publish/* $WEB_DIR
 
 # Fix up blazor.config to work in Unix
-sed -i 's/\\/\//g' $WEB_DIR/NodaTime.Web.Blazor.blazor.config
+# (Blazor is currently disabled.)
+# sed -i 's/\\/\//g' $WEB_DIR/NodaTime.Web.Blazor.blazor.config
 
 # Run a smoke test to check it still works
 (cd $WEB_DIR; dotnet NodaTime.Web.dll --smoke-test)

--- a/build/finishautobuildweb.sh
+++ b/build/finishautobuildweb.sh
@@ -7,6 +7,8 @@
 
 echo "Build and test successful. Pushing."
 
+echo $commit > $root/$commit/nodatime.org/wwwroot/commit.txt
+
 # Commit and push
 # Ignore anything in .gitignore when adding files
 (cd $root/$commit/nodatime.org;

--- a/build/finishautobuildweb.sh
+++ b/build/finishautobuildweb.sh
@@ -9,11 +9,10 @@ echo "Build and test successful. Pushing."
 
 # Commit and push
 # Ignore anything in .gitignore when adding files
-# Temporarily disabled...
-#(cd $root/$commit/nodatime.org;
-# git add --all -f
-# git commit -a -m "Regenerate from main repo commit $commit";
-# git push)
+(cd $root/$commit/nodatime.org;
+ git add --all -f
+ git commit -a -m "Regenerate from main repo commit $commit";
+ git push)
 
 echo "Building container on Google Cloud Container Builder."
 

--- a/src/NodaTime.Web.Blazor/NodaTime.Web.Blazor.csproj
+++ b/src/NodaTime.Web.Blazor/NodaTime.Web.Blazor.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RunCommand>dotnet</RunCommand>
-    <RunArguments>blazor serve</RunArguments>
+    <RunArguments>blazor serve --pathbase=/blazor</RunArguments>
     <LangVersion>7.3</LangVersion>
     <BlazorLinkOnBuild>false</BlazorLinkOnBuild>
   </PropertyGroup>
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.4.0" />
+    <DotNetCliToolReference Include="Microsoft.AspNetCore.Blazor.Cli" Version="0.4.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NodaTime.Web/NodaTime.Web.csproj
+++ b/src/NodaTime.Web/NodaTime.Web.csproj
@@ -12,13 +12,11 @@
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.4.0" />
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.391" />
     
     <!-- Local NodaTime dependencies -->
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
     <ProjectReference Include="..\NodaTime.TzValidate.NodaDump\NodaTime.TzValidate.NodaDump.csproj" />
-    <ProjectReference Include="..\NodaTime.Web.Blazor\NodaTime.Web.Blazor.csproj" />
     
     <!-- Other dependencies -->
     <PackageReference Include="Google.Cloud.Storage.V1" Version="2.1.0" />
@@ -31,4 +29,10 @@
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>
   </ItemGroup>
+
+  <ItemGroup Condition="false">
+    <ProjectReference Include="..\NodaTime.Web.Blazor\NodaTime.Web.Blazor.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.4.0" />
+  </ItemGroup>
+  
 </Project>

--- a/src/NodaTime.Web/Startup.cs
+++ b/src/NodaTime.Web/Startup.cs
@@ -2,14 +2,16 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+#if BLAZOR
 using Microsoft.AspNetCore.Blazor.Server;
+using Microsoft.AspNetCore.ResponseCompression;
+#endif
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Headers;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Rewrite;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Configuration;
@@ -54,6 +56,7 @@ namespace NodaTime.Web
             services.Configure<ForwardedHeadersOptions>(
                 options => options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto);
 
+#if BLAZOR
             services.AddResponseCompression(options =>
             {
                 options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[]
@@ -62,6 +65,7 @@ namespace NodaTime.Web
                     WasmMediaTypeNames.Application.Wasm,
                 });
             });
+#endif
 
             if (UseGoogleCloudStorage)
             {
@@ -167,7 +171,9 @@ namespace NodaTime.Web
             // Force the set of TZDB data to be first loaded on startup.
             app.ApplicationServices.GetRequiredService<ITzdbRepository>().GetReleases();
 
+#if BLAZOR
             app.Map("/blazor", child => child.UseBlazor<NodaTime.Web.Blazor.Program>());
+#endif
         }
 
         /// Sets the Cache-Control header for static content, conditionally allowing the browser to use the content


### PR DESCRIPTION
We keep the project available to experiment with, but remove it from the deployed site right now.