### PR TITLE
Disable code coverage temporarily

### DIFF
--- a/build/appveyor.sh
+++ b/build/appveyor.sh
@@ -13,7 +13,8 @@ dotnet --info
 dotnet build -c Release src/NodaTime-All.sln
 
 # Run the tests under dotCover
-build/coverage.sh
+# Temporarily disabled until we've got this working with C# 8
+# build/coverage.sh
 
 dotnet run --no-build -c Release -p src/NodaTime.Test -- --where=cat!=Slow
 


### PR DESCRIPTION
(This should fix appveyor, but not Travis, which still doesn't have the .NET Core 3.0 preview bits available.)