### PR TITLE
Experimental change to OffsetDateTime

### DIFF
--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -670,8 +670,7 @@ namespace NodaTime
         public ZonedDateTime InUtc()
         {
             // Bypass any determination of offset and arithmetic, as we know the offset is zero.
-            var ymdc = GregorianYearMonthDayCalculator.GetGregorianYearMonthDayCalendarFromDaysSinceEpoch(duration.FloorDays);
-            var offsetDateTime = new OffsetDateTime(ymdc, duration.NanosecondOfFloorDay);
+            var offsetDateTime = new OffsetDateTime(new LocalDate(duration.FloorDays), duration.NanosecondOfFloorDay);
             return new ZonedDateTime(offsetDateTime, DateTimeZone.Utc);
         }
 

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -789,7 +789,7 @@ namespace NodaTime
         /// <param name="offset">The offset to apply.</param>
         /// <returns>The result of this local date/time offset by the given amount.</returns>
         [Pure]
-        public OffsetDateTime WithOffset(Offset offset) => new OffsetDateTime(date.YearMonthDayCalendar, time, offset);
+        public OffsetDateTime WithOffset(Offset offset) => new OffsetDateTime(date, time, offset);
 
         /// <summary>
         /// Returns the mapping of this local date/time within <see cref="DateTimeZone.Utc"/>.
@@ -799,7 +799,7 @@ namespace NodaTime
         [Pure]
         public ZonedDateTime InUtc() =>
             // Use the internal constructors to avoid validation. We know it will be fine.
-            new ZonedDateTime(new OffsetDateTime(date.YearMonthDayCalendar, time.NanosecondOfDay), DateTimeZone.Utc);
+            new ZonedDateTime(new OffsetDateTime(date, time.NanosecondOfDay), DateTimeZone.Utc);
 
         /// <summary>
         /// Returns the mapping of this local date/time within the given <see cref="DateTimeZone" />,


### PR DESCRIPTION
This used to affect performance, but that was before readonly
structs etc. The code is definitely simpler using LocalDate.

Next step would be to try to use OffsetTime instead of the long, but
that's more complicated. Let's see what the performance impact of
this is first.