### PR TITLE
Fix embedded pattern documentation

### DIFF
--- a/src/NodaTime.Web/Markdown/2.0.x/offsetdatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/offsetdatetime-patterns.md
@@ -20,7 +20,7 @@ To use culture-specific standard date or time patterns in a custom `OffsetDateTi
 
 - `ld<...>`: The `LocalDate` pattern within angle brackets
 - `lt<...>`: The `LocalTime` pattern within angle brackets
-- `ldt<...>`: The `LocalDateTime` pattern within angle brackets
+- `l<...>`: The `LocalDateTime` pattern within angle brackets
 
 For example, to use a culture-specific short date format, but a fixed time format,
 followed by the offset in general form, you might use a pattern of `ld<d> HH:mm:ss o<G>`

--- a/src/NodaTime.Web/Markdown/2.0.x/zoneddatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/zoneddatetime-patterns.md
@@ -32,4 +32,4 @@ If the pattern does not contain an offset specifier ("o&lt;...&gt;") the local d
 
 If the pattern *does* contain an offset specifier, then when parsing, the offset present in the text is validated against the time zone. By specifying both a time zone identifier and an offset, the ambiguity around time zone transitions is eliminated. Again, if the offset is invalid for the time zone at the given local date and time, an `UnparsableValueException` result is produced.
 
-The `ld<...>`, `lt<...>` and `ldt<...>` specifiers from `OffsetDateTime` patterns are also supported for `ZonedDateTime`, to allow for standard date/time patterns to be used as part of the `ZonedDateTime` pattern.
+The `ld<...>`, `lt<...>` and `l<...>` specifiers from `OffsetDateTime` patterns are also supported for `ZonedDateTime`, to allow for standard date/time patterns to be used as part of the `ZonedDateTime` pattern.

--- a/src/NodaTime.Web/Markdown/2.1.x/zoneddatetime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.1.x/zoneddatetime-patterns.md
@@ -40,4 +40,4 @@ A null resolver can be specified, in which case the pattern can only be used for
 
 If the pattern *does* contain an offset specifier, then when parsing, the offset present in the text is validated against the time zone. By specifying both a time zone identifier and an offset, the ambiguity around time zone transitions is eliminated. Again, if the offset is invalid for the time zone at the given local date and time, an `UnparsableValueException` result is produced.
 
-The `ld<...>`, `lt<...>` and `ldt<...>` specifiers from `OffsetDateTime` patterns are also supported for `ZonedDateTime`, to allow for standard date/time patterns to be used as part of the `ZonedDateTime` pattern.
+The `ld<...>`, `lt<...>` and `l<...>` specifiers from `OffsetDateTime` patterns are also supported for `ZonedDateTime`, to allow for standard date/time patterns to be used as part of the `ZonedDateTime` pattern.


### PR DESCRIPTION
For both ZonedDateTime and OffsetDateTime, an embedded LocalDateTime
pattern is specified with `l<...>`, not `ldt<...>`

Fixes #1218.