### PR TITLE
Define a NETSTANDARD constant for all netstandard builds

### DIFF
--- a/src/NodaTime/AmbiguousTimeException.cs
+++ b/src/NodaTime/AmbiguousTimeException.cs
@@ -35,7 +35,7 @@ namespace NodaTime
     /// <threadsafety>Any public static members of this type are thread safe. Any instance members are not guaranteed to be thread safe.
     /// See the thread safety section of the user guide for more information.
     /// </threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     [Mutable] // Exception itself is mutable

--- a/src/NodaTime/AssemblyInfo.cs
+++ b/src/NodaTime/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System;
 using System.Resources;
 using System.Runtime.CompilerServices;
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
 // We *could* support this in netstandard, but we never did with the PCL
 // build, and we haven't had any reports of problems. We'll leave it in for
 // net45 for backwards compatibility, and can reintroduce it if necessary.

--- a/src/NodaTime/BinaryFormattingConstants.cs
+++ b/src/NodaTime/BinaryFormattingConstants.cs
@@ -4,7 +4,7 @@
 
 namespace NodaTime
 {
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     /// <summary>
     /// Names used by binary formatting, to make it easier to avoid any collisions.
     /// </summary>

--- a/src/NodaTime/DateTimeZoneProviders.cs
+++ b/src/NodaTime/DateTimeZoneProviders.cs
@@ -31,7 +31,7 @@ namespace NodaTime
             internal static readonly DateTimeZoneCache TzdbImpl = new DateTimeZoneCache(TzdbDateTimeZoneSource.Default);
         }
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         // As per TzDbHolder above, this exists to defer construction of a BCL provider until needed.
         // While BclDateTimeZoneSource itself is lightweight, DateTimeZoneCache still does a non-trivial amount of work
         // on initialisation.

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -59,11 +59,11 @@ namespace NodaTime
     /// </para>
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct Duration : IEquatable<Duration>, IComparable<Duration>, IComparable, IXmlSerializable, IFormattable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -1190,7 +1190,7 @@ namespace NodaTime
         /// <returns>The smaller duration of <paramref name="x"/> or <paramref name="y"/>.</returns>
         public static Duration Min(Duration x, Duration y) => x < y ? x : y;
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
         /// <summary>
         /// Private constructor only present for serialization.

--- a/src/NodaTime/Extensions/ClockExtensions.cs
+++ b/src/NodaTime/Extensions/ClockExtensions.cs
@@ -64,7 +64,7 @@ namespace NodaTime.Extensions
             return new ZonedClock(clock, zone, CalendarSystem.Iso);
         }
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD && !NETSTANDARD2_0
         /// <summary>
         /// Constructs a <see cref="ZonedClock"/> from a clock (the target of the method), in the wrapper for the
         /// BCL system default time zone time zone and the ISO calendar system.

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -69,7 +69,7 @@ namespace NodaTime.Globalization
         private static readonly Cache<CultureInfo, NodaFormatInfo> Cache = new Cache<CultureInfo, NodaFormatInfo>
             (500, culture => new NodaFormatInfo(culture), new ReferenceEqualityComparer<CultureInfo>());
 
-#if NETSTANDARD1_3
+#if NETSTANDARD
         private readonly string dateSeparator;
         private readonly string timeSeparator;
 #endif
@@ -108,7 +108,7 @@ namespace NodaTime.Globalization
             CultureInfo = cultureInfo;
             DateTimeFormat = dateTimeFormat;
             eraDescriptions = new ConcurrentDictionary<Era, EraDescription>();
-#if NETSTANDARD1_3
+#if NETSTANDARD
             // Horrible, but it does the job...
             dateSeparator = DateTime.MinValue.ToString("%/", cultureInfo);
             timeSeparator = DateTime.MinValue.ToString("%:", cultureInfo);
@@ -302,7 +302,7 @@ namespace NodaTime.Globalization
         /// </remarks>
         public DateTimeFormatInfo DateTimeFormat { get; }
         
-#if NETSTANDARD1_3
+#if NETSTANDARD
         /// <summary>
         /// Gets the time separator.
         /// </summary>
@@ -500,7 +500,7 @@ namespace NodaTime.Globalization
             private static string GetEraNameFromBcl(Era era, CultureInfo culture)
             {
                 var calendar = culture.DateTimeFormat.Calendar;
-#if NETSTANDARD1_3
+#if NETSTANDARD
                 var calendarTypeName = calendar.GetType().FullName;
                 bool getEraFromCalendar =
                     (era == Era.Common && calendarTypeName == "System.Globalization.GregorianCalendar") ||

--- a/src/NodaTime/IDateTimeZoneProvider.cs
+++ b/src/NodaTime/IDateTimeZoneProvider.cs
@@ -47,7 +47,7 @@ namespace NodaTime
         /// <value>The <see cref="IEnumerable{T}" /> of string ids.</value>
         [NotNull] ReadOnlyCollection<string> Ids { get; }
 
-#if NETSTANDARD1_3
+#if NETSTANDARD
         /// <summary>
         /// Gets the time zone from this provider that matches the system default time zone, if a matching time zone is
         /// available.

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -28,11 +28,11 @@ namespace NodaTime
     /// </para>
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct Instant : IEquatable<Instant>, IComparable<Instant>, IFormattable, IComparable, IXmlSerializable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -756,7 +756,7 @@ namespace NodaTime
         }
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
         /// <summary>
         /// Private constructor only present for serialization.

