### PR TITLE
Update to using the C# 8 preview

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 # TODO: Test against Mono as well, using matrix.include
 language: csharp
 mono: none
-dotnet: 2.1.300
+dotnet: 3.0.100-preview-009812
 dist: trusty
 
 # We need to install the .NET Core 1.0 runtime to run netcoreapp1.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 # it elsewhere...
 version: 1.0.{build}-appveyor
 
-image: Visual Studio 2017
+image: Visual Studio 2019 Preview
 
 branches:
   only:

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "sdk": {
-    "version": "2.1.300"
+    "version": "3.0.100-preview-009812"
   }
 }

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -16,7 +16,7 @@
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <Deterministic>True</Deterministic>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Travis and AppVeyor may fail at this point. Bagpuss certainly will when it comes to building docs, but that'll be easy to fix.