--- a/src/NodaTime/Interval.cs
+++ b/src/NodaTime/Interval.cs
@@ -27,11 +27,11 @@ namespace NodaTime
     /// </para>
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct Interval : IEquatable<Interval>, IXmlSerializable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -263,7 +263,7 @@ namespace NodaTime
         }
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
         /// <summary>
         /// Private constructor only present for serialization.

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -32,11 +32,11 @@ namespace NodaTime
     /// </para>
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct LocalDate : IEquatable<LocalDate>, IComparable<LocalDate>, IComparable, IFormattable, IXmlSerializable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -855,7 +855,7 @@ namespace NodaTime
         }
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
         /// <summary>
         /// Private constructor only present for serialization.

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -38,11 +38,11 @@ namespace NodaTime
     /// </para>
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct LocalDateTime : IEquatable<LocalDateTime>, IComparable<LocalDateTime>, IComparable, IFormattable, IXmlSerializable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -971,7 +971,7 @@ namespace NodaTime
         }
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
 
         /// <summary>

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -26,11 +26,11 @@ namespace NodaTime
     /// to a particular calendar, time zone or date.
     /// </summary>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct LocalTime : IEquatable<LocalTime>, IComparable<LocalTime>, IFormattable, IComparable, IXmlSerializable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -783,7 +783,7 @@ namespace NodaTime
         }
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
         /// <summary>
         /// Private constructor only present for serialization.

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -16,6 +16,7 @@
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <Deterministic>True</Deterministic>
+    <DefineConstants Condition="$(TargetFramework.StartsWith('netstandard'))">NETSTANDARD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime/Offset.cs
+++ b/src/NodaTime/Offset.cs
@@ -35,11 +35,11 @@ namespace NodaTime
     /// but only in very rare historical cases (or fictional ones).</para>
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct Offset : IEquatable<Offset>, IComparable<Offset>, IFormattable, IComparable, IXmlSerializable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -517,7 +517,7 @@ namespace NodaTime
         }
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
         /// <summary>
         /// Private constructor only present for serialization.

--- a/src/NodaTime/OffsetDate.cs
+++ b/src/NodaTime/OffsetDate.cs
@@ -21,11 +21,11 @@ namespace NodaTime
     /// a date at a specific offset from UTC but without any time-of-day information.
     /// </summary>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct OffsetDate : IEquatable<OffsetDate>, IXmlSerializable, IFormattable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -242,7 +242,7 @@ namespace NodaTime
         }
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
         /// <summary>
         /// Private constructor only present for serialization.

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -32,11 +32,11 @@ namespace NodaTime
     /// </para>
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct OffsetDateTime : IEquatable<OffsetDateTime>, IFormattable, IXmlSerializable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -938,7 +938,7 @@ namespace NodaTime
         }
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
         /// <summary>
         /// Private constructor only present for serialization.

--- a/src/NodaTime/OffsetTime.cs
+++ b/src/NodaTime/OffsetTime.cs
@@ -20,11 +20,11 @@ namespace NodaTime
     /// a time-of-day at a specific offset from UTC but without any date information.
     /// </summary>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct OffsetTime : IEquatable<OffsetTime>, IXmlSerializable, IFormattable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -247,7 +247,7 @@ namespace NodaTime
         }
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
         /// <summary>
         /// Private constructor only present for serialization.

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -43,12 +43,12 @@ namespace NodaTime
     /// </para>
     /// </remarks>
     /// <threadsafety>This type is immutable reference type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     [Immutable]
     public sealed class Period : IEquatable<Period>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -892,7 +892,7 @@ namespace NodaTime
             Nanoseconds == other.Nanoseconds;
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
         /// <summary>
         /// Private constructor only present for serialization.

--- a/src/NodaTime/SkippedTimeException.cs
+++ b/src/NodaTime/SkippedTimeException.cs
@@ -34,7 +34,7 @@ namespace NodaTime
     /// <threadsafety>Any public static members of this type are thread safe. Any instance members are not guaranteed to be thread safe.
     /// See the thread safety section of the user guide for more information.
     /// </threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     [Mutable] // Exception itself is mutable

--- a/src/NodaTime/Text/InvalidPatternException.cs
+++ b/src/NodaTime/Text/InvalidPatternException.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Globalization;
 using NodaTime.Annotations;
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
 using System.Runtime.Serialization;
 #endif
 
@@ -17,7 +17,7 @@ namespace NodaTime.Text
     /// <threadsafety>Any public static members of this type are thread safe. Any instance members are not guaranteed to be thread safe.
     /// See the thread safety section of the user guide for more information.
     /// </threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     [Mutable] // Exception is mutable
@@ -51,7 +51,7 @@ namespace NodaTime.Text
         }
 
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         /// <summary>
         /// Creates a new InvalidPatternException from the given serialization information.
         /// </summary>

--- a/src/NodaTime/Text/UnparsableValueException.cs
+++ b/src/NodaTime/Text/UnparsableValueException.cs
@@ -4,7 +4,7 @@
 
 using System;
 using NodaTime.Annotations;
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
 using System.Runtime.Serialization;
 #endif
 
@@ -16,7 +16,7 @@ namespace NodaTime.Text
     /// <threadsafety>Any public static members of this type are thread safe. Any instance members are not guaranteed to be thread safe.
     /// See the thread safety section of the user guide for more information.
     /// </threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     [Mutable] // Exception is Mutable
@@ -37,7 +37,7 @@ namespace NodaTime.Text
             : base(message)
         {
         }
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         /// <summary>
         /// Creates a new UnparsableValueException from the given serialization information.
         /// </summary>

--- a/src/NodaTime/TimeZones/BclDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZone.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using NodaTime.Annotations;
 using NodaTime.Extensions;
-#if !NETSTANDARD1_3
+#if !NETSTANDARD && !NETSTANDARD2_0
 using System;
 using System.Collections.Generic;
 using NodaTime.Utility;

--- a/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
 using JetBrains.Annotations;
 using NodaTime.Annotations;
 using System;

--- a/src/NodaTime/TimeZones/DateTimeZoneNotFoundException.cs
+++ b/src/NodaTime/TimeZones/DateTimeZoneNotFoundException.cs
@@ -20,12 +20,12 @@ namespace NodaTime.TimeZones
     /// <threadsafety>Any public static members of this type are thread safe. Any instance members are not guaranteed to be thread safe.
     /// See the thread safety section of the user guide for more information.
     /// </threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     [Mutable] // Exception itself is mutable
     public sealed class DateTimeZoneNotFoundException
-#if NETSTANDARD1_3
+#if NETSTANDARD
         : Exception
 #else
         : TimeZoneNotFoundException

--- a/src/NodaTime/TimeZones/InvalidDateTimeZoneSourceException.cs
+++ b/src/NodaTime/TimeZones/InvalidDateTimeZoneSourceException.cs
@@ -15,7 +15,7 @@ namespace NodaTime.TimeZones
     /// <threadsafety>Any public static members of this type are thread safe. Any instance members are not guaranteed to be thread safe.
     /// See the thread safety section of the user guide for more information.
     /// </threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     [Mutable] // Exception itself is mutable

--- a/src/NodaTime/TimeZones/ZoneYearOffset.cs
+++ b/src/NodaTime/TimeZones/ZoneYearOffset.cs
@@ -137,7 +137,7 @@ namespace NodaTime.TimeZones
             if (failed)
             {
                 string range = allowNegated ? $"[{minimum}, {maximum}] or [{-maximum}, {-minimum}]" : $"[{minimum}, {maximum}]";
-#if NETSTANDARD1_3
+#if NETSTANDARD
                 throw new ArgumentOutOfRangeException(name, $"{name} is not in the valid range: {range}");
 #else
                 throw new ArgumentOutOfRangeException(name, value, $"{name} is not in the valid range: {range}");

--- a/src/NodaTime/Utility/InvalidNodaDataException.cs
+++ b/src/NodaTime/Utility/InvalidNodaDataException.cs
@@ -21,7 +21,7 @@ namespace NodaTime.Utility
     /// <threadsafety>Any public static members of this type are thread safe. Any instance members are not guaranteed to be thread safe.
     /// See the thread safety section of the user guide for more information.
     /// </threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     [Mutable] // Exception itself is mutable

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -40,11 +40,11 @@ namespace NodaTime
     /// </para>
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
     [Serializable]
 #endif
     public struct ZonedDateTime : IEquatable<ZonedDateTime>, IFormattable, IXmlSerializable
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         , ISerializable
 #endif
     {
@@ -835,7 +835,7 @@ namespace NodaTime
         }
         #endregion
 
-#if !NETSTANDARD1_3
+#if !NETSTANDARD
         #region Binary serialization
 
         /// <summary>


### PR DESCRIPTION
This means the netstandard1.3 and netstandard2.0 builds will do the same thing. (The changes required to make netstandard2.0 work properly with BclDateTimeZone are in the master branch.)