### PR TITLE
Support C# 8 nullable reference types

### DIFF
--- a/lib/commandline/CommandLineText.cs
+++ b/lib/commandline/CommandLineText.cs
@@ -170,18 +170,11 @@ namespace CommandLine.Text
     {
         private readonly bool _isSymbolUpper;
         private readonly int[] _years;
-        private readonly string _author;
+        private readonly string? _author;
         private static readonly string _defaultCopyrightWord = "Copyright";
         private static readonly string _symbolLower = "(c)";
         private static readonly string _symbolUpper = "(C)";
         private StringBuilder _builder;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CommandLine.Text.CopyrightInfo"/> class.
-        /// </summary>
-        protected CopyrightInfo ()
-        {
-        }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandLine.Text.CopyrightInfo"/> class
@@ -234,39 +227,19 @@ namespace CommandLine.Text
         /// Returns the copyright informations as a <see cref="System.String"/>.
         /// </summary>
         /// <returns>The <see cref="System.String"/> that contains the copyright informations.</returns>
-        public override string ToString ()
-        {
-            _builder.Append (CopyrightWord);
-            _builder.Append (' ');
-            if (_isSymbolUpper)
-                _builder.Append (_symbolUpper);
-            else
-                _builder.Append (_symbolLower);
-
-            _builder.Append (' ');
-            _builder.Append (FormatYears (_years));
-            _builder.Append (' ');
-            _builder.Append (_author);
-
-            return _builder.ToString ();
-        }
+        public override string ToString() => $"{CopyrightWord} {(_isSymbolUpper ? _symbolUpper : _symbolLower)} {FormatYears(_years)} {_author}";
 
         /// <summary>
         /// Converts the copyright informations to a <see cref="System.String"/>.
         /// </summary>
         /// <param name="info">This <see cref="CommandLine.Text.CopyrightInfo"/> instance.</param>
         /// <returns>The <see cref="System.String"/> that contains the copyright informations.</returns>
-        public static implicit operator string (CopyrightInfo info)
-        {
-            return info.ToString ();
-        }
+        public static implicit operator string(CopyrightInfo info) => info.ToString();
 
         /// <summary>
         /// When overridden in a derived class, allows to specify a different copyright word.
         /// </summary>
-        protected virtual string CopyrightWord {
-            get { return _defaultCopyrightWord; }
-        }
+        protected virtual string CopyrightWord => _defaultCopyrightWord;
 
         /// <summary>
         /// When overridden in a derived class, allows to specify a new algorithm to render copyright years
@@ -274,24 +247,24 @@ namespace CommandLine.Text
         /// </summary>
         /// <param name="years">A <see cref="System.Int32"/> array of years.</param>
         /// <returns>A <see cref="System.String"/> instance with copyright years.</returns>
-        protected virtual string FormatYears (int[] years)
+        protected virtual string FormatYears(int[] years)
         {
             if (years.Length == 1)
-                return years [0].ToString (CultureInfo.InvariantCulture);
+            {
+                return years[0].ToString(CultureInfo.InvariantCulture);
+            }
 
-            var yearsPart = new StringBuilder (years.Length * 6);
+            var yearsPart = new StringBuilder(years.Length * 6);
             for (int i = 0; i < years.Length; i++) {
                 yearsPart.Append (years [i].ToString (CultureInfo.InvariantCulture));
                 int next = i + 1;
-                if (next < years.Length) {
-                    if (years [next] - years [i] > 1)
-                        yearsPart.Append (" - ");
-                    else
-                        yearsPart.Append (", ");
+                if (next < years.Length)
+                {
+                    yearsPart.Append(years[next] - years[i] > 1 ? " - " : ", ");
                 }
             }
 
-            return yearsPart.ToString ();
+            return yearsPart.ToString();
         }
     }
 
@@ -302,7 +275,7 @@ namespace CommandLine.Text
     public class HeadingInfo
     {
         private readonly string _programName;
-        private readonly string _version;
+        private readonly string? _version;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandLine.Text.HeadingInfo"/> class
@@ -310,7 +283,7 @@ namespace CommandLine.Text
         /// </summary>
         /// <param name="programName">The name of the program.</param>
         /// <exception cref="System.ArgumentException">Thrown when parameter <paramref name="programName"/> is null or empty string.</exception>
-        public HeadingInfo (string programName)
+        public HeadingInfo(string programName)
             : this(programName, null)
         {
         }
@@ -322,7 +295,7 @@ namespace CommandLine.Text
         /// <param name="programName">The name of the program.</param>
         /// <param name="version">The version of the program.</param>
         /// <exception cref="System.ArgumentException">Thrown when parameter <paramref name="programName"/> is null or empty string.</exception>
-        public HeadingInfo (string programName, string version)
+        public HeadingInfo(string programName, string? version)
         {
             Assumes.NotNullOrEmpty (programName, "programName");
 
@@ -334,19 +307,15 @@ namespace CommandLine.Text
         /// Returns the heading informations as a <see cref="System.String"/>.
         /// </summary>
         /// <returns>The <see cref="System.String"/> that contains the heading informations.</returns>
-        public override string ToString ()
+        public override string ToString()
         {
-            bool isVersionNull = string.IsNullOrEmpty (_version);
-            var builder = new StringBuilder (_programName.Length +
-                (!isVersionNull ? _version.Length + 1 : 0)
-            );
-            builder.Append (_programName);
-            if (!isVersionNull) {
-                builder.Append (' ');
-                builder.Append (_version);
+            var builder = new StringBuilder(_programName);
+            if (!string.IsNullOrEmpty(_version))
+            {
+                builder.Append(' ');
+                builder.Append(_version);
             }
-
-            return builder.ToString ();
+            return builder.ToString();
         }
 
         /// <summary>
@@ -354,10 +323,7 @@ namespace CommandLine.Text
         /// </summary>
         /// <param name="info">This <see cref="CommandLine.Text.HeadingInfo"/> instance.</param>
         /// <returns>The <see cref="System.String"/> that contains the heading informations.</returns>
-        public static implicit operator string (HeadingInfo info)
-        {
-            return info.ToString ();
-        }
+        public static implicit operator string(HeadingInfo info) => info.ToString();
 
         /// <summary>
         /// Writes out a string and a new line using the program name specified in the constructor
@@ -367,15 +333,15 @@ namespace CommandLine.Text
         /// <param name="writer">The target <see cref="System.IO.TextWriter"/> derived type.</param>
         /// <exception cref="System.ArgumentException">Thrown when parameter <paramref name="message"/> is null or empty string.</exception>
         /// <exception cref="System.ArgumentNullException">Thrown when parameter <paramref name="writer"/> is null.</exception>
-        public void WriteMessage (string message, TextWriter writer)
+        public void WriteMessage(string message, TextWriter writer)
         {
-            Assumes.NotNullOrEmpty (message, "message");
-            Assumes.NotNull (writer, "writer");
+            Assumes.NotNullOrEmpty(message, "message");
+            Assumes.NotNull(writer, "writer");
 
             var builder = new StringBuilder (_programName.Length + message.Length + 2);
-            builder.Append (_programName);
-            builder.Append (": ");
-            builder.Append (message);
+            builder.Append(_programName);
+            builder.Append(": ");
+            builder.Append(message);
             writer.WriteLine (builder.ToString ());
         }
 
@@ -434,36 +400,32 @@ namespace CommandLine.Text
     #region Attributes
     public abstract class MultiLineTextAttribute : Attribute
     {
-        //string _fullText;
-        string _line1;
-        string _line2;
-        string _line3;
-        string _line4;
-        string _line5;
+        string? _line1;
+        string? _line2;
+        string? _line3;
+        string? _line4;
+        string? _line5;
 
-        //public MultiLineTextAttribute(object fullText)
-        //{
-        //    var realFullText = fullText as string;
-        //    Assumes.NotNullOrEmpty(realFullText, "fullText");
-        //    _fullText = realFullText;
-        //}
         public MultiLineTextAttribute(string line1)
         {
             Assumes.NotNullOrEmpty(line1, "line1");
             _line1 = line1;
         }
+
         public MultiLineTextAttribute(string line1, string line2)
             : this(line1)
         {
             Assumes.NotNullOrEmpty(line2, "line2");
             _line2 = line2;
         }
-                public MultiLineTextAttribute(string line1, string line2, string line3)
+
+        public MultiLineTextAttribute(string line1, string line2, string line3)
             : this(line1, line2)
         {
             Assumes.NotNullOrEmpty(line3, "line3");
             _line3 = line3;
         }
+
         public MultiLineTextAttribute(string line1, string line2, string line3, string line4)
             : this(line1, line2, line3)
         {
@@ -475,29 +437,7 @@ namespace CommandLine.Text
         {
             Assumes.NotNullOrEmpty(line5, "line5");
             _line5 = line5;
-        }
-
-        /*
-        public string FullText
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(_fullText))
-                {
-                    if (!string.IsNullOrEmpty(_line1))
-                    {
-                        var builder = new StringBuilder(_line1);
-                        builder.AppendLineIfNotNullOrEmpty(_line2);
-                        builder.AppendLineIfNotNullOrEmpty(_line3);
-                        builder.AppendLineIfNotNullOrEmpty(_line4);
-                        builder.AppendLineIfNotNullOrEmpty(_line5);
-                        _fullText = builder.ToString();
-                    }
-                }
-                return _fullText;
-            }
-        }
-        */
+        }        
 
         internal void AddToHelpText(HelpText helpText, bool before)
         {
@@ -631,21 +571,16 @@ namespace CommandLine.Text
         private const int _builderCapacity = 128;
         private const int _defaultMaximumLength = 80; // default console width
         private int? _maximumDisplayWidth;
-        private string _heading;
-        private string _copyright;
+        private string? _heading;
+        private string? _copyright;
         private bool _additionalNewLineAfterOption;
         private StringBuilder _preOptionsHelp;
-        private StringBuilder _optionsHelp;
+        private StringBuilder? _optionsHelp;
         private StringBuilder _postOptionsHelp;
         private BaseSentenceBuilder _sentenceBuilder;
         private static readonly string _defaultRequiredWord = "Required.";
         private bool _addDashesToOption = false;
         
-        /// <summary>
-        /// Occurs when an option help text is formatted.
-        /// </summary>
-        public event EventHandler<FormatOptionHelpTextEventArgs> FormatOptionHelpText;
-
         /// <summary>
         /// Message type enumeration.
         /// </summary>
@@ -670,10 +605,9 @@ namespace CommandLine.Text
         /// </summary>
         public HelpText ()
         {
-            _preOptionsHelp = new StringBuilder (_builderCapacity);
-            _postOptionsHelp = new StringBuilder (_builderCapacity);
-            
-            _sentenceBuilder = BaseSentenceBuilder.CreateBuiltIn ();
+            _preOptionsHelp = new StringBuilder(_builderCapacity);
+            _postOptionsHelp = new StringBuilder(_builderCapacity);            
+            _sentenceBuilder = BaseSentenceBuilder.CreateBuiltIn();
         }
         
         /// <summary>
@@ -683,11 +617,9 @@ namespace CommandLine.Text
         /// <param name="sentenceBuilder">
         /// A <see cref="BaseSentenceBuilder"/> instance.
         /// </param>
-        public HelpText (BaseSentenceBuilder sentenceBuilder)
-            : this()
+        public HelpText (BaseSentenceBuilder sentenceBuilder) : this()
         {
-            Assumes.NotNull (sentenceBuilder, "sentenceBuilder");
-            
+            Assumes.NotNull (sentenceBuilder, "sentenceBuilder");            
             _sentenceBuilder = sentenceBuilder;
         }
 
@@ -791,10 +723,7 @@ namespace CommandLine.Text
         /// <param name='options'>
         /// The instance that collected command line arguments parsed with <see cref="CommandLine.CommandLineParser"/> class.
         /// </param>
-        public static HelpText AutoBuild(object options)
-        {
-            return AutoBuild(options, null);
-        }
+        public static HelpText AutoBuild(object options) => AutoBuild(options, null);
 
         /// <summary>
         /// Creates a new instance of the <see cref="CommandLine.Text.HelpText"/> class using common defaults.
@@ -808,7 +737,7 @@ namespace CommandLine.Text
         /// <param name='errDelegate'>
         /// A delegate used to customize the text block for reporting parsing errors.
         /// </param>
-        public static HelpText AutoBuild(object options, HandleParsingErrorsDelegate errDelegate)
+        public static HelpText AutoBuild(object options, HandleParsingErrorsDelegate? errDelegate)
         {
             var title = ReflectionUtil.GetAttribute<AssemblyTitleAttribute>();
             if (title == null) throw new InvalidOperationException("HelpText::AutoBuild() requires that you define AssemblyTitleAttribute.");
@@ -982,7 +911,7 @@ namespace CommandLine.Text
         /// <param name="maximumLength">The maximum length of the help documentation.</param>
         /// <exception cref="System.ArgumentNullException">Thrown when parameter <paramref name="options"/> is null.</exception>
         /// <exception cref="System.ArgumentNullException">Thrown when parameter <paramref name="requiredWord"/> is null or empty string.</exception>
-        public void AddOptions (object options, string requiredWord, int maximumLength)
+        public void AddOptions(object options, string requiredWord, int maximumLength)
         {
             Assumes.NotNull (options, "options");
             Assumes.NotNullOrEmpty (requiredWord, "requiredWord");
@@ -998,11 +927,12 @@ namespace CommandLine.Text
                 return;
             }
 
-            int maxLength = GetMaxLength (optionList);
-            _optionsHelp = new StringBuilder (_builderCapacity);
+            int maxLength = GetMaxLength(optionList);
+            _optionsHelp = new StringBuilder(_builderCapacity);
             int remainingSpace = maximumLength - (maxLength + 6);
-            foreach (BaseOptionAttribute option in optionList) {
-                AddOption (requiredWord, maxLength, option, remainingSpace);
+            foreach (BaseOptionAttribute option in optionList)
+            {
+                AddOption(requiredWord, maxLength, option, remainingSpace);
             }
         }
 
@@ -1062,81 +992,82 @@ namespace CommandLine.Text
 
         private void AddOption (string requiredWord, int maxLength, BaseOptionAttribute option, int widthOfHelpText)
         {
-            _optionsHelp.Append ("  ");
+            // Only called by AddOption, after setting _optionsHelp
+            _optionsHelp!.Append("  ");
             StringBuilder optionName = new StringBuilder (maxLength);
-            if (option.HasShortName) {
-                if (_addDashesToOption) {
+            if (option.HasShortName)
+            {
+                if (_addDashesToOption)
+                {
                     optionName.Append ('-');
-                }
-                
-                optionName.AppendFormat ("{0}", option.ShortName);
-                
-                if (option.HasLongName) {
+                }                
+                optionName.AppendFormat ("{0}", option.ShortName);                
+                if (option.HasLongName)
+                {
                     optionName.Append (", ");
                 }
             }
 
-            if (option.HasLongName) {
-                if (_addDashesToOption) {
+            if (option.HasLongName)
+            {
+                if (_addDashesToOption)
+                {
                     optionName.Append ("--");
-                }
-                
+                }                
                 optionName.AppendFormat ("{0}", option.LongName);
             }
 
-            if (optionName.Length < maxLength) {
-                _optionsHelp.Append (optionName.ToString ().PadRight (maxLength));
-            } else {
-                _optionsHelp.Append (optionName.ToString ());
-            }
+            _optionsHelp.Append(optionName.Length < maxLength ? optionName.ToString().PadRight(maxLength) : optionName.ToString());
 
-            _optionsHelp.Append ("    ");
-            if (option.Required) {
+            _optionsHelp.Append("    ");
+            if (option.Required)
+            {
                 option.HelpText = String.Format ("{0} ", requiredWord) + option.HelpText;
             }
 
-            FormatOptionHelpTextEventArgs e = new FormatOptionHelpTextEventArgs (option);
-            OnFormatOptionHelpText (e);
-            option.HelpText = e.Option.HelpText;
-
-            if (!string.IsNullOrEmpty (option.HelpText)) {
-                do {
+            if (!string.IsNullOrEmpty (option.HelpText))
+            {
+                do
+                {
                     int wordBuffer = 0;
                     var words = option.HelpText.Split (new[] {' '});
-                    for (int i = 0; i < words.Length; i++) {
-                        if (words [i].Length < (widthOfHelpText - wordBuffer)) {
+                    for (int i = 0; i < words.Length; i++)
+                    {
+                        if (words [i].Length < (widthOfHelpText - wordBuffer))
+                        {
                             _optionsHelp.Append (words [i]);
                             wordBuffer += words [i].Length;
-                            if ((widthOfHelpText - wordBuffer) > 1 && i != words.Length - 1) {
+                            if ((widthOfHelpText - wordBuffer) > 1 && i != words.Length - 1)
+                            {
                                 _optionsHelp.Append (" ");
                                 wordBuffer++;
                             }
-                        } else if (words [i].Length >= widthOfHelpText && wordBuffer == 0) {
-                            _optionsHelp.Append (words [i].Substring (
-                                0,
-                                widthOfHelpText
-                            ));
+                        }
+                        else if (words [i].Length >= widthOfHelpText && wordBuffer == 0)
+                        {
+                            _optionsHelp.Append (words[i].Substring(0, widthOfHelpText));
                             wordBuffer = widthOfHelpText;
                             break;
-                        } else {
+                        }
+                        else
+                        {
                             break;
                         }
                     }
-                    option.HelpText = option.HelpText.Substring (Math.Min (
-                        wordBuffer,
-                        option.HelpText.Length
-                    ))
-                        .Trim ();
-                    if (option.HelpText.Length > 0) {
-                        _optionsHelp.Append (Environment.NewLine);
-                        _optionsHelp.Append (new string (' ', maxLength + 6));
+                    option.HelpText = option.HelpText.Substring(Math.Min(wordBuffer, option.HelpText.Length)).Trim();
+                    if (option.HelpText.Length > 0)
+                    {
+                        _optionsHelp.Append(Environment.NewLine);
+                        _optionsHelp.Append(new string (' ', maxLength + 6));
                     }
                 } while (option.HelpText.Length > widthOfHelpText);
             }
-            _optionsHelp.Append (option.HelpText);
-            _optionsHelp.Append (Environment.NewLine);
+            _optionsHelp.Append(option.HelpText);
+            _optionsHelp.Append(Environment.NewLine);
             if (_additionalNewLineAfterOption)
-                _optionsHelp.Append (Environment.NewLine);
+            {
+                _optionsHelp.Append(Environment.NewLine);
+            }
         }
 
         /// <summary>
@@ -1145,31 +1076,32 @@ namespace CommandLine.Text
         /// <returns>The <see cref="System.String"/> that contains the help informations.</returns>
         public override string ToString ()
         {
-            const int extraLength = 10;
-            var builder = new StringBuilder (GetLength (_heading) + GetLength (_copyright) +
-                GetLength (_preOptionsHelp) + GetLength (_optionsHelp) + extraLength
-            );
+            var builder = new StringBuilder();
 
-            builder.Append (_heading);
-            if (!string.IsNullOrEmpty (_copyright)) {
-                builder.Append (Environment.NewLine);
-                builder.Append (_copyright);
+            builder.Append(_heading);
+            if (!string.IsNullOrEmpty(_copyright))
+            {
+                builder.Append(Environment.NewLine);
+                builder.Append(_copyright);
             }
-            if (_preOptionsHelp.Length > 0) {
-                builder.Append (Environment.NewLine);
-                builder.Append (_preOptionsHelp.ToString ());
+            if (_preOptionsHelp.Length > 0)
+            {
+                builder.Append(Environment.NewLine);
+                builder.Append(_preOptionsHelp);
             }
-            if (_optionsHelp != null && _optionsHelp.Length > 0) {
-                builder.Append (Environment.NewLine);
-                builder.Append (Environment.NewLine);
-                builder.Append (_optionsHelp.ToString ());
+            if (_optionsHelp != null && _optionsHelp.Length > 0)
+            {
+                builder.Append(Environment.NewLine);
+                builder.Append(Environment.NewLine);
+                builder.Append(_optionsHelp);
             }
-            if (_postOptionsHelp.Length > 0) {
-                builder.Append (Environment.NewLine);
-                builder.Append (_postOptionsHelp.ToString ());
+            if (_postOptionsHelp.Length > 0)
+            {
+                builder.Append(Environment.NewLine);
+                builder.Append(_postOptionsHelp);
             }
-
-            return builder.ToString ();
+        
+            return builder.ToString();
         }
 
         /// <summary>
@@ -1243,34 +1175,34 @@ namespace CommandLine.Text
         private int GetMaxLength (IList<BaseOptionAttribute> optionList)
         {
             int length = 0;
-            foreach (BaseOptionAttribute option in optionList) {
+            foreach (BaseOptionAttribute option in optionList)
+            {
                 int optionLength = 0;
                 bool hasShort = option.HasShortName;
                 bool hasLong = option.HasLongName;
-                if (hasShort) {
-                    optionLength += option.ShortName.Length;
+                if (hasShort)
+                {
+                    optionLength += option.ShortName!.Length;
                     if (AddDashesToOption)
-                        ++optionLength;
+                    {
+                        optionLength++;
+                    }
                 }
-                if (hasLong) {
-                    optionLength += option.LongName.Length;
+                if (hasLong)
+                {
+                    optionLength += option.LongName!.Length;
                     if (AddDashesToOption)
+                    {
                         optionLength += 2;
+                    }
                 }
-                if (hasShort && hasLong) {
+                if (hasShort && hasLong)
+                {
                     optionLength += 2; // ", "
                 }
                 length = Math.Max (length, optionLength);
             }
             return length;
-        }
-
-        protected virtual void OnFormatOptionHelpText (FormatOptionHelpTextEventArgs e)
-        {
-            EventHandler<FormatOptionHelpTextEventArgs> handler = FormatOptionHelpText;
-
-            if (handler != null)
-                handler (this, e);
         }
     }
     #endregion

--- a/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
+++ b/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
@@ -7,7 +7,8 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>True</Deterministic>
     <IsPackable>False</IsPackable>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Benchmarks/NodaTimeTests/DateIntervalBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/DateIntervalBenchmarks.cs
@@ -18,16 +18,16 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public int Length() => JanuaryJune2017.Length;
 
         [Benchmark]
-        public DateInterval Union_Disjoint() => JanuaryJune2017.Union(AugustDecember2017);
+        public DateInterval? Union_Disjoint() => JanuaryJune2017.Union(AugustDecember2017);
 
         [Benchmark]
-        public DateInterval Union_Overlapping() => JanuaryJune2017.Union(MarchSeptember2017);
+        public DateInterval? Union_Overlapping() => JanuaryJune2017.Union(MarchSeptember2017);
 
         [Benchmark]
-        public DateInterval Intersection_Disjoint() => JanuaryJune2017.Intersection(AugustDecember2017);
+        public DateInterval? Intersection_Disjoint() => JanuaryJune2017.Intersection(AugustDecember2017);
 
         [Benchmark]
-        public DateInterval Intersection_Overlapping() => JanuaryJune2017.Intersection(MarchSeptember2017);
+        public DateInterval? Intersection_Overlapping() => JanuaryJune2017.Intersection(MarchSeptember2017);
 
         [Benchmark]
         public bool Contains_Disjoint() => JanuaryJune2017.Contains(AugustDecember2017);

--- a/src/NodaTime.Demo/NodaTime.Demo.csproj
+++ b/src/NodaTime.Demo/NodaTime.Demo.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <Deterministic>True</Deterministic>
     <IsPackable>False</IsPackable>
+    <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.NzdPrinter/NodaTime.NzdPrinter.csproj
+++ b/src/NodaTime.NzdPrinter/NodaTime.NzdPrinter.csproj
@@ -7,6 +7,8 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>True</Deterministic>
     <IsPackable>False</IsPackable>
+    <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.NzdPrinter/Program.cs
+++ b/src/NodaTime.NzdPrinter/Program.cs
@@ -30,7 +30,7 @@ namespace NodaTime.NzdPrinter
             var stream = new MemoryStream(FileUtility.LoadFileOrUrl(args[0]));
             int version = new BinaryReader(stream).ReadInt32();
             Console.WriteLine($"File format version: {version}");
-            string[] stringPool = null; // Will be populated before it's used...
+            string[]? stringPool = null; // In a valid file, this will be non-null before it's used for any non-string-pool field.
             foreach (var field in TzdbStreamField.ReadFields(stream))
             {
                 Console.WriteLine($"Field: {field.Id}");

--- a/src/NodaTime.Test/CalendarSystemTest.Validation.cs
+++ b/src/NodaTime.Test/CalendarSystemTest.Validation.cs
@@ -88,13 +88,13 @@ namespace NodaTime.Test
         [Test]
         public void GetAbsoluteYear_NullEra()
         {
-            TestHelper.AssertArgumentNull(Iso.GetAbsoluteYear, 1, (Era) null);
+            TestHelper.AssertArgumentNull(Iso.GetAbsoluteYear, 1, (Era) null!);
         }
 
         [Test]
         public void GetMinYearOfEra_NullEra()
         {
-            TestHelper.AssertArgumentNull(Iso.GetMinYearOfEra, (Era) null);
+            TestHelper.AssertArgumentNull(Iso.GetMinYearOfEra, (Era) null!);
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace NodaTime.Test
         [Test]
         public void GetMaxYearOfEra_NullEra()
         {
-            TestHelper.AssertArgumentNull(Iso.GetMaxYearOfEra, (Era) null);
+            TestHelper.AssertArgumentNull(Iso.GetMaxYearOfEra, (Era) null!);
         }
 
         [Test]

--- a/src/NodaTime.Test/Calendars/BclCalendars.cs
+++ b/src/NodaTime.Test/Calendars/BclCalendars.cs
@@ -62,7 +62,7 @@ namespace NodaTime.Test.Calendars
         /// get day/month/year values to match without getting the calendar right, the calendar
         /// affects the day of week.
         /// </summary>
-        internal static CalendarSystem CalendarSystemForCalendar(Calendar bcl) =>
+        internal static CalendarSystem? CalendarSystemForCalendar(Calendar bcl) =>
             // Yes, this is horrible... but the specific calendars aren't available to test
             // against in netstandard
             bcl.GetType().Name switch

--- a/src/NodaTime.Test/Calendars/CopticCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/CopticCalendarSystemTest.cs
@@ -65,7 +65,7 @@ namespace NodaTime.Test.Calendars
         [Test]
         public void InvalidEra()
         {
-            Assert.Throws<ArgumentNullException>(() => CalendarSystem.Coptic.GetAbsoluteYear(1720, null));
+            Assert.Throws<ArgumentNullException>(() => CalendarSystem.Coptic.GetAbsoluteYear(1720, null!));
             Assert.Throws<ArgumentException>(() => CalendarSystem.Coptic.GetAbsoluteYear(1720, Era.AnnoHegirae));
         }
     }

--- a/src/NodaTime.Test/Calendars/PersianCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/PersianCalendarSystemTest.cs
@@ -19,7 +19,7 @@ namespace NodaTime.Test.Calendars
         public void BclThroughHistory()
         {
             Calendar bcl = BclCalendars.Persian;
-            CalendarSystem noda = BclCalendars.CalendarSystemForCalendar(bcl);
+            CalendarSystem noda = BclCalendars.CalendarSystemForCalendar(bcl)!;
             // Note: Noda Time stops in 9377, whereas the BCL goes into the start of 9378. This is because
             // Noda Time ensures that the whole year is valid.
             BclEquivalenceHelper.AssertEquivalent(bcl, noda);

--- a/src/NodaTime.Test/Calendars/SimpleWeekYearRuleTest.cs
+++ b/src/NodaTime.Test/Calendars/SimpleWeekYearRuleTest.cs
@@ -250,7 +250,7 @@ namespace NodaTime.Test.Calendars
             [ValueSource(nameof(CalendarWeekRules))] CalendarWeekRule bclRule,
             [ValueSource(nameof(BclDaysOfWeek))] DayOfWeek firstDayOfWeek)
         {
-            var nodaCalendar = BclCalendars.CalendarSystemForCalendar(calendar);
+            var nodaCalendar = BclCalendars.CalendarSystemForCalendar(calendar)!;
             var nodaRule = WeekYearRules.FromCalendarWeekRule(bclRule, firstDayOfWeek);
             var startYear = new LocalDate(2016, 1, 1).WithCalendar(nodaCalendar).Year;
 
@@ -287,7 +287,7 @@ namespace NodaTime.Test.Calendars
             [ValueSource(nameof(CalendarWeekRules))] CalendarWeekRule bclRule,
             [ValueSource(nameof(BclDaysOfWeek))] DayOfWeek firstDayOfWeek)
         {
-            var nodaCalendar = BclCalendars.CalendarSystemForCalendar(calendar);
+            var nodaCalendar = BclCalendars.CalendarSystemForCalendar(calendar)!;
             var nodaRule = WeekYearRules.FromCalendarWeekRule(bclRule, firstDayOfWeek);
             var startYear = new LocalDate(2016, 1, 1).WithCalendar(nodaCalendar).Year;
 

--- a/src/NodaTime.Test/DateIntervalTest.cs
+++ b/src/NodaTime.Test/DateIntervalTest.cs
@@ -134,7 +134,7 @@ namespace NodaTime.Test
             LocalDate end = new LocalDate(2001, 6, 19);
             var interval = new DateInterval(start, end);
 
-            Assert.IsFalse(interval.Equals(null));
+            Assert.IsFalse(interval.Equals(null!));
         }
 
         [Test]
@@ -222,7 +222,7 @@ namespace NodaTime.Test
             var end = new LocalDate(2017, 11, 10);
             var value = new DateInterval(start, end);
 
-            Assert.Throws<ArgumentNullException>(() => value.Contains(null));
+            Assert.Throws<ArgumentNullException>(() => value.Contains(null!));
         }
 
         [Test]
@@ -259,7 +259,7 @@ namespace NodaTime.Test
         public void Intersection_NullInterval_Throws()
         {
             var value = new DateInterval(new LocalDate(100), new LocalDate(200));
-            Assert.Throws<ArgumentNullException>(() => value.Intersection(null));
+            Assert.Throws<ArgumentNullException>(() => value.Intersection(null!));
         }
 
         [Test]
@@ -289,7 +289,7 @@ namespace NodaTime.Test
         {
             var value = ParseInterval(firstInterval);
             var other = ParseInterval(secondInterval);
-            var expectedResult = ParseInterval(expectedInterval);
+            var expectedResult = ParseIntervalOrNull(expectedInterval);
             Assert.AreEqual(expectedResult, value.Intersection(other));
         }
 
@@ -297,7 +297,7 @@ namespace NodaTime.Test
         public void Union_NullInterval_Throws()
         {
             var value = new DateInterval(new LocalDate(100), new LocalDate(200));
-            Assert.Throws<ArgumentNullException>(() => value.Union(null));
+            Assert.Throws<ArgumentNullException>(() => value.Union(null!));
         }
 
         [Test]
@@ -323,7 +323,7 @@ namespace NodaTime.Test
         {
             DateInterval firstInterval = ParseInterval(first);
             DateInterval secondInterval = ParseInterval(second);
-            DateInterval expectedResult = ParseInterval(expected);
+            DateInterval? expectedResult = ParseIntervalOrNull(expected);
 
             Assert.Multiple(() =>
             {
@@ -343,13 +343,11 @@ namespace NodaTime.Test
             Assert.AreEqual(expected, actual);
         }
 
+        private DateInterval? ParseIntervalOrNull(string? textualInterval) =>
+            textualInterval is null ? null : ParseInterval(textualInterval);
+
         private DateInterval ParseInterval(string textualInterval)
         {
-            if (textualInterval is null)
-            {
-                return null;
-            }
-
             var parts = textualInterval.Split(new char[] { ',' });
             var start = LocalDatePattern.Iso.Parse(parts[0]).Value;
             var end = LocalDatePattern.Iso.Parse(parts[1]).Value;

--- a/src/NodaTime.Test/Globalization/NodaFormatInfoTest.cs
+++ b/src/NodaTime.Test/Globalization/NodaFormatInfoTest.cs
@@ -77,7 +77,7 @@ namespace NodaTime.Test.Globalization
         [Test]
         public void TestConstructor_null()
         {
-            Assert.Throws<ArgumentNullException>(() => new NodaFormatInfo(null));
+            Assert.Throws<ArgumentNullException>(() => new NodaFormatInfo(null!));
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace NodaTime.Test.Globalization
         public void TestGetFormatInfo_null()
         {
             NodaFormatInfo.ClearCache();
-            Assert.Throws<ArgumentNullException>(() => NodaFormatInfo.GetFormatInfo(null));
+            Assert.Throws<ArgumentNullException>(() => NodaFormatInfo.GetFormatInfo(null!));
         }
 
         [Test]
@@ -198,7 +198,7 @@ namespace NodaTime.Test.Globalization
         public void TestEraGetNames_Null()
         {
             var info = NodaFormatInfo.GetFormatInfo(enUs);
-            Assert.Throws<ArgumentNullException>(() => info.GetEraNames(null));
+            Assert.Throws<ArgumentNullException>(() => info.GetEraNames(null!));
         }
 
         [Test]
@@ -219,7 +219,7 @@ namespace NodaTime.Test.Globalization
         public void TestEraGetEraPrimaryName_Null()
         {
             var info = NodaFormatInfo.GetFormatInfo(enUs);
-            Assert.Throws<ArgumentNullException>(() => info.GetEraPrimaryName(null));
+            Assert.Throws<ArgumentNullException>(() => info.GetEraPrimaryName(null!));
         }
 
         [Test]

--- a/src/NodaTime.Test/LocalDateTest.Comparison.cs
+++ b/src/NodaTime.Test/LocalDateTest.Comparison.cs
@@ -53,7 +53,7 @@ namespace NodaTime.Test
         public void Equals_DifferentToNull()
         {
             LocalDate date = new LocalDate(2011, 1, 2);
-            Assert.IsFalse(date.Equals(null));
+            Assert.IsFalse(date.Equals(null!));
         }
 
         [Test]
@@ -151,9 +151,8 @@ namespace NodaTime.Test
         public void IComparableCompareTo_Null_Positive()
         {
             var instance = new LocalDate(2012, 3, 5);
-            var i_instance = (IComparable)instance;
-            object arg = null;
-            var result = i_instance.CompareTo(arg);
+            var comparable = (IComparable)instance;
+            var result = comparable.CompareTo(null!);
             Assert.Greater(result, 0);
         }
 

--- a/src/NodaTime.Test/LocalDateTest.PeriodArithmetic.cs
+++ b/src/NodaTime.Test/LocalDateTest.PeriodArithmetic.cs
@@ -32,7 +32,7 @@ namespace NodaTime.Test
         {
             LocalDate date = new LocalDate(2010, 1, 1);
             // Call to ToString just to make it a valid statement
-            Assert.Throws<ArgumentNullException>(() => (date + (Period)null).ToString());
+            Assert.Throws<ArgumentNullException>(() => (date + (Period)null!).ToString());
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NodaTime.Test
         {
             LocalDate date = new LocalDate(2010, 1, 1);
             // Call to ToString just to make it a valid statement
-            Assert.Throws<ArgumentNullException>(() => (date - (Period)null).ToString());
+            Assert.Throws<ArgumentNullException>(() => (date - (Period)null!).ToString());
         }
 
         [Test]

--- a/src/NodaTime.Test/LocalDateTest.cs
+++ b/src/NodaTime.Test/LocalDateTest.cs
@@ -62,8 +62,8 @@ namespace NodaTime.Test
         {
             Assert.Multiple(() =>
             {
-                Assert.Throws<ArgumentNullException>(() => new LocalDate(2017, 11, 7, calendar: null), "Basic construction.");
-                Assert.Throws<ArgumentNullException>(() => new LocalDate(Era.Common, 2017, 11, 7, calendar: null), "Construction including era.");
+                Assert.Throws<ArgumentNullException>(() => new LocalDate(2017, 11, 7, calendar: null!), "Basic construction.");
+                Assert.Throws<ArgumentNullException>(() => new LocalDate(Era.Common, 2017, 11, 7, calendar: null!), "Construction including era.");
             });
         }
 

--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -279,9 +279,8 @@ namespace NodaTime.Test
         public void IComparableCompareTo_Null_Positive()
         {
             var instance = new LocalDateTime(2012, 3, 5, 10, 45);
-            var i_instance = (IComparable)instance;
-            object arg = null;
-            var result = i_instance.CompareTo(arg);
+            var comparable = (IComparable)instance;
+            var result = comparable.CompareTo(null);
             Assert.That(result, Is.GreaterThan(0));
         }
 

--- a/src/NodaTime.Test/LocalTimeTest.Operators.cs
+++ b/src/NodaTime.Test/LocalTimeTest.Operators.cs
@@ -32,7 +32,7 @@ namespace NodaTime.Test
         {
             LocalTime date = new LocalTime(12, 0);
             // Call to ToString just to make it a valid statement
-            Assert.Throws<ArgumentNullException>(() => (date + (Period)null).ToString());
+            Assert.Throws<ArgumentNullException>(() => (date + (Period)null!).ToString());
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace NodaTime.Test
         {
             LocalTime date = new LocalTime(12, 0);
             // Call to ToString just to make it a valid statement
-            Assert.Throws<ArgumentNullException>(() => (date - (Period)null).ToString());
+            Assert.Throws<ArgumentNullException>(() => (date - (Period)null!).ToString());
         }
 
         [Test]
@@ -183,9 +183,8 @@ namespace NodaTime.Test
         public void IComparableCompareTo_Null_Positive()
         {
             var instance = new LocalTime(10, 30, 45);
-            var i_instance = (IComparable)instance;
-            object arg = null;
-            var result = i_instance.CompareTo(arg);
+            var comparable = (IComparable)instance;
+            var result = comparable.CompareTo(null);
             Assert.That(result, Is.GreaterThan(0));
         }
 

--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -8,6 +8,7 @@
     <Deterministic>True</Deterministic>
     <IsPackable>False</IsPackable>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Test/PeriodBuilderTest.cs
+++ b/src/NodaTime.Test/PeriodBuilderTest.cs
@@ -145,7 +145,7 @@ namespace NodaTime.Test
             /// Use this property!
             /// </summary>
             [XmlIgnore]
-            public Period Period { get; set; }
+            public Period? Period { get; set; }
 
             /// <summary>
             /// Don't use this property! It's only present for the purposes of XML serialization.
@@ -153,7 +153,7 @@ namespace NodaTime.Test
             /// </summary>
             [XmlElement("period")]
             [EditorBrowsable(EditorBrowsableState.Never)]
-            public PeriodBuilder PeriodBuilder
+            public PeriodBuilder? PeriodBuilder
             {
                 get => Period?.ToBuilder();
                 set => Period = value?.Build();

--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -434,7 +434,7 @@ namespace NodaTime.Test
             Assert.IsFalse(Period.FromHours(1).Equals(Period.FromMinutes(60)));
             Assert.IsFalse(Period.FromHours(1).Equals(new object()));
             Assert.IsFalse(Period.FromHours(1).Equals(null));
-            Assert.IsFalse(Period.FromHours(1).Equals((object) null));
+            Assert.IsFalse(Period.FromHours(1).Equals((object?) null));
         }
 
         [Test]

--- a/src/NodaTime.Test/TestHelper.cs
+++ b/src/NodaTime.Test/TestHelper.cs
@@ -191,7 +191,7 @@ namespace NodaTime.Test
         /// <param name="value">The base value.</param>
         /// <param name="equalValue">The value equal to but not the same object as the base value.</param>
         /// <param name="greaterValue">The values greater than the base value, in ascending order.</param>
-        public static void TestCompareToClass<T>(T value, T equalValue, params T[] greaterValues) where T : class, IComparable<T>
+        public static void TestCompareToClass<T>(T value, T equalValue, params T[] greaterValues) where T : class, IComparable<T?>
         {
             ValidateInput(value, equalValue, greaterValues, "greaterValue");
             Assert.Greater(value.CompareTo(null), 0, "value.CompareTo<T>(null)");
@@ -265,7 +265,7 @@ namespace NodaTime.Test
         /// <param name="value">The base value.</param>
         /// <param name="equalValue">The value equal to but not the same object as the base value.</param>
         /// <param name="unequalValue">Values not equal to the base value.</param>
-        public static void TestEqualsClass<T>(T value, T equalValue, params T[] unequalValues) where T : class, IEquatable<T>
+        public static void TestEqualsClass<T>(T value, T equalValue, params T[] unequalValues) where T : class, IEquatable<T?>
         {
             TestObjectEquals(value, equalValue, unequalValues);
             Assert.False(value.Equals(null), "value.Equals<T>(null)");
@@ -331,6 +331,7 @@ namespace NodaTime.Test
         /// <param name="equalValue">The value equal to but not the same object as the base value.</param>
         /// <param name="greaterValue">The values greater than the base value, in ascending order.</param>
         public static void TestOperatorComparison<T>(T value, T equalValue, params T[] greaterValues)
+            where T : struct
         {
             ValidateInput(value, equalValue, greaterValues, "greaterValue");
             Type type = typeof(T);
@@ -342,23 +343,23 @@ namespace NodaTime.Test
             {
                 if (!type.GetTypeInfo().IsValueType)
                 {
-                    Assert.True((bool) greaterThan.Invoke(null, new object[] { value, null }), "value > null");
-                    Assert.False((bool) greaterThan.Invoke(null, new object[] { null, value }), "null > value");
+                    Assert.True((bool) greaterThan.Invoke(null, new object?[] { value, null }), "value > null");
+                    Assert.False((bool) greaterThan.Invoke(null, new object?[] { null, value }), "null > value");
                 }
-                Assert.False((bool) greaterThan.Invoke(null, new object[] { value, value }), "value > value");
-                Assert.False((bool) greaterThan.Invoke(null, new object[] { value, equalValue }), "value > equalValue");
-                Assert.False((bool) greaterThan.Invoke(null, new object[] { equalValue, value }), "equalValue > value");
+                Assert.False((bool) greaterThan.Invoke(null, new object?[] { value, value }), "value > value");
+                Assert.False((bool) greaterThan.Invoke(null, new object?[] { value, equalValue }), "value > equalValue");
+                Assert.False((bool) greaterThan.Invoke(null, new object?[] { equalValue, value }), "equalValue > value");
             }
             if (lessThan != null)
             {
                 if (!type.GetTypeInfo().IsValueType)
                 {
-                    Assert.False((bool) lessThan.Invoke(null, new object[] { value, null }), "value < null");
-                    Assert.True((bool) lessThan.Invoke(null, new object[] { null, value }), "null < value");
+                    Assert.False((bool) lessThan.Invoke(null, new object?[] { value, null }), "value < null");
+                    Assert.True((bool) lessThan.Invoke(null, new object?[] { null, value }), "null < value");
                 }
-                Assert.False((bool) lessThan.Invoke(null, new object[] { value, value }), "value < value");
-                Assert.False((bool) lessThan.Invoke(null, new object[] { value, equalValue }), "value < equalValue");
-                Assert.False((bool) lessThan.Invoke(null, new object[] { equalValue, value }), "equalValue < value");
+                Assert.False((bool) lessThan.Invoke(null, new object?[] { value, value }), "value < value");
+                Assert.False((bool) lessThan.Invoke(null, new object?[] { value, equalValue }), "value < equalValue");
+                Assert.False((bool) lessThan.Invoke(null, new object?[] { equalValue, value }), "equalValue < value");
             }
 
             // Then comparisons involving the greater values
@@ -366,13 +367,13 @@ namespace NodaTime.Test
             {
                 if (greaterThan != null)
                 {
-                    Assert.False((bool) greaterThan.Invoke(null, new object[] { value, greaterValue }), "value > greaterValue");
-                    Assert.True((bool) greaterThan.Invoke(null, new object[] { greaterValue, value }), "greaterValue > value");
+                    Assert.False((bool) greaterThan.Invoke(null, new object?[] { value, greaterValue }), "value > greaterValue");
+                    Assert.True((bool) greaterThan.Invoke(null, new object?[] { greaterValue, value }), "greaterValue > value");
                 }
                 if (lessThan != null)
                 {
-                    Assert.True((bool) lessThan.Invoke(null, new object[] { value, greaterValue }), "value < greaterValue");
-                    Assert.False((bool) lessThan.Invoke(null, new object[] { greaterValue, value }), "greaterValue < value");
+                    Assert.True((bool) lessThan.Invoke(null, new object?[] { value, greaterValue }), "value < greaterValue");
+                    Assert.False((bool) lessThan.Invoke(null, new object?[] { greaterValue, value }), "greaterValue < value");
                 }
                 // Now move up to the next pair...
                 value = greaterValue;
@@ -388,6 +389,7 @@ namespace NodaTime.Test
         /// <param name="equalValue">The value equal to but not the same object as the base value.</param>
         /// <param name="greaterValue">The values greater than the base value, in ascending order.</param>
         public static void TestOperatorComparisonEquality<T>(T value, T equalValue, params T[] greaterValues)
+            where T : struct
         {
             foreach (var greaterValue in greaterValues)
             {
@@ -403,23 +405,23 @@ namespace NodaTime.Test
             {
                 if (!type.GetTypeInfo().IsValueType)
                 {
-                    Assert.True((bool) greaterThanOrEqual.Invoke(null, new object[] { value, null }), "value >= null");
-                    Assert.False((bool) greaterThanOrEqual.Invoke(null, new object[] { null, value }), "null >= value");
+                    Assert.True((bool) greaterThanOrEqual.Invoke(null, new object?[] { value, null }), "value >= null");
+                    Assert.False((bool) greaterThanOrEqual.Invoke(null, new object?[] { null, value }), "null >= value");
                 }
-                Assert.True((bool) greaterThanOrEqual.Invoke(null, new object[] { value, value }), "value >= value");
-                Assert.True((bool) greaterThanOrEqual.Invoke(null, new object[] { value, equalValue }), "value >= equalValue");
-                Assert.True((bool) greaterThanOrEqual.Invoke(null, new object[] { equalValue, value }), "equalValue >= value");
+                Assert.True((bool) greaterThanOrEqual.Invoke(null, new object?[] { value, value }), "value >= value");
+                Assert.True((bool) greaterThanOrEqual.Invoke(null, new object?[] { value, equalValue }), "value >= equalValue");
+                Assert.True((bool) greaterThanOrEqual.Invoke(null, new object?[] { equalValue, value }), "equalValue >= value");
             }
             if (lessThanOrEqual != null)
             {
                 if (!type.GetTypeInfo().IsValueType)
                 {
-                    Assert.False((bool) lessThanOrEqual.Invoke(null, new object[] { value, null }), "value <= null");
-                    Assert.True((bool) lessThanOrEqual.Invoke(null, new object[] { null, value }), "null <= value");
+                    Assert.False((bool) lessThanOrEqual.Invoke(null, new object?[] { value, null }), "value <= null");
+                    Assert.True((bool) lessThanOrEqual.Invoke(null, new object?[] { null, value }), "null <= value");
                 }
-                Assert.True((bool) lessThanOrEqual.Invoke(null, new object[] { value, value }), "value <= value");
-                Assert.True((bool) lessThanOrEqual.Invoke(null, new object[] { value, equalValue }), "value <= equalValue");
-                Assert.True((bool) lessThanOrEqual.Invoke(null, new object[] { equalValue, value }), "equalValue <= value");
+                Assert.True((bool) lessThanOrEqual.Invoke(null, new object?[] { value, value }), "value <= value");
+                Assert.True((bool) lessThanOrEqual.Invoke(null, new object?[] { value, equalValue }), "value <= equalValue");
+                Assert.True((bool) lessThanOrEqual.Invoke(null, new object?[] { equalValue, value }), "equalValue <= value");
             }
 
             // Now the "greater than" values
@@ -427,13 +429,13 @@ namespace NodaTime.Test
             {
                 if (greaterThanOrEqual != null)
                 {
-                    Assert.False((bool) greaterThanOrEqual.Invoke(null, new object[] { value, greaterValue }), "value >= greaterValue");
-                    Assert.True((bool) greaterThanOrEqual.Invoke(null, new object[] { greaterValue, value }), "greaterValue >= value");
+                    Assert.False((bool) greaterThanOrEqual.Invoke(null, new object?[] { value, greaterValue }), "value >= greaterValue");
+                    Assert.True((bool) greaterThanOrEqual.Invoke(null, new object?[] { greaterValue, value }), "greaterValue >= value");
                 }
                 if (lessThanOrEqual != null)
                 {
-                    Assert.True((bool) lessThanOrEqual.Invoke(null, new object[] { value, greaterValue }), "value <= greaterValue");
-                    Assert.False((bool) lessThanOrEqual.Invoke(null, new object[] { greaterValue, value }), "greaterValue <= value");
+                    Assert.True((bool) lessThanOrEqual.Invoke(null, new object?[] { value, greaterValue }), "value <= greaterValue");
+                    Assert.False((bool) lessThanOrEqual.Invoke(null, new object?[] { greaterValue, value }), "greaterValue <= value");
                 }
                 // Now move up to the next pair...
                 value = greaterValue;
@@ -447,7 +449,7 @@ namespace NodaTime.Test
         /// <param name="value">The base value.</param>
         /// <param name="equalValue">The value equal to but not the same object as the base value.</param>
         /// <param name="unequalValue">The value not equal to the base value.</param>
-        public static void TestOperatorEquality<T>(T value, T equalValue, T unequalValue)
+        public static void TestOperatorEquality<T>(T value, T equalValue, T unequalValue) where T : struct
         {
             ValidateInput(value, equalValue, unequalValue, "unequalValue");
             Type type = typeof(T);
@@ -456,28 +458,28 @@ namespace NodaTime.Test
             {
                 if (!type.GetTypeInfo().IsValueType)
                 {
-                    Assert.True((bool)equality.Invoke(null, new object[] { null, null }), "null == null");
-                    Assert.False((bool)equality.Invoke(null, new object[] { value, null }), "value == null");
-                    Assert.False((bool)equality.Invoke(null, new object[] { null, value }), "null == value");
+                    Assert.True((bool)equality.Invoke(null, new object?[] { null, null }), "null == null");
+                    Assert.False((bool)equality.Invoke(null, new object?[] { value, null }), "value == null");
+                    Assert.False((bool)equality.Invoke(null, new object?[] { null, value }), "null == value");
                 }
-                Assert.True((bool)equality.Invoke(null, new object[] { value, value }), "value == value");
-                Assert.True((bool)equality.Invoke(null, new object[] { value, equalValue }), "value == equalValue");
-                Assert.True((bool)equality.Invoke(null, new object[] { equalValue, value }), "equalValue == value");
-                Assert.False((bool)equality.Invoke(null, new object[] { value, unequalValue }), "value == unequalValue");
+                Assert.True((bool)equality.Invoke(null, new object?[] { value, value }), "value == value");
+                Assert.True((bool)equality.Invoke(null, new object?[] { value, equalValue }), "value == equalValue");
+                Assert.True((bool)equality.Invoke(null, new object?[] { equalValue, value }), "equalValue == value");
+                Assert.False((bool)equality.Invoke(null, new object?[] { value, unequalValue }), "value == unequalValue");
             }
             var inequality = type.GetMethod("op_Inequality", new[] { type, type });
             if (inequality != null)
             {
                 if (!type.GetTypeInfo().IsValueType)
                 {
-                    Assert.False((bool)inequality.Invoke(null, new object[] { null, null }), "null != null");
-                    Assert.True((bool)inequality.Invoke(null, new object[] { value, null }), "value != null");
-                    Assert.True((bool)inequality.Invoke(null, new object[] { null, value }), "null != value");
+                    Assert.False((bool)inequality.Invoke(null, new object?[] { null, null }), "null != null");
+                    Assert.True((bool)inequality.Invoke(null, new object?[] { value, null }), "value != null");
+                    Assert.True((bool)inequality.Invoke(null, new object?[] { null, value }), "null != value");
                 }
-                Assert.False((bool)inequality.Invoke(null, new object[] { value, value }), "value != value");
-                Assert.False((bool)inequality.Invoke(null, new object[] { value, equalValue }), "value != equalValue");
-                Assert.False((bool)inequality.Invoke(null, new object[] { equalValue, value }), "equalValue != value");
-                Assert.True((bool)inequality.Invoke(null, new object[] { value, unequalValue }), "value != unequalValue");
+                Assert.False((bool)inequality.Invoke(null, new object?[] { value, value }), "value != value");
+                Assert.False((bool)inequality.Invoke(null, new object?[] { value, equalValue }), "value != equalValue");
+                Assert.False((bool)inequality.Invoke(null, new object?[] { equalValue, value }), "equalValue != value");
+                Assert.True((bool)inequality.Invoke(null, new object?[] { value, unequalValue }), "value != unequalValue");
             }
         }
 
@@ -486,7 +488,7 @@ namespace NodaTime.Test
         /// value, and that a direct call of ReadXml on a value with an XmlReader initially positioned
         /// at an element will read to the end of that element.
         /// </summary>
-        internal static void AssertXmlRoundtrip<T>(T value, string expectedXml, IEqualityComparer<T> comparer = null)
+        internal static void AssertXmlRoundtrip<T>(T value, string expectedXml, IEqualityComparer<T>? comparer = null)
             where T : IXmlSerializable, new()
         {
             comparer = comparer ?? EqualityComparer<T>.Default;
@@ -617,7 +619,7 @@ namespace NodaTime.Test
         public int Before { get; set; }
 
         [XmlElement("value")]
-        public T Value { get; set; }
+        public T Value { get; set; } = default!;
 
         [XmlElement("after")]
         public int After { get; set; }

--- a/src/NodaTime.Test/Testing/TimeZones/FakeDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/Testing/TimeZones/FakeDateTimeZoneSourceTest.cs
@@ -74,7 +74,7 @@ namespace NodaTime.Test.Testing.TimeZones
         [Test]
         public void NullZoneViaCollectionInitializer()
         {
-            Assert.Throws<ArgumentNullException>(() => new FakeDateTimeZoneSource.Builder { null });
+            Assert.Throws<ArgumentNullException>(() => new FakeDateTimeZoneSource.Builder { null! });
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace NodaTime.Test.Testing.TimeZones
         {
             var source = new FakeDateTimeZoneSource.Builder
             {
-                Zones = { null }
+                Zones = { null! }
             };
             AssertBuildFails(source);
         }
@@ -92,7 +92,7 @@ namespace NodaTime.Test.Testing.TimeZones
         {
             var source = new FakeDateTimeZoneSource.Builder
             {
-                BclIdsToZoneIds = { { "x", null } },
+                BclIdsToZoneIds = { { "x", null! } },
                 Zones = { CreateZone("z") }
             };
             AssertBuildFails(source);

--- a/src/NodaTime.Test/Text/AnnualDatePatternTest.cs
+++ b/src/NodaTime.Test/Text/AnnualDatePatternTest.cs
@@ -160,7 +160,7 @@ namespace NodaTime.Test.Text
             }
 
             internal override IPattern<AnnualDate> CreatePattern() =>
-                AnnualDatePattern.CreateWithInvariantCulture(Pattern)
+                AnnualDatePattern.CreateWithInvariantCulture(Pattern!)
                     .WithTemplateValue(Template)
                     .WithCulture(Culture);
         }

--- a/src/NodaTime.Test/Text/DurationPatternTest.cs
+++ b/src/NodaTime.Test/Text/DurationPatternTest.cs
@@ -178,7 +178,7 @@ namespace NodaTime.Test.Text
             {
             }
 
-            internal override IPattern<Duration> CreatePattern() => DurationPattern.Create(Pattern, Culture);
+            internal override IPattern<Duration> CreatePattern() => DurationPattern.Create(Pattern!, Culture);
         }
     }
 }

--- a/src/NodaTime.Test/Text/InstantPatternTest.cs
+++ b/src/NodaTime.Test/Text/InstantPatternTest.cs
@@ -106,7 +106,7 @@ namespace NodaTime.Test.Text
             }
 
             internal override IPattern<Instant> CreatePattern() =>
-                InstantPattern.CreateWithInvariantCulture(Pattern).WithCulture(Culture);
+                InstantPattern.CreateWithInvariantCulture(Pattern!).WithCulture(Culture);
         }
     }
 }

--- a/src/NodaTime.Test/Text/LocalDatePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalDatePatternTest.cs
@@ -304,7 +304,7 @@ namespace NodaTime.Test.Text
             }
 
             internal override IPattern<LocalDate> CreatePattern() =>
-                LocalDatePattern.CreateWithInvariantCulture(Pattern)
+                LocalDatePattern.CreateWithInvariantCulture(Pattern!)
                     .WithTemplateValue(Template)
                     .WithCulture(Culture);
         }

--- a/src/NodaTime.Test/Text/LocalDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalDateTimePatternTest.cs
@@ -273,7 +273,7 @@ namespace NodaTime.Test.Text
         }
 
         // Helper method to make it slightly easier for tests to skip "bad" cultures.
-        private LocalDateTimePattern CreatePatternOrNull(string patternText, CultureInfo culture, LocalDateTime templateValue)
+        private LocalDateTimePattern? CreatePatternOrNull(string patternText, CultureInfo culture, LocalDateTime templateValue)
         {
             try
             {
@@ -326,7 +326,7 @@ namespace NodaTime.Test.Text
             }
 
             internal override IPattern<LocalDateTime> CreatePattern() =>
-                LocalDateTimePattern.CreateWithInvariantCulture(Pattern)
+                LocalDateTimePattern.CreateWithInvariantCulture(Pattern!)
                     .WithTemplateValue(Template)
                     .WithCulture(Culture);
         }

--- a/src/NodaTime.Test/Text/LocalTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalTimePatternTest.cs
@@ -356,13 +356,13 @@ namespace NodaTime.Test.Text
         [Test]
         public void CreateWithInvariantCulture_NullPatternText()
         {
-            Assert.Throws<ArgumentNullException>(() => LocalTimePattern.CreateWithInvariantCulture(null));
+            Assert.Throws<ArgumentNullException>(() => LocalTimePattern.CreateWithInvariantCulture(null!));
         }
 
         [Test]
         public void Create_NullFormatInfo()
         {
-            Assert.Throws<ArgumentNullException>(() => LocalTimePattern.Create("HH", null));
+            Assert.Throws<ArgumentNullException>(() => LocalTimePattern.Create("HH", null!));
         }
 
         [Test]
@@ -467,7 +467,7 @@ namespace NodaTime.Test.Text
             }
 
             internal override IPattern<LocalTime> CreatePattern() =>
-                LocalTimePattern.CreateWithInvariantCulture(Pattern)
+                LocalTimePattern.CreateWithInvariantCulture(Pattern!)
                     .WithTemplateValue(Template)
                     .WithCulture(Culture);
         }

--- a/src/NodaTime.Test/Text/OffsetDatePatternTest.cs
+++ b/src/NodaTime.Test/Text/OffsetDatePatternTest.cs
@@ -169,7 +169,7 @@ namespace NodaTime.Test.Text
             }
 
             internal override IPattern<OffsetDate> CreatePattern() =>
-                OffsetDatePattern.Create(Pattern, Culture, Template);
+                OffsetDatePattern.Create(Pattern!, Culture, Template);
         }
     }
 }

--- a/src/NodaTime.Test/Text/OffsetDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/OffsetDateTimePatternTest.cs
@@ -231,7 +231,7 @@ namespace NodaTime.Test.Text
             }
 
             internal override IPattern<OffsetDateTime> CreatePattern() =>
-                OffsetDateTimePattern.Create(Pattern, Culture, Template);
+                OffsetDateTimePattern.Create(Pattern!, Culture, Template);
         }
     }
 }

--- a/src/NodaTime.Test/Text/OffsetPatternTest.cs
+++ b/src/NodaTime.Test/Text/OffsetPatternTest.cs
@@ -267,11 +267,11 @@ namespace NodaTime.Test.Text
             }
 
             internal override IPattern<Offset> CreatePattern() =>
-                OffsetPattern.CreateWithInvariantCulture(Pattern)
+                OffsetPattern.CreateWithInvariantCulture(Pattern!)
                     .WithCulture(Culture);
 
             internal override IPartialPattern<Offset> CreatePartialPattern() =>
-                OffsetPattern.CreateWithInvariantCulture(Pattern).WithCulture(Culture).UnderlyingPattern;
+                OffsetPattern.CreateWithInvariantCulture(Pattern!).WithCulture(Culture).UnderlyingPattern;
         }
 
     }

--- a/src/NodaTime.Test/Text/OffsetTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/OffsetTimePatternTest.cs
@@ -172,7 +172,7 @@ namespace NodaTime.Test.Text
             }
 
             internal override IPattern<OffsetTime> CreatePattern() =>
-                OffsetTimePattern.Create(Pattern, Culture, Template);
+                OffsetTimePattern.Create(Pattern!, Culture, Template);
         }
     }
 }

--- a/src/NodaTime.Test/Text/PatternTestBase.cs
+++ b/src/NodaTime.Test/Text/PatternTestBase.cs
@@ -63,7 +63,10 @@ namespace NodaTime.Test.Text
 
         protected void AssertParseNull(IPattern<T> pattern)
         {
-            var result = pattern.Parse(null);
+            // Rare case where we pass a null value to a non-nullable reference type parameter,
+            // but don't expect an immediate exception. The parameter is still correctly non-nullable,
+            // as it's a bug to pass in a null reference, but the handling is slightly different.
+            var result = pattern.Parse(null!);
             Assert.IsFalse(result.Success);
             Assert.IsInstanceOf<ArgumentNullException>(result.Exception);
         }

--- a/src/NodaTime.Test/Text/PatternTestData.cs
+++ b/src/NodaTime.Test/Text/PatternTestData.cs
@@ -30,17 +30,17 @@ namespace NodaTime.Test.Text
         /// <summary>
         /// Standard pattern, expected to format/parse the same way as Pattern.
         /// </summary>
-        internal IPattern<T> StandardPattern { get; set; }
+        internal IPattern<T>? StandardPattern { get; set; }
 
         /// <summary>
         /// Pattern text.
         /// </summary>
-        internal string Pattern { get; set; }
+        internal string? Pattern { get; set; }
 
         /// <summary>
         /// String value to be parsed, and expected result of formatting.
         /// </summary>
-        internal string Text { get; set; }
+        internal string? Text { get; set; }
 
         /// <summary>
         /// Template value to specify in the pattern
@@ -50,12 +50,12 @@ namespace NodaTime.Test.Text
         /// <summary>
         /// Extra description for the test case
         /// </summary>
-        internal string Description { get; set; }
+        internal string? Description { get; set; }
 
         /// <summary>
         /// Message format to verify for exceptions.
         /// </summary>
-        internal string Message { get; set; }
+        internal string? Message { get; set; }
 
         /// <summary>
         /// Message parameters to verify for exceptions.
@@ -74,13 +74,13 @@ namespace NodaTime.Test.Text
         {
             Assert.IsNull(Message);
             IPattern<T> pattern = CreatePattern();
-            var result = pattern.Parse(Text);
+            var result = pattern.Parse(Text!);
             var actualValue = result.Value;
             Assert.AreEqual(Value, actualValue);
 
             if (StandardPattern != null)
             {
-                Assert.AreEqual(Value, StandardPattern.Parse(Text).Value);
+                Assert.AreEqual(Value, StandardPattern.Parse(Text!).Value);
             }
         }
 
@@ -127,7 +127,7 @@ namespace NodaTime.Test.Text
 
         internal void TestInvalidPattern()
         {
-            string expectedMessage = FormatMessage(Message, Parameters.ToArray());
+            string expectedMessage = FormatMessage(Message!, Parameters.ToArray());
             try
             {
                 CreatePattern();
@@ -142,9 +142,9 @@ namespace NodaTime.Test.Text
 
         public void TestParseFailure()
         {
-            string expectedMessage = FormatMessage(Message, Parameters.ToArray());
+            string expectedMessage = FormatMessage(Message!, Parameters.ToArray());
             IPattern<T> pattern = CreatePattern();
-            var result = pattern.Parse(Text);
+            var result = pattern.Parse(Text!);
             Assert.IsFalse(result.Success);
             try
             {
@@ -176,7 +176,7 @@ namespace NodaTime.Test.Text
                 {
                     builder.AppendFormat("Description={0}; ", Description);
                 }
-                if (!Template.Equals(DefaultTemplate))
+                if (!Template!.Equals(DefaultTemplate))
                 {
                     builder.AppendFormat("Template={0};", Template);
                 }

--- a/src/NodaTime.Test/Text/PeriodPatternTest.NormalizingIso.cs
+++ b/src/NodaTime.Test/Text/PeriodPatternTest.NormalizingIso.cs
@@ -14,7 +14,7 @@ namespace NodaTime.Test.Text
         public class PeriodPatternNormalizingIsoTest : PatternTestBase<Period>
         {
             // Single null value to keep it from being "inconclusive"
-            internal static readonly Data[] InvalidPatternData = { null };
+            internal static readonly Data?[] InvalidPatternData = { null };
 
             internal static readonly Data[] ParseFailureData = {
                 new Data { Text = "X5H", Message = TextErrorMessages.MismatchedCharacter, Parameters = { 'P' } },

--- a/src/NodaTime.Test/Text/PeriodPatternTest.cs
+++ b/src/NodaTime.Test/Text/PeriodPatternTest.cs
@@ -30,7 +30,7 @@ namespace NodaTime.Test.Text
             {
             }
 
-            internal override IPattern<Period> CreatePattern() => StandardPattern;
+            internal override IPattern<Period> CreatePattern() => StandardPattern!;
         }
     }
 }

--- a/src/NodaTime.Test/Text/ValueCursorTest.cs
+++ b/src/NodaTime.Test/Text/ValueCursorTest.cs
@@ -436,7 +436,7 @@ namespace NodaTime.Test.Text
             var value = new ValueCursor("92233720368547758071");
             value.Move(0);
             var parseResult = value.ParseInt64<string>(out long result);
-            Assert.IsFalse(parseResult.Success);
+            Assert.IsFalse(parseResult!.Success);
             Assert.IsInstanceOf<UnparsableValueException>(parseResult.Exception);            
             Assert.AreEqual(0, value.Index); // Cursor hasn't moved
         }

--- a/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
@@ -369,7 +369,7 @@ namespace NodaTime.Test.Text
             }
 
             internal override IPattern<ZonedDateTime> CreatePattern() =>
-                ZonedDateTimePattern.Create(Pattern, Culture, Resolver, ZoneProvider, Template);
+                ZonedDateTimePattern.Create(Pattern!, Culture, Resolver, ZoneProvider, Template);
         }
     }
 }

--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneSourceTest.cs
@@ -49,7 +49,7 @@ namespace NodaTime.Test.TimeZones
 
             // However, there _are_ cases where we can't fetch the local timezone at all (sigh, Mono), so we'll have to
             // skip this test then.
-            TimeZoneInfo local = null;
+            TimeZoneInfo? local = null;
             try
             {
                 local = TimeZoneInfo.Local;
@@ -68,12 +68,12 @@ namespace NodaTime.Test.TimeZones
             // Now that we have our BCL local time zone, we should be able to look it up in the source.
 
             var source = new BclDateTimeZoneSource();
-            string id = source.GetSystemDefaultId();
+            string? id = source.GetSystemDefaultId();
             Assert.IsNotNull(id);
 
             // These lines replicate how DateTimeZoneCache implements GetSystemDefault().
             Assert.Contains(id, source.GetIds().ToList(), "BCL local time zone ID should be included in the source ID list");
-            var zone = source.ForId(id);
+            var zone = source.ForId(id!);
 
             Assert.IsNotNull(zone);  // though really we only need to test that the call above didn't throw.
         }

--- a/src/NodaTime.Test/TimeZones/DateTimeZoneCacheTest.cs
+++ b/src/NodaTime.Test/TimeZones/DateTimeZoneCacheTest.cs
@@ -19,21 +19,21 @@ namespace NodaTime.Test.TimeZones
         [Test]
         public void Construction_NullProvider()
         {
-            Assert.Throws<ArgumentNullException>(() => new DateTimeZoneCache(null));
+            Assert.Throws<ArgumentNullException>(() => new DateTimeZoneCache(null!));
         }
 
         [Test]
         public void InvalidSource_NullVersionId()
         {
-            var source = new TestDateTimeZoneSource("Test1", "Test2") { VersionId = null };
+            var source = new TestDateTimeZoneSource("Test1", "Test2") { VersionId = null! };
             Assert.Throws<InvalidDateTimeZoneSourceException>(() => new DateTimeZoneCache(source));
         }
 
         [Test]
         public void InvalidSource_NullIdSequence()
         {
-            string[] ids = null;
-            var source = new TestDateTimeZoneSource(ids);
+            string[] ids = null!;
+            var source = new TestDateTimeZoneSource(ids!);
             Assert.Throws<InvalidDateTimeZoneSourceException>(() => new DateTimeZoneCache(source));
         }
 
@@ -48,7 +48,7 @@ namespace NodaTime.Test.TimeZones
         [Test]
         public void InvalidProvider_NullIdWithinSequence()
         {
-            var source = new TestDateTimeZoneSource("Test1", null);
+            var source = new TestDateTimeZoneSource("Test1", null!);
             Assert.Throws<InvalidDateTimeZoneSourceException>(() => new DateTimeZoneCache(source));
         }
 
@@ -175,7 +175,7 @@ namespace NodaTime.Test.TimeZones
         {
             var provider = new DateTimeZoneCache(new TestDateTimeZoneSource("Test1", "Test2"));
             // GetType call just to avoid trying to use a property as a statement...
-            Assert.Throws<ArgumentNullException>(() => provider[null].GetType());
+            Assert.Throws<ArgumentNullException>(() => provider[null!].GetType());
         }
 
         [Test]
@@ -253,7 +253,7 @@ namespace NodaTime.Test.TimeZones
 
         private class TestDateTimeZoneSource : IDateTimeZoneSource
         {
-            public string LastRequestedId { get; set; }
+            public string? LastRequestedId { get; set; }
             private readonly string[] ids;
 
             public TestDateTimeZoneSource(params string[] ids)
@@ -272,7 +272,7 @@ namespace NodaTime.Test.TimeZones
 
             public string VersionId { get; set; }
 
-            public virtual string GetSystemDefaultId() => "map";
+            public virtual string? GetSystemDefaultId() => "map";
         }
 
         // A test source that returns null from ForId and GetSystemDefaultId()
@@ -286,10 +286,10 @@ namespace NodaTime.Test.TimeZones
             {
                 // Still remember what was requested.
                 base.ForId(id);
-                return null;
+                return null!;
             }
 
-            public override string GetSystemDefaultId() => null;
+            public override string? GetSystemDefaultId() => null;
         }
     }
 }

--- a/src/NodaTime.Test/TimeZones/FixedDateTimeZoneTest.cs
+++ b/src/NodaTime.Test/TimeZones/FixedDateTimeZoneTest.cs
@@ -50,7 +50,7 @@ namespace NodaTime.Test.TimeZones
         public void For_Id_FixedOffset()
         {
             string id = "UTC+05:30";
-            DateTimeZone zone = FixedDateTimeZone.GetFixedZoneOrNull(id);
+            DateTimeZone zone = FixedDateTimeZone.GetFixedZoneOrNull(id)!;
             Assert.AreEqual(DateTimeZone.ForOffset(Offset.FromHoursAndMinutes(5, 30)), zone);
             Assert.AreEqual(id, zone.Id);
         }
@@ -59,7 +59,7 @@ namespace NodaTime.Test.TimeZones
         public void For_Id_FixedOffset_NonCanonicalId()
         {
             string id = "UTC+05:00:00";
-            DateTimeZone zone = FixedDateTimeZone.GetFixedZoneOrNull(id);
+            DateTimeZone zone = FixedDateTimeZone.GetFixedZoneOrNull(id)!;
             Assert.AreEqual(zone, DateTimeZone.ForOffset(Offset.FromHours(5)));
             Assert.AreEqual("UTC+05", zone.Id);
         }

--- a/src/NodaTime.Test/TimeZones/IO/DtzIoHelper.cs
+++ b/src/NodaTime.Test/TimeZones/IO/DtzIoHelper.cs
@@ -31,7 +31,7 @@ namespace NodaTime.Test.TimeZones.IO
 
         internal static DtzIoHelper CreateNoStringPool()
         {
-            return new DtzIoHelper(null);
+            return new DtzIoHelper(null!);
         }
 
         internal static DtzIoHelper CreateWithStringPool()

--- a/src/NodaTime.Test/TimeZones/IO/IoStream.cs
+++ b/src/NodaTime.Test/TimeZones/IO/IoStream.cs
@@ -20,9 +20,9 @@ namespace NodaTime.Test.TimeZones.IO
     {
         private readonly byte[] buffer = new byte[4096];
         private int readIndex;
-        private Stream readStream;
+        private Stream? readStream;
         private int writeIndex;
-        private Stream writeStream;
+        private Stream? writeStream;
 
         /// <summary>
         ///   Returns the next byte from the stream if there is one.

--- a/src/NodaTime.Test/TimeZones/TimeZoneInfoReplacer.cs
+++ b/src/NodaTime.Test/TimeZones/TimeZoneInfoReplacer.cs
@@ -18,9 +18,9 @@ namespace NodaTime.Test.TimeZones
         private readonly TimeZoneInfoInterceptor.ITimeZoneInfoShim originalShim;
         private readonly ReadOnlyCollection<TimeZoneInfo> zones;
 
-        public TimeZoneInfo Local { get; }
+        public TimeZoneInfo? Local { get; }
 
-        private TimeZoneInfoReplacer(TimeZoneInfo local, ReadOnlyCollection<TimeZoneInfo> zones)
+        private TimeZoneInfoReplacer(TimeZoneInfo? local, ReadOnlyCollection<TimeZoneInfo> zones)
         {
             originalShim = TimeZoneInfoInterceptor.Shim;
             Local = local;
@@ -29,7 +29,7 @@ namespace NodaTime.Test.TimeZones
 
         }
 
-        internal static IDisposable Replace(TimeZoneInfo local, params TimeZoneInfo[] allZones) =>
+        internal static IDisposable Replace(TimeZoneInfo? local, params TimeZoneInfo[] allZones) =>
             new TimeZoneInfoReplacer(local, allZones.ToList().AsReadOnly());
 
         public TimeZoneInfo FindSystemTimeZoneById(string id)

--- a/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
@@ -80,7 +80,7 @@ namespace NodaTime.Test.TimeZones
         [Test]
         public void ForId_Null()
         {
-            Assert.Throws<ArgumentNullException>(() => TzdbDateTimeZoneSource.Default.ForId(null));
+            Assert.Throws<ArgumentNullException>(() => TzdbDateTimeZoneSource.Default.ForId(null!));
         }
 
         [Test]
@@ -227,7 +227,7 @@ namespace NodaTime.Test.TimeZones
                 return;
             }
 
-            string id = TzdbDateTimeZoneSource.Default.GuessZoneIdByTransitionsUncached(bclZone,
+            string? id = TzdbDateTimeZoneSource.Default.GuessZoneIdByTransitionsUncached(bclZone,
                 TzdbDefaultZonesForIdGuessZoneIdByTransitionsUncached);
 
             // Unmappable zones may not be mapped, or may be mapped to something reasonably accurate.
@@ -238,7 +238,7 @@ namespace NodaTime.Test.TimeZones
             }
 
             Assert.IsNotNull(id, $"Unable to guess time zone for {bclZone.Id}");
-            var tzdbZone = TzdbDateTimeZoneSource.Default.ForId(id);
+            var tzdbZone = TzdbDateTimeZoneSource.Default.ForId(id!);
 
             var thisYear = SystemClock.Instance.GetCurrentInstant().InUtc().Year;
             LocalDate? lastIncorrectDate = null;

--- a/src/NodaTime.Test/TimeZones/TzdbZone1970LocationTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbZone1970LocationTest.cs
@@ -99,18 +99,18 @@ namespace NodaTime.Test.TimeZones
         [Test]
         public void Constructor_InvalidArguments()
         {
-            Assert.Throws<ArgumentNullException>(() => new TzdbZone1970Location(0, 0, null, "Zone", ""));
-            Assert.Throws<ArgumentException>(() => new TzdbZone1970Location(0, 0, new[] { SampleCountry, null }, "Zone", ""));
-            Assert.Throws<ArgumentNullException>(() => new TzdbZone1970Location(0, 0, new[] { SampleCountry }, "Zone", null));
-            Assert.Throws<ArgumentNullException>(() => new TzdbZone1970Location(0, 0, new[] { SampleCountry }, null, ""));
-            Assert.Throws<ArgumentException>(() => new TzdbZone1970Location(0, 0, new Country[] { }, null, ""));
+            Assert.Throws<ArgumentNullException>(() => new TzdbZone1970Location(0, 0, null!, "Zone", ""));
+            Assert.Throws<ArgumentException>(() => new TzdbZone1970Location(0, 0, new[] { SampleCountry, null! }, "Zone", ""));
+            Assert.Throws<ArgumentNullException>(() => new TzdbZone1970Location(0, 0, new[] { SampleCountry }, "Zone", null!));
+            Assert.Throws<ArgumentNullException>(() => new TzdbZone1970Location(0, 0, new[] { SampleCountry }, null!, ""));
+            Assert.Throws<ArgumentException>(() => new TzdbZone1970Location(0, 0, new Country[] { }, null!, ""));
         }
 
         [Test]
         public void CountryConstructor_InvalidArguments()
         {
-            Assert.Throws<ArgumentNullException>(() => new Country(code: null, name: "Name"));
-            Assert.Throws<ArgumentNullException>(() => new Country(code: "CO", name: null));
+            Assert.Throws<ArgumentNullException>(() => new Country(code: null!, name: "Name"));
+            Assert.Throws<ArgumentNullException>(() => new Country(code: "CO", name: null!));
             Assert.Throws<ArgumentException>(() => new Country(code: "CO", name: ""));
             Assert.Throws<ArgumentException>(() => new Country(code: "Long code", name: "Name"));
             Assert.Throws<ArgumentException>(() => new Country(code: "S", name: "Name"));

--- a/src/NodaTime.Test/TimeZones/TzdbZoneLocationTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbZoneLocationTest.cs
@@ -54,10 +54,10 @@ namespace NodaTime.Test.TimeZones
         [Test]
         public void Constructor_InvalidArguments()
         {
-            Assert.Throws<ArgumentNullException>(() => new TzdbZoneLocation(0, 0, null, "CO", "Zone", ""));
-            Assert.Throws<ArgumentNullException>(() => new TzdbZoneLocation(0, 0, "Name", null, "Zone", ""));
-            Assert.Throws<ArgumentNullException>(() => new TzdbZoneLocation(0, 0, "Name", "CO", null, ""));
-            Assert.Throws<ArgumentNullException>(() => new TzdbZoneLocation(0, 0, "Name", "CO", "Zone", null));
+            Assert.Throws<ArgumentNullException>(() => new TzdbZoneLocation(0, 0, null!, "CO", "Zone", ""));
+            Assert.Throws<ArgumentNullException>(() => new TzdbZoneLocation(0, 0, "Name", null!, "Zone", ""));
+            Assert.Throws<ArgumentNullException>(() => new TzdbZoneLocation(0, 0, "Name", "CO", null!, ""));
+            Assert.Throws<ArgumentNullException>(() => new TzdbZoneLocation(0, 0, "Name", "CO", "Zone", null!));
             Assert.Throws<ArgumentException>(() => new TzdbZoneLocation(0, 0, "", "CO", "Zone", ""));
             Assert.Throws<ArgumentException>(() => new TzdbZoneLocation(0, 0, "Name", "Long code", "Zone", ""));
             Assert.Throws<ArgumentException>(() => new TzdbZoneLocation(0, 0, "Name", "S", "Zone", ""));

--- a/src/NodaTime.Test/TimeZones/ZoneRecurrenceTest.cs
+++ b/src/NodaTime.Test/TimeZones/ZoneRecurrenceTest.cs
@@ -16,13 +16,13 @@ namespace NodaTime.Test.TimeZones
         public void Constructor_nullName_exception()
         {
             var yearOffset = new ZoneYearOffset(TransitionMode.Utc, 10, 31, (int)IsoDayOfWeek.Wednesday, true, LocalTime.Midnight);
-            Assert.Throws(typeof(ArgumentNullException), () => new ZoneRecurrence(null, Offset.Zero, yearOffset, 1971, 2009), "Null name");
+            Assert.Throws(typeof(ArgumentNullException), () => new ZoneRecurrence(null!, Offset.Zero, yearOffset, 1971, 2009), "Null name");
         }
 
         [Test]
         public void Constructor_nullYearOffset_exception()
         {
-            Assert.Throws(typeof(ArgumentNullException), () => new ZoneRecurrence("bob", Offset.Zero, null, 1971, 2009), "Null yearOffset");
+            Assert.Throws(typeof(ArgumentNullException), () => new ZoneRecurrence("bob", Offset.Zero, null!, 1971, 2009), "Null yearOffset");
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace NodaTime.Test.TimeZones
             var januaryFirstMidnight = new ZoneYearOffset(TransitionMode.Utc, 1, 1, 0, true, LocalTime.Midnight);
             var recurrence = new ZoneRecurrence("bob", Offset.Zero, januaryFirstMidnight, 1970, 1972);
             Transition? actual = recurrence.Next(NodaConstants.UnixEpoch, Offset.Zero, Offset.Zero);
-            actual = recurrence.Next(actual.Value.Instant, Offset.Zero, Offset.Zero);
+            actual = recurrence.Next(actual!.Value.Instant, Offset.Zero, Offset.Zero);
             Transition? expected = new Transition(Instant.FromUtc(1972, 1, 1, 0, 0), Offset.Zero);
             Assert.AreEqual(expected, actual);
         }
@@ -93,7 +93,7 @@ namespace NodaTime.Test.TimeZones
             var januaryFirstMidnight = new ZoneYearOffset(TransitionMode.Utc, 1, 1, 0, true, LocalTime.Midnight);
             var recurrence = new ZoneRecurrence("bob", Offset.Zero, januaryFirstMidnight, 1970, 1973);
             Transition? actual = recurrence.PreviousOrSame(Instant.FromUtc(1972, 1, 1, 0, 0) - Duration.Epsilon, Offset.Zero, Offset.Zero);
-            actual = recurrence.PreviousOrSame(actual.Value.Instant - Duration.Epsilon, Offset.Zero, Offset.Zero);
+            actual = recurrence.PreviousOrSame(actual!.Value.Instant - Duration.Epsilon, Offset.Zero, Offset.Zero);
             Transition? expected = new Transition(NodaConstants.UnixEpoch, Offset.Zero);
             Assert.AreEqual(expected, actual);
         }
@@ -126,7 +126,7 @@ namespace NodaTime.Test.TimeZones
             var recurrence = new ZoneRecurrence("x", Offset.Zero, january10thMidnight, 2000, 3000);
             var transition = Instant.FromUtc(2500, 1, 10, 0, 0);
             var next = recurrence.Next(transition, Offset.Zero, Offset.Zero);
-            Assert.AreEqual(2501, next.Value.Instant.InUtc().Year);
+            Assert.AreEqual(2501, next!.Value.Instant.InUtc().Year);
         }
 
         [Test]
@@ -136,7 +136,7 @@ namespace NodaTime.Test.TimeZones
             var recurrence = new ZoneRecurrence("x", Offset.Zero, january10thMidnight, 2000, 3000);
             var transition = Instant.FromUtc(2500, 1, 10, 0, 0);
             var next = recurrence.PreviousOrSame(transition, Offset.Zero, Offset.Zero);
-            Assert.AreEqual(transition, next.Value.Instant);
+            Assert.AreEqual(transition, next!.Value.Instant);
         }
 
         [Test]
@@ -196,7 +196,7 @@ namespace NodaTime.Test.TimeZones
             var recurrence = new ZoneRecurrence("awkward", Offset.FromHours(1), yearOffset, GregorianYearMonthDayCalculator.MinGregorianYear, GregorianYearMonthDayCalculator.MaxGregorianYear);
 
             var next = recurrence.Next(Instant.FromUtc(9999, 6, 1, 0, 0), Offset.Zero, Offset.Zero);
-            Assert.AreEqual(Instant.AfterMaxValue, next.Value.Instant);
+            Assert.AreEqual(Instant.AfterMaxValue, next!.Value.Instant);
         }
 
         [Test]

--- a/src/NodaTime.Test/Utility/PreconditionsTest.cs
+++ b/src/NodaTime.Test/Utility/PreconditionsTest.cs
@@ -41,7 +41,7 @@ namespace NodaTime.Test.Utility
         public void DebugCheckNotNull_Debug()
         {
             Preconditions.DebugCheckNotNull("value", "ignore");
-            Assert.Throws<DebugPreconditionException>(() => Preconditions.DebugCheckNotNull((string) null, "ignore"));
+            Assert.Throws<DebugPreconditionException>(() => Preconditions.DebugCheckNotNull((string) null!, "ignore"));
         }
 #else
         [Test]

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -336,9 +336,9 @@ namespace NodaTime.Test
         [Test]
         public void Constructor_ArgumentValidation()
         {
-            Assert.Throws<ArgumentNullException>(() => new ZonedDateTime(Instant.FromUnixTimeTicks(1000), null));
-            Assert.Throws<ArgumentNullException>(() => new ZonedDateTime(Instant.FromUnixTimeTicks(1000), null, CalendarSystem.Iso));
-            Assert.Throws<ArgumentNullException>(() => new ZonedDateTime(Instant.FromUnixTimeTicks(1000), SampleZone, null));
+            Assert.Throws<ArgumentNullException>(() => new ZonedDateTime(Instant.FromUnixTimeTicks(1000), null!));
+            Assert.Throws<ArgumentNullException>(() => new ZonedDateTime(Instant.FromUnixTimeTicks(1000), null!, CalendarSystem.Iso));
+            Assert.Throws<ArgumentNullException>(() => new ZonedDateTime(Instant.FromUnixTimeTicks(1000), SampleZone, null!));
         }
 
         [Test]

--- a/src/NodaTime.Testing/NodaTime.Testing.csproj
+++ b/src/NodaTime.Testing/NodaTime.Testing.csproj
@@ -14,7 +14,7 @@
     <RepositoryUrl>https://github.com/nodatime/nodatime</RepositoryUrl>
     <Deterministic>True</Deterministic>
     <LangVersion>8.0</LangVersion>
-    <NullableReferenceTypes>True</NullableReferenceTypes>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Testing/NodaTime.Testing.csproj
+++ b/src/NodaTime.Testing/NodaTime.Testing.csproj
@@ -13,7 +13,8 @@
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/nodatime/nodatime</RepositoryUrl>
     <Deterministic>True</Deterministic>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
+    <NullableReferenceTypes>True</NullableReferenceTypes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Testing/TimeZones/FakeDateTimeZoneSource.cs
+++ b/src/NodaTime.Testing/TimeZones/FakeDateTimeZoneSource.cs
@@ -60,7 +60,7 @@ namespace NodaTime.Testing.TimeZones
         /// The ID for the system default time zone for this source,
         /// or null if the system default time zone has no mapping in this source.
         /// </returns>
-        public string GetSystemDefaultId()
+        public string? GetSystemDefaultId()
         {
             string id = TimeZoneInfo.Local.Id;
             // We don't care about the return value of TryGetValue - if it's false,

--- a/src/NodaTime.Tools.Common/NodaTime.Tools.Common.csproj
+++ b/src/NodaTime.Tools.Common/NodaTime.Tools.Common.csproj
@@ -1,10 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyOriginatorKeyFile>../../NodaTime Release.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <Deterministic>True</Deterministic>
     <IsPackable>False</IsPackable>
+    <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Tools.DumpTimeZoneInfo/NodaTime.Tools.DumpTimeZoneInfo.csproj
+++ b/src/NodaTime.Tools.DumpTimeZoneInfo/NodaTime.Tools.DumpTimeZoneInfo.csproj
@@ -4,5 +4,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <Deterministic>True</Deterministic>
     <IsPackable>False</IsPackable>
+    <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 </Project>

--- a/src/NodaTime.TzValidate.NodaDump/NodaTime.TzValidate.NodaDump.csproj
+++ b/src/NodaTime.TzValidate.NodaDump/NodaTime.TzValidate.NodaDump.csproj
@@ -5,6 +5,8 @@
     <OutputType>Exe</OutputType>
     <Deterministic>True</Deterministic>
     <IsPackable>False</IsPackable>
+    <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.TzValidate.NodaDump/Options.cs
+++ b/src/NodaTime.TzValidate.NodaDump/Options.cs
@@ -23,13 +23,13 @@ namespace NodaTime.TzValidate.NodaDump
         public int ToYear { get; set; }
 
         [Option("s", "source", Required = false, HelpText = "Data source - a single file or URL, or a directory")]
-        public string Source { get; set; }
+        public string? Source { get; set; }
 
         [Option("z", "zone", Required = false, HelpText = "Zone ID, to dump a single time zone")]
-        public string ZoneId { get; set; }
+        public string? ZoneId { get; set; }
 
         [Option("o", "output", Required = false, HelpText = "Output file (defaults to writing to the console")]
-        public string OutputFile { get; set; }
+        public string? OutputFile { get; set; }
 
         [Option(null, "hash", Required = false, HelpText = "Only output the SHA-256 hash")]
         public bool HashOnly { get; set; }

--- a/src/NodaTime.TzValidate.NodaDump/Program.cs
+++ b/src/NodaTime.TzValidate.NodaDump/Program.cs
@@ -28,6 +28,7 @@ namespace NodaTime.TzValidate.NodaDump
             {
                 return 1;
             }
+            // Not null after we've parsed the arguments.
             TzdbDateTimeZoneSource source = LoadSource(options.Source);
             var dumper = new ZoneDumper(source, options);
             try
@@ -46,7 +47,7 @@ namespace NodaTime.TzValidate.NodaDump
             return 0;
         }        
 
-        private static TzdbDateTimeZoneSource LoadSource(string source)
+        private static TzdbDateTimeZoneSource LoadSource(string? source)
         {
             if (source is null)
             {

--- a/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
+++ b/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
@@ -7,6 +7,8 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>True</Deterministic>
     <IsPackable>False</IsPackable>
+    <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.TzdbCompiler.Test/Tzdb/TokensTest.cs
+++ b/src/NodaTime.TzdbCompiler.Test/Tzdb/TokensTest.cs
@@ -17,8 +17,7 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
         [Test]
         public void Tokenize_nullArgument_Exception()
         {
-            string line = null;
-            Assert.Throws(typeof(ArgumentNullException), () => Tokens.Tokenize(line));
+            Assert.Throws(typeof(ArgumentNullException), () => Tokens.Tokenize(null!));
         }
 
         [Test]

--- a/src/NodaTime.TzdbCompiler.Test/Tzdb/TzdbZoneInfoParserTest.cs
+++ b/src/NodaTime.TzdbCompiler.Test/Tzdb/TzdbZoneInfoParserTest.cs
@@ -210,7 +210,7 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
         public void ParseMonth_nullOrEmpty()
         {
             Assert.Throws<ArgumentException>(() => TzdbZoneInfoParser.ParseMonth(""));
-            Assert.Throws<ArgumentException>(() => TzdbZoneInfoParser.ParseMonth(null));
+            Assert.Throws<ArgumentException>(() => TzdbZoneInfoParser.ParseMonth(null!));
         }
 
         [Test]

--- a/src/NodaTime.TzdbCompiler.Test/Tzdb/ZoneTransitionTest.cs
+++ b/src/NodaTime.TzdbCompiler.Test/Tzdb/ZoneTransitionTest.cs
@@ -13,7 +13,7 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
         [Test]
         public void Construct_NullName_Exception()
         {
-            Assert.Throws(typeof(ArgumentNullException), () => new ZoneTransition(NodaConstants.UnixEpoch, null, Offset.Zero, Offset.Zero));
+            Assert.Throws(typeof(ArgumentNullException), () => new ZoneTransition(NodaConstants.UnixEpoch, null!, Offset.Zero, Offset.Zero));
         }
 
         [Test]
@@ -28,10 +28,10 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
         }
 
         [Test]
-        public void IsTransitionFrom_null_true()
+        public void IsTransitionFrom_null_throws()
         {
             var value = new ZoneTransition(NodaConstants.UnixEpoch, "abc", Offset.Zero, Offset.Zero);
-            Assert.True(value.IsTransitionFrom(null));
+            Assert.Throws<ArgumentNullException>(() => value.IsTransitionFrom(null!));
         }
 
         [Test]

--- a/src/NodaTime.TzdbCompiler/CompilerOptions.cs
+++ b/src/NodaTime.TzdbCompiler/CompilerOptions.cs
@@ -13,22 +13,22 @@ namespace NodaTime.TzdbCompiler
     public class CompilerOptions
     {
         [Option("o", "output", Required = false, HelpText = "The name of the output file.", MutuallyExclusiveSet = "Output")]
-        public string OutputFileName { get; set; }
+        public string? OutputFileName { get; set; }
 
         [Option("s", "source", Required = true, HelpText = "Source directory or archive containing the TZDB input files.")]
-        public string SourceDirectoryName { get; set; } = "";
+        public string? SourceDirectoryName { get; set; } = "";
 
         [Option("w", "windows", Required = true, HelpText = "Windows to TZDB time zone mapping file (e.g. windowsZones.xml) or directory")]
-        public string WindowsMapping { get; set; } = "";
+        public string? WindowsMapping { get; set; } = "";
 
         [Option(null, "windows-override", Required = false, HelpText = "Additional 'override' file providing extra Windows time zone mappings")]
-        public string WindowsOverride { get; set; }
+        public string? WindowsOverride { get; set; }
 
         [Option("z", "zone",
             Required = false,
             HelpText = "Single zone ID to compile data for, for test purposes. (Incompatible with -o.)",
             MutuallyExclusiveSet = "Output")]
-        public string ZoneId { get; set; }
+        public string? ZoneId { get; set; }
 
         [HelpOption(HelpText = "Display this help screen.")]
         public string GetUsage()

--- a/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
+++ b/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
@@ -7,6 +7,8 @@
     <SignAssembly>true</SignAssembly>
     <Deterministic>True</Deterministic>
     <IsPackable>False</IsPackable>
+    <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.TzdbCompiler/Program.cs
+++ b/src/NodaTime.TzdbCompiler/Program.cs
@@ -36,7 +36,7 @@ namespace NodaTime.TzdbCompiler
             }
 
             var tzdbCompiler = new TzdbZoneInfoCompiler();
-            var tzdb = tzdbCompiler.Compile(options.SourceDirectoryName);
+            var tzdb = tzdbCompiler.Compile(options.SourceDirectoryName!);
             tzdb.LogCounts();
             if (options.ZoneId != null)
             {
@@ -74,7 +74,7 @@ namespace NodaTime.TzdbCompiler
         /// </summary>
         private static WindowsZones LoadWindowsZones(CompilerOptions options, string targetTzdbVersion)
         {
-            var mappingPath = options.WindowsMapping;
+            var mappingPath = options.WindowsMapping!;
             if (File.Exists(mappingPath))
             {
                 return CldrWindowsZonesParser.Parse(mappingPath);

--- a/src/NodaTime.TzdbCompiler/Tzdb/DateTimeZoneBuilder.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/DateTimeZoneBuilder.cs
@@ -16,7 +16,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
     internal sealed class DateTimeZoneBuilder
     {
         private readonly List<ZoneInterval> zoneIntervals;
-        private StandardDaylightAlternatingMap tailZone;
+        private StandardDaylightAlternatingMap? tailZone;
 
         private DateTimeZoneBuilder()
         {
@@ -105,7 +105,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
                 activeRules
                     .Select(rule => new { rule, prev = rule.PreviousOrSame(start, lastZoneInterval.StandardOffset, lastZoneInterval.Savings) })
                     .Where(pair => pair.prev != null)
-                    .OrderBy(pair => pair.prev.Value.Instant)
+                    .OrderBy(pair => pair.prev!.Value.Instant)
                     .Select(pair => pair.rule)
                     .LastOrDefault();
 
@@ -136,7 +136,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
             // corresponds with a return statement in the loop.
             while (true)
             {
-                ZoneTransition bestTransition = null;
+                ZoneTransition? bestTransition = null;
                 for (int i = 0; i < activeRules.Count; i++)
                 {
                     var rule = activeRules[i];

--- a/src/NodaTime.TzdbCompiler/Tzdb/ParserHelper.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/ParserHelper.cs
@@ -80,10 +80,10 @@ namespace NodaTime.TzdbCompiler.Tzdb
         }
 
         /// <summary>
-        /// Formats the optional.
+        /// Formats an optional, converting null input to "-".
         /// </summary>
         /// <param name="value">The value.</param>
-        public static string FormatOptional(string value) => value ?? "-";
+        public static string FormatOptional(string? value) => value ?? "-";
 
         /// <summary>
         ///   Parses the given text for an integer. Leading and trailing white space is ignored.
@@ -163,7 +163,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// </summary>
         /// <param name="text">The value to parse.</param>
         /// <returns>The input string or null.</returns>
-        public static string ParseOptional([NotNull] String text)
+        public static string? ParseOptional([NotNull] String text)
         {
             Preconditions.CheckNotNull(text, nameof(text));
             return text == "-" ? null : text;

--- a/src/NodaTime.TzdbCompiler/Tzdb/RuleLine.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/RuleLine.cs
@@ -16,14 +16,14 @@ namespace NodaTime.TzdbCompiler.Tzdb
     /// <remarks>
     /// Immutable, threadsafe.
     /// </remarks>
-    internal class RuleLine : IEquatable<RuleLine>
+    internal class RuleLine : IEquatable<RuleLine?>
     {
         /// <summary>
         /// The string to replace "%s" with (if any) when formatting the zone name key.
         /// </summary>
         /// <remarks>This is always used to replace %s, whether or not the recurrence
         /// actually includes savings; it is expected to be appropriate to the recurrence.</remarks>
-        private readonly string daylightSavingsIndicator;
+        private readonly string? daylightSavingsIndicator;
 
         /// <summary>
         /// The recurrence pattern for the rule.
@@ -40,14 +40,14 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// "odd", "even" etc - usually yearistype.sh is used to determine this; Noda Time only supports
         /// "odd" and "even" (used in Australia for data up to and including 2000e).
         /// </summary>
-        public string Type { get; }
+        public string? Type { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RuleLine" /> class.
         /// </summary>
         /// <param name="recurrence">The recurrence definition of this rule.</param>
         /// <param name="daylightSavingsIndicator">The daylight savings indicator letter for time zone names.</param>
-        public RuleLine(ZoneRecurrence recurrence, string daylightSavingsIndicator, string type)
+        public RuleLine(ZoneRecurrence recurrence, string? daylightSavingsIndicator, string? type)
         {
             this.recurrence = recurrence;
             this.daylightSavingsIndicator = daylightSavingsIndicator;
@@ -63,7 +63,8 @@ namespace NodaTime.TzdbCompiler.Tzdb
         ///   true if the current object is equal to the <paramref name = "other" /> parameter;
         ///   otherwise, false.
         /// </returns>
-        public bool Equals(RuleLine other) => !(other is null) && Equals(recurrence, other.recurrence) && Equals(daylightSavingsIndicator, other.daylightSavingsIndicator);
+        public bool Equals(RuleLine? other) =>
+            !(other is null) && Equals(recurrence, other.recurrence) && Equals(daylightSavingsIndicator, other.daylightSavingsIndicator);
         #endregion
 
         #region Operator overloads
@@ -140,7 +141,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance;
         /// otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj) => Equals(obj as RuleLine);
+        public override bool Equals(object? obj) => Equals(obj as RuleLine);
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbDatabase.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbDatabase.cs
@@ -39,12 +39,12 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// <summary>
         /// A list of the zone locations known to this database from zone.tab.
         /// </summary>
-        internal IList<TzdbZoneLocation> ZoneLocations { get; set; }
+        internal IList<TzdbZoneLocation>? ZoneLocations { get; set; }
 
         /// <summary>
         /// A list of the zone locations known to this database from zone1970.tab.
         /// </summary>
-        internal IList<TzdbZone1970Location> Zone1970Locations { get; set; }
+        internal IList<TzdbZone1970Location>? Zone1970Locations { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TzdbDatabase" /> class.

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbStreamWriter.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbStreamWriter.cs
@@ -144,8 +144,8 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// </summary>
         private static List<string> CreateOptimizedStringPool(
             IEnumerable<DateTimeZone> zones,
-            IEnumerable<TzdbZoneLocation> zoneLocations,
-            IEnumerable<TzdbZone1970Location> zone1970Locations,
+            IEnumerable<TzdbZoneLocation>? zoneLocations,
+            IEnumerable<TzdbZone1970Location>? zone1970Locations,
             WindowsZones cldrWindowsZones)
         {
             var optimizingWriter = new StringPoolOptimizingFakeWriter();
@@ -215,7 +215,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         {
             private readonly MemoryStream stream;
 
-            internal FieldData(TzdbStreamFieldId fieldId, IList<string> stringPool)
+            internal FieldData(TzdbStreamFieldId fieldId, IList<string>? stringPool)
             {
                 this.FieldId = fieldId;
                 this.stream = new MemoryStream();
@@ -239,7 +239,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         {
             private readonly List<FieldData> fields = new List<FieldData>();
 
-            internal FieldData AddField(TzdbStreamFieldId fieldNumber, IList<string> stringPool)
+            internal FieldData AddField(TzdbStreamFieldId fieldNumber, IList<string>? stringPool)
             {
                 FieldData ret = new FieldData(fieldNumber, stringPool);
                 fields.Add(ret);

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbZoneInfoCompiler.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbZoneInfoCompiler.cs
@@ -32,7 +32,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
 
         private static readonly Regex VersionRegex = new Regex(@"\d{2,4}[a-z]");
 
-        private readonly TextWriter log;
+        private readonly TextWriter? log;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TzdbZoneInfoCompiler" /> class
@@ -44,7 +44,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// Initializes a new instance of the <see cref="TzdbZoneInfoCompiler" /> class
         /// logging to the given text writer, which may be null.
         /// </summary>
-        public TzdbZoneInfoCompiler(TextWriter log)
+        public TzdbZoneInfoCompiler(TextWriter? log)
         {
             this.log = log;
         }

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbZoneInfoParser.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbZoneInfoParser.cs
@@ -72,7 +72,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// </summary>
         /// <param name="tokens">The tokens.</param>
         /// <param name="name">The name of the expected value, for use in the exception if no value is available.</param>
-        private string NextOptional(Tokens tokens, string name) => ParserHelper.ParseOptional(NextString(tokens, name));
+        private string? NextOptional(Tokens tokens, string name) => ParserHelper.ParseOptional(NextString(tokens, name));
 
         /// <summary>
         /// Returns the next string from the token stream.
@@ -122,7 +122,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// <param name="database">The database to fill.</param>
         internal void Parse(TextReader reader, TzdbDatabase database)
         {
-            string currentZone = null;
+            string? currentZone = null;
             foreach (var line in reader.ReadLines())
             {
                 currentZone = ParseLine(line, currentZone, database);
@@ -267,9 +267,10 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// </para>
         /// </remarks>
         /// <param name="line">The line to parse.</param>
+        /// <param name="previousZone">The previous zone ID, or null if we don't have one.</param>
         /// <param name="database">The database to fill.</param>
         /// <return>The zone name just parsed, if any - so that it can be passed into the next call.</return>
-        private string ParseLine(string line, string previousZone, TzdbDatabase database)
+        private string? ParseLine(string line, string? previousZone, TzdbDatabase database)
         {
             // Trim end-of-line comments
             int index = line.IndexOf("#", StringComparison.Ordinal);

--- a/src/NodaTime.TzdbCompiler/Tzdb/ZoneLine.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/ZoneLine.cs
@@ -19,14 +19,14 @@ namespace NodaTime.TzdbCompiler.Tzdb
     /// <remarks>
     /// Immutable, thread-safe
     /// </remarks>
-    internal class ZoneLine : IEquatable<ZoneLine>
+    internal class ZoneLine : IEquatable<ZoneLine?>
     {
         private static readonly OffsetPattern PercentZPattern = OffsetPattern.CreateWithInvariantCulture("i");
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ZoneLine" /> class.
         /// </summary>
-        public ZoneLine(string name, Offset offset, string rules, string format, int untilYear, ZoneYearOffset untilYearOffset)
+        public ZoneLine(string name, Offset offset, string? rules, string format, int untilYear, ZoneYearOffset untilYearOffset)
         {
             this.Name = name;
             this.StandardOffset = offset;
@@ -64,7 +64,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// null for just standard time, or an offset for a "fixed savings" rule.
         /// </summary>
         /// <value>The name of the rules to apply for this zone line.</value>
-        internal string Rules { get; }
+        internal string? Rules { get; }
 
         #region IEquatable<Zone> Members
         /// <summary>
@@ -75,7 +75,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         ///   true if the current object is equal to the <paramref name = "other" /> parameter;
         ///   otherwise, false.
         /// </returns>
-        public bool Equals(ZoneLine other)
+        public bool Equals(ZoneLine? other)
         {
             if (other is null)
             {
@@ -102,7 +102,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance;
         ///   otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj) => Equals(obj as ZoneLine);
+        public override bool Equals(object? obj) => Equals(obj as ZoneLine);
 
         /// <summary>
         ///   Returns a hash code for this instance.
@@ -176,7 +176,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
             }
         }
 
-        internal string FormatName(Offset savings, string daylightSavingsIndicator)
+        internal string FormatName(Offset savings, string? daylightSavingsIndicator)
         {
             int index = Format.IndexOf("/", StringComparison.Ordinal);
             if (index >= 0)

--- a/src/NodaTime.TzdbCompiler/Tzdb/ZoneRuleSet.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/ZoneRuleSet.cs
@@ -18,7 +18,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
     {
         // Either rules or name+fixedSavings is specified.
         private readonly List<ZoneRecurrence> rules = new List<ZoneRecurrence>();
-        private readonly string name;
+        private readonly string? name;
         private readonly Offset fixedSavings;
         private readonly int upperYear;
         private readonly ZoneYearOffset upperYearOffset;
@@ -55,7 +55,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         {
             Preconditions.CheckState(IsFixed, "Rule set is not fixed");
             var limit = GetUpperLimit(fixedSavings);
-            return new ZoneInterval(name, start, limit, StandardOffset + fixedSavings, fixedSavings);
+            return new ZoneInterval(name!, start, limit, StandardOffset + fixedSavings, fixedSavings);
         }
 
         /// <summary>

--- a/src/NodaTime.TzdbCompiler/Tzdb/ZoneTransition.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/ZoneTransition.cs
@@ -83,10 +83,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// </returns>
         internal bool IsTransitionFrom(ZoneTransition other)
         {
-            if (other is null)
-            {
-                return true;
-            }
+            Preconditions.CheckNotNull(other, nameof(other));
             bool later = Instant > other.Instant;
             bool different = Name != other.Name || StandardOffset != other.StandardOffset || Savings != other.Savings;
             return later && different;

--- a/src/NodaTime/Annotations/TestExemptionAttribute.cs
+++ b/src/NodaTime/Annotations/TestExemptionAttribute.cs
@@ -15,7 +15,7 @@ namespace NodaTime.Annotations
     {
         internal TestExemptionCategory Category { get; }
 
-        internal TestExemptionAttribute(TestExemptionCategory category, string message = null)
+        internal TestExemptionAttribute(TestExemptionCategory category, string? message = null)
         {
             Category = category;
         }

--- a/src/NodaTime/AnnualDate.cs
+++ b/src/NodaTime/AnnualDate.cs
@@ -125,7 +125,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             AnnualDatePattern.BclSupport.Format(this, patternText, formatProvider);
 
         /// <summary>

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -60,7 +60,7 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// Returns the hash code for this interval, consistent with <see cref="Equals(DateInterval)"/>.
+        /// Returns the hash code for this interval, consistent with <see cref="Equals(DateInterval?)"/>.
         /// </summary>
         /// <returns>The hash code for this interval.</returns>
         public override int GetHashCode() =>
@@ -113,10 +113,10 @@ namespace NodaTime
         public bool Equals(DateInterval? other) => this == other;
 
         /// <summary>
-        /// Compares the given object for equality with this one, as per <see cref="Equals(DateInterval)"/>.
+        /// Compares the given object for equality with this one, as per <see cref="Equals(DateInterval?)"/>.
         /// </summary>
         /// <param name="obj">The value to compare this one with.</param>
-        /// <returns>true if the other object is a date interval equal to this one, consistent with <see cref="Equals(DateInterval)"/>.</returns>
+        /// <returns>true if the other object is a date interval equal to this one, consistent with <see cref="Equals(DateInterval?)"/>.</returns>
         public override bool Equals(object obj) => this == (obj as DateInterval);
 
         /// <summary>

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -26,7 +26,7 @@ namespace NodaTime
     /// </remarks>
     /// <threadsafety>This type is immutable reference type. See the thread safety section of the user guide for more information.</threadsafety>
     [Immutable]
-    public sealed class DateInterval : IEquatable<DateInterval>, IEnumerable<LocalDate>
+    public sealed class DateInterval : IEquatable<DateInterval?>, IEnumerable<LocalDate>
     {
         /// <summary>
         /// Gets the start date of the interval.
@@ -110,7 +110,7 @@ namespace NodaTime
         /// </remarks>
         /// <param name="other">The date interval to compare this one with.</param>
         /// <returns>True if this date interval has the same same start and end date as the one specified.</returns>
-        public bool Equals(DateInterval other) => this == other;
+        public bool Equals(DateInterval? other) => this == other;
 
         /// <summary>
         /// Compares the given object for equality with this one, as per <see cref="Equals(DateInterval)"/>.

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -78,7 +78,7 @@ namespace NodaTime
         /// <param name="lhs">The first value to compare</param>
         /// <param name="rhs">The second value to compare</param>
         /// <returns>True if the two date intervals have the same properties; false otherwise.</returns>
-        public static bool operator ==(DateInterval lhs, DateInterval rhs)
+        public static bool operator ==(DateInterval? lhs, DateInterval? rhs)
         {
             if (ReferenceEquals(lhs, rhs))
             {
@@ -100,7 +100,7 @@ namespace NodaTime
         /// <param name="lhs">The first value to compare</param>
         /// <param name="rhs">The second value to compare</param>
         /// <returns>False if the two date intervals have the same start and end date; true otherwise.</returns>
-        public static bool operator !=(DateInterval lhs, DateInterval rhs) => !(lhs == rhs);
+        public static bool operator !=(DateInterval? lhs, DateInterval? rhs) => !(lhs == rhs);
 
         /// <summary>
         /// Compares the given date interval for equality with this one.
@@ -207,14 +207,12 @@ namespace NodaTime
         /// <exception cref="ArgumentException"><paramref name="interval" /> uses a different
         /// calendar to this date interval.</exception>
         [CanBeNull]
-        public DateInterval Intersection([NotNull]DateInterval interval)
-        {
-            return Contains(interval) ? interval
+        public DateInterval? Intersection([NotNull]DateInterval interval) =>
+            Contains(interval) ? interval
                 : interval.Contains(this) ? this
                 : interval.Contains(Start) ? new DateInterval(Start, interval.End)
                 : interval.Contains(End) ? new DateInterval(interval.Start, End)
                 : null;
-        }
 
         /// <summary>
         /// Returns the union between the given interval and this interval, as long as they're overlapping or contiguous.
@@ -226,7 +224,7 @@ namespace NodaTime
         /// </returns>
         /// <exception cref="ArgumentException"><paramref name="interval" /> uses a different calendar to this date interval.</exception>
         [CanBeNull]
-        public DateInterval Union([NotNull] DateInterval interval)
+        public DateInterval? Union([NotNull] DateInterval interval)
         {
             ValidateInterval(interval);
 

--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -246,12 +246,12 @@ namespace NodaTime
             // are close enough that we've found the right instant.
             if (interval.Contains(localInstant))
             {
-                ZoneInterval earlier = GetEarlierMatchingInterval(interval, localInstant);
+                ZoneInterval? earlier = GetEarlierMatchingInterval(interval, localInstant);
                 if (earlier != null)
                 {
                     return new ZoneLocalMapping(this, localDateTime, earlier, interval, 2);
                 }
-                ZoneInterval later = GetLaterMatchingInterval(interval, localInstant);
+                ZoneInterval? later = GetLaterMatchingInterval(interval, localInstant);
                 if (later != null)
                 {
                     return new ZoneLocalMapping(this, localDateTime, interval, later, 2);
@@ -262,12 +262,12 @@ namespace NodaTime
             {
                 // Our first guess was wrong. Either we need to change interval by one (either direction)
                 // or we're in a gap.
-                ZoneInterval earlier = GetEarlierMatchingInterval(interval, localInstant);
+                ZoneInterval? earlier = GetEarlierMatchingInterval(interval, localInstant);
                 if (earlier != null)
                 {
                     return new ZoneLocalMapping(this, localDateTime, earlier, earlier, 1);
                 }
-                ZoneInterval later = GetLaterMatchingInterval(interval, localInstant);
+                ZoneInterval? later = GetLaterMatchingInterval(interval, localInstant);
                 if (later != null)
                 {
                     return new ZoneLocalMapping(this, localDateTime, later, later, 1);
@@ -383,7 +383,7 @@ namespace NodaTime
         /// <summary>
         /// Returns the interval before this one, if it contains the given local instant, or null otherwise.
         /// </summary>
-        private ZoneInterval GetEarlierMatchingInterval(ZoneInterval interval, LocalInstant localInstant)
+        private ZoneInterval? GetEarlierMatchingInterval(ZoneInterval interval, LocalInstant localInstant)
         {
             // Micro-optimization to avoid fetching interval.Start multiple times. Seems
             // to give a performance improvement on x86 at least...
@@ -407,7 +407,7 @@ namespace NodaTime
         /// <summary>
         /// Returns the next interval after this one, if it contains the given local instant, or null otherwise.
         /// </summary>
-        private ZoneInterval GetLaterMatchingInterval(ZoneInterval interval, LocalInstant localInstant)
+        private ZoneInterval? GetLaterMatchingInterval(ZoneInterval interval, LocalInstant localInstant)
         {
             // Micro-optimization to avoid fetching interval.End multiple times. Seems
             // to give a performance improvement on x86 at least...

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -1094,7 +1094,7 @@ namespace NodaTime
 
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -454,7 +454,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             DurationPattern.BclSupport.Format(this, patternText, formatProvider);
         #endregion Formatting
 

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -43,17 +43,17 @@ namespace NodaTime.Globalization
         private readonly object fieldLock = new object();
 
         #region Patterns
-        private FixedFormatInfoPatternParser<Duration> durationPatternParser;
-        private FixedFormatInfoPatternParser<Offset> offsetPatternParser;
-        private FixedFormatInfoPatternParser<Instant> instantPatternParser;
-        private FixedFormatInfoPatternParser<LocalTime> localTimePatternParser;
-        private FixedFormatInfoPatternParser<LocalDate> localDatePatternParser;
-        private FixedFormatInfoPatternParser<LocalDateTime> localDateTimePatternParser;
-        private FixedFormatInfoPatternParser<OffsetDateTime> offsetDateTimePatternParser;
-        private FixedFormatInfoPatternParser<OffsetDate> offsetDatePatternParser;
-        private FixedFormatInfoPatternParser<OffsetTime> offsetTimePatternParser;
-        private FixedFormatInfoPatternParser<ZonedDateTime> zonedDateTimePatternParser;
-        private FixedFormatInfoPatternParser<AnnualDate> annualDatePatternParser;
+        private FixedFormatInfoPatternParser<Duration>? durationPatternParser;
+        private FixedFormatInfoPatternParser<Offset>? offsetPatternParser;
+        private FixedFormatInfoPatternParser<Instant>? instantPatternParser;
+        private FixedFormatInfoPatternParser<LocalTime>? localTimePatternParser;
+        private FixedFormatInfoPatternParser<LocalDate>? localDatePatternParser;
+        private FixedFormatInfoPatternParser<LocalDateTime>? localDateTimePatternParser;
+        private FixedFormatInfoPatternParser<OffsetDateTime>? offsetDateTimePatternParser;
+        private FixedFormatInfoPatternParser<OffsetDate>? offsetDatePatternParser;
+        private FixedFormatInfoPatternParser<OffsetTime>? offsetTimePatternParser;
+        private FixedFormatInfoPatternParser<ZonedDateTime>? zonedDateTimePatternParser;
+        private FixedFormatInfoPatternParser<AnnualDate>? annualDatePatternParser;
         #endregion
 
         /// <summary>
@@ -69,12 +69,12 @@ namespace NodaTime.Globalization
         private static readonly Cache<CultureInfo, NodaFormatInfo> Cache = new Cache<CultureInfo, NodaFormatInfo>
             (500, culture => new NodaFormatInfo(culture), new ReferenceEqualityComparer<CultureInfo>());
 
-        private IList<string> longMonthNames;
-        private IList<string> longMonthGenitiveNames;
-        private IList<string> longDayNames;
-        private IList<string> shortMonthNames;
-        private IList<string> shortMonthGenitiveNames;
-        private IList<string> shortDayNames;
+        private IList<string>? longMonthNames;
+        private IList<string>? longMonthGenitiveNames;
+        private IList<string>? longDayNames;
+        private IList<string>? shortMonthNames;
+        private IList<string>? shortMonthGenitiveNames;
+        private IList<string>? shortDayNames;
 
         private readonly ConcurrentDictionary<Era, EraDescription> eraDescriptions;
 
@@ -123,12 +123,12 @@ namespace NodaTime.Globalization
         }
 
         /// <summary>
-        /// The BCL returns arrays of month names starting at 0; we want a read-only list starting at 1 (with 0 as null).
+        /// The BCL returns arrays of month names starting at 0; we want a read-only list starting at 1 (with 0 as an empty string).
         /// </summary>
         private static IList<string> ConvertMonthArray(string[] monthNames)
         {
             List<string> list = new List<string>(monthNames);
-            list.Insert(0, null);
+            list.Insert(0, "");
             return new ReadOnlyCollection<string>(list);
         }
 
@@ -146,14 +146,14 @@ namespace NodaTime.Globalization
         }
 
         /// <summary>
-        /// The BCL returns arrays of week names starting at 0 as Sunday; we want a read-only list starting at 1 (with 0 as null)
+        /// The BCL returns arrays of week names starting at 0 as Sunday; we want a read-only list starting at 1 (with 0 as an empty string)
         /// and with 7 as Sunday.
         /// </summary>
         private static IList<string> ConvertDayArray(string[] dayNames)
         {
             List<string> list = new List<string>(dayNames);
             list.Add(dayNames[0]);
-            list[0] = null;
+            list[0] = "";
             return new ReadOnlyCollection<string>(list);
         }
 
@@ -213,7 +213,7 @@ namespace NodaTime.Globalization
         internal FixedFormatInfoPatternParser<ZonedDateTime> ZonedDateTimePatternParser => EnsureFixedFormatInitialized(ref zonedDateTimePatternParser, () => new ZonedDateTimePatternParser(ZonedDateTimePattern.DefaultTemplateValue, Resolvers.StrictResolver, null));
         internal FixedFormatInfoPatternParser<AnnualDate> AnnualDatePatternParser => EnsureFixedFormatInitialized(ref annualDatePatternParser, () => new AnnualDatePatternParser(AnnualDatePattern.DefaultTemplateValue));
 
-        private FixedFormatInfoPatternParser<T> EnsureFixedFormatInitialized<T>(ref FixedFormatInfoPatternParser<T> field,
+        private FixedFormatInfoPatternParser<T> EnsureFixedFormatInitialized<T>(ref FixedFormatInfoPatternParser<T>? field,
             Func<IPatternParser<T>> patternParserFactory)
         {
             lock (fieldLock)
@@ -229,11 +229,11 @@ namespace NodaTime.Globalization
             var localConstruction = new FixedFormatInfoPatternParser<T>(patternParserFactory(), this);
             lock (fieldLock)
             {
-                if (field == null)
+                if (field is null)
                 {
                     field = localConstruction;
                 }
-                return field;
+                return field!;
             }
         }
 
@@ -242,13 +242,13 @@ namespace NodaTime.Globalization
         /// See the usage guide for caveats around the use of these names for other calendars.
         /// Element 0 of the list is null, to allow a more natural mapping from (say) 1 to the string "January".
         /// </summary>
-        public IList<string> LongMonthNames { get { EnsureMonthsInitialized();  return longMonthNames; } }
+        public IList<string> LongMonthNames { get { EnsureMonthsInitialized();  return longMonthNames!; } }
         /// <summary>
         /// Returns a read-only list of the abbreviated names of the months for the default calendar for this culture.
         /// See the usage guide for caveats around the use of these names for other calendars.
         /// Element 0 of the list is null, to allow a more natural mapping from (say) 1 to the string "Jan".
         /// </summary>
-        public IList<string> ShortMonthNames { get { EnsureMonthsInitialized(); return shortMonthNames; } }
+        public IList<string> ShortMonthNames { get { EnsureMonthsInitialized(); return shortMonthNames!; } }
         /// <summary>
         /// Returns a read-only list of the names of the months for the default calendar for this culture.
         /// See the usage guide for caveats around the use of these names for other calendars.
@@ -257,7 +257,7 @@ namespace NodaTime.Globalization
         /// If the culture does not use genitive month names, this property will return the same reference as
         /// <see cref="LongMonthNames"/>.
         /// </summary>
-        public IList<string> LongMonthGenitiveNames { get { EnsureMonthsInitialized(); return longMonthGenitiveNames; } }
+        public IList<string> LongMonthGenitiveNames { get { EnsureMonthsInitialized(); return longMonthGenitiveNames!; } }
         /// <summary>
         /// Returns a read-only list of the abbreviated names of the months for the default calendar for this culture.
         /// See the usage guide for caveats around the use of these names for other calendars.
@@ -266,21 +266,21 @@ namespace NodaTime.Globalization
         /// If the culture does not use genitive month names, this property will return the same reference as
         /// <see cref="ShortMonthNames"/>.
         /// </summary>
-        public IList<string> ShortMonthGenitiveNames { get { EnsureMonthsInitialized(); return shortMonthGenitiveNames; } }
+        public IList<string> ShortMonthGenitiveNames { get { EnsureMonthsInitialized(); return shortMonthGenitiveNames!; } }
         /// <summary>
         /// Returns a read-only list of the names of the days of the week for the default calendar for this culture.
         /// See the usage guide for caveats around the use of these names for other calendars.
         /// Element 0 of the list is null, and the other elements correspond with the index values returned from
         /// <see cref="LocalDateTime.DayOfWeek"/> and similar properties.
         /// </summary>
-        public IList<string> LongDayNames { get { EnsureDaysInitialized(); return longDayNames; } }
+        public IList<string> LongDayNames { get { EnsureDaysInitialized(); return longDayNames!; } }
         /// <summary>
         /// Returns a read-only list of the abbreviated names of the days of the week for the default calendar for this culture.
         /// See the usage guide for caveats around the use of these names for other calendars.
         /// Element 0 of the list is null, and the other elements correspond with the index values returned from
         /// <see cref="LocalDateTime.DayOfWeek"/> and similar properties.
         /// </summary>
-        public IList<string> ShortDayNames { get { EnsureDaysInitialized(); return shortDayNames; } }
+        public IList<string> ShortDayNames { get { EnsureDaysInitialized(); return shortDayNames!; } }
 
         /// <summary>
         /// Gets the BCL date time format associated with this formatting information.
@@ -452,7 +452,7 @@ namespace NodaTime.Globalization
                 }
                 else
                 {
-                    string eraNameFromCulture = GetEraNameFromBcl(era, cultureInfo);
+                    string? eraNameFromCulture = GetEraNameFromBcl(era, cultureInfo);
                     if (eraNameFromCulture != null && !pipeDelimited.StartsWith(eraNameFromCulture + "|"))
                     {
                         pipeDelimited = eraNameFromCulture + "|" + pipeDelimited;
@@ -470,7 +470,7 @@ namespace NodaTime.Globalization
             /// it's correct. (The selection here seems small, but it covers most cases.) This isn't ideal, but it's better
             /// than nothing, and fixes an issue where non-English BCL cultures have "gg" in their patterns.
             /// </summary>
-            private static string GetEraNameFromBcl(Era era, CultureInfo culture)
+            private static string? GetEraNameFromBcl(Era era, CultureInfo culture)
             {
                 var calendar = culture.DateTimeFormat.Calendar;
                 bool getEraFromCalendar =

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -2,19 +2,18 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
-using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Globalization;
 using JetBrains.Annotations;
+using NodaTime.Annotations;
 using NodaTime.Calendars;
 using NodaTime.Text;
 using NodaTime.Text.Patterns;
 using NodaTime.TimeZones;
 using NodaTime.Utility;
-using NodaTime.Annotations;
-using System.Threading;
+using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
 
 namespace NodaTime.Globalization
 {
@@ -411,14 +410,15 @@ namespace NodaTime.Globalization
         /// <param name="provider">The <see cref="IFormatProvider" />.</param>
         /// <exception cref="ArgumentException">The format provider cannot be used for Noda Time.</exception>
         /// <returns>The <see cref="NodaFormatInfo" />. Will never be null.</returns>
-        public static NodaFormatInfo GetInstance(IFormatProvider provider) => provider switch
+        public static NodaFormatInfo GetInstance(IFormatProvider? provider) => provider switch
             {
                 null => GetFormatInfo(CurrentInfo.CultureInfo),
                 CultureInfo cultureInfo => GetFormatInfo(cultureInfo),
                 // Note: no caching for this case. It's a corner case anyway... we could add a cache later
                 // if users notice a problem.
                 DateTimeFormatInfo dateTimeFormatInfo => new NodaFormatInfo(CultureInfo.InvariantCulture, dateTimeFormatInfo),
-                _ => throw new ArgumentException($"Cannot use provider of type {provider.GetType().FullName} in Noda Time", nameof(provider))
+                // TODO(nullable): File a Roslyn bug, as provider really won't be null here.
+                _ => throw new ArgumentException($"Cannot use provider of type {provider!.GetType().FullName} in Noda Time", nameof(provider))
             };
 
         /// <summary>

--- a/src/NodaTime/IDateTimeZoneProvider.cs
+++ b/src/NodaTime/IDateTimeZoneProvider.cs
@@ -94,7 +94,7 @@ namespace NodaTime
         /// <param name="id">The time zone ID to find.</param>
         /// <returns>The <see cref="DateTimeZone" /> for the given ID or null if the provider does not support
         /// the given ID.</returns>
-        [CanBeNull] DateTimeZone GetZoneOrNull([NotNull] string id);
+        [CanBeNull] DateTimeZone? GetZoneOrNull([NotNull] string id);
 
         /// <summary>
         /// Returns the time zone for the given ID.

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -733,7 +733,7 @@ namespace NodaTime
 
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -486,7 +486,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             InstantPattern.BclSupport.Format(this, patternText, formatProvider);
         #endregion Formatting
 

--- a/src/NodaTime/Interval.cs
+++ b/src/NodaTime/Interval.cs
@@ -227,7 +227,7 @@ namespace NodaTime
 
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -814,7 +814,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             LocalDatePattern.BclSupport.Format(this, patternText, formatProvider);
         #endregion Formatting
 

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -820,7 +820,7 @@ namespace NodaTime
 
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -932,7 +932,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             LocalDateTimePattern.BclSupport.Format(this, patternText, formatProvider);
         #endregion Formatting
 

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -938,7 +938,7 @@ namespace NodaTime
 
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -750,7 +750,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             LocalTimePattern.BclSupport.Format(this, patternText, formatProvider);
         #endregion Formatting
 

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -756,10 +756,7 @@ namespace NodaTime
 
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema()
-        {
-            return null;
-        }
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -17,6 +17,7 @@
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <Deterministic>True</Deterministic>
     <LangVersion>8.0</LangVersion>
+    <NullableReferenceTypes>True</NullableReferenceTypes>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -17,7 +17,7 @@
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <Deterministic>True</Deterministic>
     <LangVersion>8.0</LangVersion>
-    <NullableReferenceTypes>True</NullableReferenceTypes>
+    <NullableContextOptions>enable</NullableContextOptions>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime/Offset.cs
+++ b/src/NodaTime/Offset.cs
@@ -370,7 +370,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             OffsetPattern.BclSupport.Format(this, patternText, formatProvider);
         #endregion Formatting
 

--- a/src/NodaTime/Offset.cs
+++ b/src/NodaTime/Offset.cs
@@ -493,7 +493,7 @@ namespace NodaTime
 
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)

--- a/src/NodaTime/OffsetDate.cs
+++ b/src/NodaTime/OffsetDate.cs
@@ -206,7 +206,7 @@ namespace NodaTime
 
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)

--- a/src/NodaTime/OffsetDate.cs
+++ b/src/NodaTime/OffsetDate.cs
@@ -189,7 +189,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             OffsetDatePattern.Patterns.BclSupport.Format(this, patternText, formatProvider);
 
         /// <summary>

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -829,7 +829,7 @@ namespace NodaTime
 
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -502,7 +502,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             OffsetDateTimePattern.Patterns.BclSupport.Format(this, patternText, formatProvider);
         #endregion Formatting
 

--- a/src/NodaTime/OffsetTime.cs
+++ b/src/NodaTime/OffsetTime.cs
@@ -293,7 +293,7 @@ namespace NodaTime
         }
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)

--- a/src/NodaTime/OffsetTime.cs
+++ b/src/NodaTime/OffsetTime.cs
@@ -272,7 +272,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             OffsetTimePattern.Patterns.BclSupport.Format(this, patternText, formatProvider);
 
 

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -829,14 +829,14 @@ namespace NodaTime
         public override string ToString() => PeriodPattern.Roundtrip.Format(this);
 
         /// <summary>
-        /// Compares the given object for equality with this one, as per <see cref="Equals(Period)"/>.
+        /// Compares the given object for equality with this one, as per <see cref="Equals(Period?)"/>.
         /// </summary>
         /// <param name="other">The value to compare this one with.</param>
-        /// <returns>true if the other object is a period equal to this one, consistent with <see cref="Equals(Period)"/></returns>
+        /// <returns>true if the other object is a period equal to this one, consistent with <see cref="Equals(Period?)"/></returns>
         public override bool Equals(object? other) => Equals(other as Period);
 
         /// <summary>
-        /// Returns the hash code for this period, consistent with <see cref="Equals(Period)"/>.
+        /// Returns the hash code for this period, consistent with <see cref="Equals(Period?)"/>.
         /// </summary>
         /// <returns>The hash code for this period.</returns>
         public override int GetHashCode() =>

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -63,7 +63,7 @@ namespace NodaTime
         /// equal 1 year.
         /// </summary>
         /// <value>An equality comparer which compares periods by first normalizing them.</value>
-        [NotNull] public static IEqualityComparer<Period> NormalizingEqualityComparer => NormalizingPeriodEqualityComparer.Instance;
+        [NotNull] public static IEqualityComparer<Period?> NormalizingEqualityComparer => NormalizingPeriodEqualityComparer.Instance;
 
         // The fields that make up this period.
 
@@ -327,7 +327,7 @@ namespace NodaTime
         /// <param name="baseDateTime">The base local date/time to use for comparisons.</param>
         /// <returns>The new comparer.</returns>
         [NotNull]
-        public static IComparer<Period> CreateComparer(LocalDateTime baseDateTime) => new PeriodComparer(baseDateTime);
+        public static IComparer<Period?> CreateComparer(LocalDateTime baseDateTime) => new PeriodComparer(baseDateTime);
 
         /// <summary>
         /// Subtracts one period from another, by simply subtracting each property value.
@@ -879,7 +879,7 @@ namespace NodaTime
         /// <summary>
         /// Equality comparer which simply normalizes periods before comparing them.
         /// </summary>
-        private sealed class NormalizingPeriodEqualityComparer : EqualityComparer<Period>
+        private sealed class NormalizingPeriodEqualityComparer : EqualityComparer<Period?>
         {
             internal static readonly NormalizingPeriodEqualityComparer Instance = new NormalizingPeriodEqualityComparer();
 
@@ -887,7 +887,7 @@ namespace NodaTime
             {
             }
 
-            public override bool Equals(Period x, Period y)
+            public override bool Equals(Period? x, Period? y)
             {
                 if (ReferenceEquals(x, y))
                 {
@@ -900,11 +900,11 @@ namespace NodaTime
                 return x.Normalize().Equals(y.Normalize());
             }
 
-            public override int GetHashCode([NotNull] Period obj) =>
-                Preconditions.CheckNotNull(obj, nameof(obj)).Normalize().GetHashCode();
+            public override int GetHashCode([NotNull] Period? obj) =>
+                Preconditions.CheckNotNull(obj!, nameof(obj)).Normalize().GetHashCode();
         }
 
-        private sealed class PeriodComparer : Comparer<Period>
+        private sealed class PeriodComparer : Comparer<Period?>
         {
             private readonly LocalDateTime baseDateTime;
 
@@ -913,7 +913,7 @@ namespace NodaTime
                 this.baseDateTime = baseDateTime;
             }
 
-            public override int Compare(Period x, Period y)
+            public override int Compare(Period? x, Period? y)
             {
                 if (ReferenceEquals(x, y))
                 {

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -44,7 +44,7 @@ namespace NodaTime
     /// <threadsafety>This type is immutable reference type. See the thread safety section of the user guide for more information.</threadsafety>
     [Immutable]
     [TypeConverter(typeof(PeriodTypeConverter))]
-    public sealed class Period : IEquatable<Period>
+    public sealed class Period : IEquatable<Period?>
     {
         // General implementation note: operations such as normalization work out the total number of nanoseconds as an Int64
         // value. This can handle +/- 106,751 days, or 292 years. We could move to using BigInteger if we feel that's required,
@@ -833,7 +833,7 @@ namespace NodaTime
         /// </summary>
         /// <param name="other">The value to compare this one with.</param>
         /// <returns>true if the other object is a period equal to this one, consistent with <see cref="Equals(Period)"/></returns>
-        public override bool Equals(object other) => Equals(other as Period);
+        public override bool Equals(object? other) => Equals(other as Period);
 
         /// <summary>
         /// Returns the hash code for this period, consistent with <see cref="Equals(Period)"/>.
@@ -862,7 +862,7 @@ namespace NodaTime
         /// </remarks>
         /// <param name="other">The period to compare this one with.</param>
         /// <returns>True if this period has the same values for the same properties as the one specified.</returns>
-        public bool Equals(Period other) =>
+        public bool Equals(Period? other) =>
             other != null &&
             Years == other.Years &&
             Months == other.Months &&

--- a/src/NodaTime/PeriodBuilder.cs
+++ b/src/NodaTime/PeriodBuilder.cs
@@ -179,7 +179,7 @@ namespace NodaTime
             new Period(Years, Months, Weeks, Days, Hours, Minutes, Seconds, Milliseconds, Ticks, Nanoseconds);
 
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml(XmlReader reader)

--- a/src/NodaTime/Text/AnnualDatePatternParser.cs
+++ b/src/NodaTime/Text/AnnualDatePatternParser.cs
@@ -116,7 +116,7 @@ namespace NodaTime.Text
                 return ParseResult<AnnualDate>.ForValue(new AnnualDate(MonthOfYearNumeric, day));
             }
 
-            private ParseResult<AnnualDate> DetermineMonth(PatternFields usedFields, string text)
+            private ParseResult<AnnualDate>? DetermineMonth(PatternFields usedFields, string text)
             {
                 switch (usedFields & (PatternFields.MonthOfYearNumeric | PatternFields.MonthOfYearText))
                 {

--- a/src/NodaTime/Text/CompositePatternBuilder.cs
+++ b/src/NodaTime/Text/CompositePatternBuilder.cs
@@ -99,7 +99,7 @@ namespace NodaTime.Text
                         return result;
                     }
                 }
-                return ParseResult<T>.NoMatchingFormat(new ValueCursor(text));
+                return ParseResult<T>.NoMatchingFormat(new ValueCursor(text!));
             }
 
             public ParseResult<T> ParsePartial(ValueCursor cursor)

--- a/src/NodaTime/Text/CompositePatternBuilder.cs
+++ b/src/NodaTime/Text/CompositePatternBuilder.cs
@@ -75,13 +75,7 @@ namespace NodaTime.Text
             return (IPartialPattern<T>) Build();
         }
 
-
-        // TODO(nullable): See https://github.com/dotnet/roslyn/issues/31862
-#pragma warning disable CS8616 // Nullability of reference types in return type doesn't match implemented member.
-                              /// <inheritdoc />
         IEnumerator<IPattern<T>> IEnumerable<IPattern<T>>.GetEnumerator() => patterns.GetEnumerator();
-#pragma warning restore CS8616 // Nullability of reference types in return type doesn't match implemented member.
-                              /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator() => patterns.GetEnumerator();
 
         private sealed class CompositePattern : IPartialPattern<T>

--- a/src/NodaTime/Text/CompositePatternBuilder.cs
+++ b/src/NodaTime/Text/CompositePatternBuilder.cs
@@ -75,9 +75,13 @@ namespace NodaTime.Text
             return (IPartialPattern<T>) Build();
         }
 
-        /// <inheritdoc />
+
+        // TODO(nullable): See https://github.com/dotnet/roslyn/issues/31862
+#pragma warning disable CS8616 // Nullability of reference types in return type doesn't match implemented member.
+                              /// <inheritdoc />
         IEnumerator<IPattern<T>> IEnumerable<IPattern<T>>.GetEnumerator() => patterns.GetEnumerator();
-        /// <inheritdoc />
+#pragma warning restore CS8616 // Nullability of reference types in return type doesn't match implemented member.
+                              /// <inheritdoc />
         IEnumerator IEnumerable.GetEnumerator() => patterns.GetEnumerator();
 
         private sealed class CompositePattern : IPartialPattern<T>

--- a/src/NodaTime/Text/LocalDatePatternParser.cs
+++ b/src/NodaTime/Text/LocalDatePatternParser.cs
@@ -84,7 +84,7 @@ namespace NodaTime.Text
 
             internal CalendarSystem Calendar;
             internal int Year;
-            private Era Era;
+            private Era? Era;
             internal int YearOfEra;
             internal int MonthOfYearNumeric;
             internal int MonthOfYearText;
@@ -98,7 +98,7 @@ namespace NodaTime.Text
                 this.Calendar = templateValue.Calendar;
             }
 
-            internal ParseResult<TResult> ParseEra<TResult>(NodaFormatInfo formatInfo, ValueCursor cursor)
+            internal ParseResult<TResult>? ParseEra<TResult>(NodaFormatInfo formatInfo, ValueCursor cursor)
             {
                 var compareInfo = formatInfo.CompareInfo;
                 foreach (var era in Calendar.Eras)
@@ -122,7 +122,7 @@ namespace NodaTime.Text
                     return ParseResult<LocalDate>.ForValue(new LocalDate(Year, MonthOfYearNumeric, DayOfMonth, Calendar));
                 }
                 // This will set Year if necessary
-                ParseResult<LocalDate> failure = DetermineYear(usedFields, text);
+                ParseResult<LocalDate>? failure = DetermineYear(usedFields, text);
                 if (failure != null)
                 {
                     return failure;
@@ -174,7 +174,7 @@ namespace NodaTime.Text
             /// 
             /// Phew.
             /// </summary>
-            private ParseResult<LocalDate> DetermineYear(PatternFields usedFields, string text)
+            private ParseResult<LocalDate>? DetermineYear(PatternFields usedFields, string text)
             {
                 if (usedFields.HasAny(PatternFields.Year))
                 {
@@ -217,6 +217,8 @@ namespace NodaTime.Text
                     Era = TemplateValue.Era;
                 }
 
+                // After this point, Era is definitely non-null.
+
                 if (usedFields.HasAny(PatternFields.YearTwoDigits))
                 {
                     int century = TemplateValue.YearOfEra / 100;
@@ -227,16 +229,16 @@ namespace NodaTime.Text
                     YearOfEra += century * 100;
                 }
 
-                if (YearOfEra < Calendar.GetMinYearOfEra(Era) ||
-                    YearOfEra > Calendar.GetMaxYearOfEra(Era))
+                if (YearOfEra < Calendar.GetMinYearOfEra(Era!) ||
+                    YearOfEra > Calendar.GetMaxYearOfEra(Era!))
                 {
-                    return ParseResult<LocalDate>.YearOfEraOutOfRange(text, YearOfEra, Era, Calendar);
+                    return ParseResult<LocalDate>.YearOfEraOutOfRange(text, YearOfEra, Era!, Calendar);
                 }
-                Year = Calendar.GetAbsoluteYear(YearOfEra, Era);
+                Year = Calendar.GetAbsoluteYear(YearOfEra, Era!);
                 return null;
             }
 
-            private ParseResult<LocalDate> DetermineMonth(PatternFields usedFields, string text)
+            private ParseResult<LocalDate>? DetermineMonth(PatternFields usedFields, string text)
             {
                 switch (usedFields & (PatternFields.MonthOfYearNumeric | PatternFields.MonthOfYearText))
                 {

--- a/src/NodaTime/Text/LocalTimePatternParser.cs
+++ b/src/NodaTime/Text/LocalTimePatternParser.cs
@@ -128,7 +128,7 @@ namespace NodaTime.Text
                 {
                     AmPm = TemplateValue.Hour / 12;
                 }
-                ParseResult<LocalTime> failure = DetermineHour(usedFields, text, out int hour);
+                ParseResult<LocalTime>? failure = DetermineHour(usedFields, text, out int hour);
                 if (failure != null)
                 {
                     return failure;
@@ -139,7 +139,7 @@ namespace NodaTime.Text
                 return ParseResult<LocalTime>.ForValue(LocalTime.FromHourMinuteSecondNanosecond(hour, minutes, seconds, fraction));
             }
 
-            private ParseResult<LocalTime> DetermineHour(PatternFields usedFields, string text, out int hour)
+            private ParseResult<LocalTime>? DetermineHour(PatternFields usedFields, string text, out int hour)
             {
                 hour = 0;
                 if (usedFields.HasAny(PatternFields.Hours24))

--- a/src/NodaTime/Text/ParseResult.cs
+++ b/src/NodaTime/Text/ParseResult.cs
@@ -19,6 +19,7 @@ namespace NodaTime.Text
     [Immutable]
     public sealed class ParseResult<T>
     {
+        // Invariant: exactly one of value or exceptionProvider is null.
         private readonly T value;
         private readonly Func<Exception>? exceptionProvider;
         internal bool ContinueAfterErrorWithMultipleFormats { get; }
@@ -27,7 +28,7 @@ namespace NodaTime.Text
         {
             this.exceptionProvider = exceptionProvider;
             this.ContinueAfterErrorWithMultipleFormats = continueWithMultiple;
-            // TODO(nullable): Work out a better option for this.
+            // Satisfy the compiler around the invariant.
             value = default!;
         }
 

--- a/src/NodaTime/Text/ParseResult.cs
+++ b/src/NodaTime/Text/ParseResult.cs
@@ -20,13 +20,15 @@ namespace NodaTime.Text
     public sealed class ParseResult<T>
     {
         private readonly T value;
-        private readonly Func<Exception> exceptionProvider;
+        private readonly Func<Exception>? exceptionProvider;
         internal bool ContinueAfterErrorWithMultipleFormats { get; }
 
         private ParseResult(Func<Exception> exceptionProvider, bool continueWithMultiple)
         {
             this.exceptionProvider = exceptionProvider;
             this.ContinueAfterErrorWithMultipleFormats = continueWithMultiple;
+            // TODO(nullable): Work out a better option for this.
+            value = default!;
         }
 
         private ParseResult(T value)
@@ -118,7 +120,7 @@ namespace NodaTime.Text
             Preconditions.CheckNotNull(projection, nameof(projection));
             return Success
                 ? ParseResult<TTarget>.ForValue(projection(Value))
-                : new ParseResult<TTarget>(exceptionProvider, ContinueAfterErrorWithMultipleFormats);
+                : new ParseResult<TTarget>(exceptionProvider!, ContinueAfterErrorWithMultipleFormats);
         }
 
         /// <summary>
@@ -132,7 +134,7 @@ namespace NodaTime.Text
             {
                 throw new InvalidOperationException("ConvertError should not be called on a successful parse result");
             }
-            return new ParseResult<TTarget>(exceptionProvider, ContinueAfterErrorWithMultipleFormats);
+            return new ParseResult<TTarget>(exceptionProvider!, ContinueAfterErrorWithMultipleFormats);
         }
 
         #region Factory methods and readonly static fields

--- a/src/NodaTime/Text/Patterns/PatternBclSupport.cs
+++ b/src/NodaTime/Text/Patterns/PatternBclSupport.cs
@@ -22,7 +22,7 @@ namespace NodaTime.Text.Patterns
             this.defaultFormatPattern = defaultFormatPattern;
         }
 
-        internal string Format(T value, string? patternText, IFormatProvider formatProvider)
+        internal string Format(T value, string? patternText, IFormatProvider? formatProvider)
         {
             if (string.IsNullOrEmpty(patternText))
             {

--- a/src/NodaTime/Text/Patterns/PatternBclSupport.cs
+++ b/src/NodaTime/Text/Patterns/PatternBclSupport.cs
@@ -22,7 +22,7 @@ namespace NodaTime.Text.Patterns
             this.defaultFormatPattern = defaultFormatPattern;
         }
 
-        internal string Format(T value, string patternText, IFormatProvider formatProvider)
+        internal string Format(T value, string? patternText, IFormatProvider formatProvider)
         {
             if (string.IsNullOrEmpty(patternText))
             {

--- a/src/NodaTime/Text/TypeConverterBase.cs
+++ b/src/NodaTime/Text/TypeConverterBase.cs
@@ -35,7 +35,7 @@ namespace NodaTime.Text
         [Pure]
         public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value) =>
             // The ParseResult<>.Value property will throw appropriately if the operation was unsuccessful
-            value is string text ? pattern.Parse(text).Value : base.ConvertFrom(context, culture, value);
+            value is string text ? pattern.Parse(text).Value! : base.ConvertFrom(context, culture, value);
 
         /// <inheritdoc />
         [Pure]

--- a/src/NodaTime/Text/ValueCursor.cs
+++ b/src/NodaTime/Text/ValueCursor.cs
@@ -113,7 +113,7 @@ namespace NodaTime.Text
         /// <param name="result">The result integer value. The value of this is not guaranteed
         /// to be anything specific if the return value is non-null.</param>
         /// <returns>null if the digits were parsed, or the appropriate parse failure</returns>
-        internal ParseResult<T> ParseInt64<T>(out long result)
+        internal ParseResult<T>? ParseInt64<T>(out long result)
         {
             unchecked
             {

--- a/src/NodaTime/Text/ZonedDateTimePattern.cs
+++ b/src/NodaTime/Text/ZonedDateTimePattern.cs
@@ -89,7 +89,7 @@ namespace NodaTime.Text
         /// This may be null, in which case the pattern can only be used for formatting (not parsing).
         /// </summary>
         /// <value>The resolver which is used to map local date/times to zoned date/times.</value>
-        [CanBeNull] public ZoneLocalMappingResolver Resolver { get; }
+        [CanBeNull] public ZoneLocalMappingResolver? Resolver { get; }
 
         /// <summary>
         /// Gets the provider which is used to look up time zones when parsing a pattern
@@ -98,10 +98,10 @@ namespace NodaTime.Text
         /// </summary>
         /// <value>The provider which is used to look up time zones when parsing a pattern
         /// which contains a time zone identifier.</value>
-        [CanBeNull] public IDateTimeZoneProvider ZoneProvider { get; }
+        [CanBeNull] public IDateTimeZoneProvider? ZoneProvider { get; }
 
         private ZonedDateTimePattern(string patternText, NodaFormatInfo formatInfo, ZonedDateTime templateValue,
-            ZoneLocalMappingResolver resolver, IDateTimeZoneProvider zoneProvider, IPattern<ZonedDateTime> pattern)
+            ZoneLocalMappingResolver? resolver, IDateTimeZoneProvider? zoneProvider, IPattern<ZonedDateTime> pattern)
         {
             this.PatternText = patternText;
             this.FormatInfo = formatInfo;
@@ -149,7 +149,7 @@ namespace NodaTime.Text
         /// <returns>A pattern for parsing and formatting zoned date/times.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
         private static ZonedDateTimePattern Create([NotNull] string patternText, [NotNull] NodaFormatInfo formatInfo,
-            [NotNull] ZoneLocalMappingResolver resolver, IDateTimeZoneProvider zoneProvider, ZonedDateTime templateValue)
+            [CanBeNull] ZoneLocalMappingResolver? resolver, IDateTimeZoneProvider? zoneProvider, ZonedDateTime templateValue)
         {
             Preconditions.CheckNotNull(patternText, nameof(patternText));
             Preconditions.CheckNotNull(formatInfo, nameof(formatInfo));
@@ -173,7 +173,7 @@ namespace NodaTime.Text
         /// <returns>A pattern for parsing and formatting zoned date/times.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
         [NotNull] public static ZonedDateTimePattern Create([NotNull] string patternText, [NotNull] CultureInfo cultureInfo,
-            [CanBeNull] ZoneLocalMappingResolver resolver, [CanBeNull] IDateTimeZoneProvider zoneProvider, ZonedDateTime templateValue) =>
+            [CanBeNull] ZoneLocalMappingResolver? resolver, [CanBeNull] IDateTimeZoneProvider? zoneProvider, ZonedDateTime templateValue) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), resolver, zoneProvider, templateValue);
 
         /// <summary>
@@ -188,7 +188,7 @@ namespace NodaTime.Text
         /// <param name="patternText">Pattern text to create the pattern for</param>
         /// <param name="zoneProvider">Time zone provider, used when parsing text which contains a time zone identifier.</param>
         /// <returns>A pattern for parsing and formatting zoned date/times.</returns>
-        [NotNull] public static ZonedDateTimePattern CreateWithInvariantCulture([NotNull] string patternText, [CanBeNull] IDateTimeZoneProvider zoneProvider) =>
+        [NotNull] public static ZonedDateTimePattern CreateWithInvariantCulture([NotNull] string patternText, [CanBeNull] IDateTimeZoneProvider? zoneProvider) =>
             Create(patternText, NodaFormatInfo.InvariantInfo, Resolvers.StrictResolver, zoneProvider, DefaultTemplateValue);
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace NodaTime.Text
         /// <param name="patternText">Pattern text to create the pattern for</param>
         /// <param name="zoneProvider">Time zone provider, used when parsing text which contains a time zone identifier.</param>
         /// <returns>A pattern for parsing and formatting zoned date/times.</returns>
-        [NotNull] public static ZonedDateTimePattern CreateWithCurrentCulture([NotNull] string patternText, [CanBeNull] IDateTimeZoneProvider zoneProvider) =>
+        [NotNull] public static ZonedDateTimePattern CreateWithCurrentCulture([NotNull] string patternText, [CanBeNull] IDateTimeZoneProvider? zoneProvider) =>
             Create(patternText, NodaFormatInfo.CurrentInfo, Resolvers.StrictResolver, zoneProvider, DefaultTemplateValue);
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="resolver">The new local mapping resolver to use.</param>
         /// <returns>A new pattern with the given resolver.</returns>
-        [NotNull] public ZonedDateTimePattern WithResolver([CanBeNull] ZoneLocalMappingResolver resolver) =>
+        [NotNull] public ZonedDateTimePattern WithResolver([CanBeNull] ZoneLocalMappingResolver? resolver) =>
             Resolver == resolver ? this : Create(PatternText, FormatInfo, resolver, ZoneProvider, TemplateValue);
 
         /// <summary>
@@ -253,7 +253,7 @@ namespace NodaTime.Text
         /// </remarks>
         /// <param name="newZoneProvider">The new time zone provider to use.</param>
         /// <returns>A new pattern with the given time zone provider.</returns>
-        [NotNull] public ZonedDateTimePattern WithZoneProvider([CanBeNull] IDateTimeZoneProvider newZoneProvider) =>
+        [NotNull] public ZonedDateTimePattern WithZoneProvider([CanBeNull] IDateTimeZoneProvider? newZoneProvider) =>
             newZoneProvider == ZoneProvider ? this : Create(PatternText, FormatInfo, Resolver, newZoneProvider, TemplateValue);
 
         /// <summary>

--- a/src/NodaTime/TimeZones/BclDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZone.cs
@@ -393,7 +393,7 @@ namespace NodaTime.TimeZones
         /// <see cref="TimeZoneInfo.Local"/>.</returns>
         [NotNull] public static BclDateTimeZone ForSystemDefault()
         {
-            TimeZoneInfo local = TimeZoneInfoInterceptor.Local;
+            TimeZoneInfo? local = TimeZoneInfoInterceptor.Local;
             if (local is null)
             {
                 throw new InvalidOperationException("No system default time zone is available");

--- a/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
@@ -122,6 +122,6 @@ namespace NodaTime.TimeZones
         // We'll let the DateTimeZoneCache do that for us. (We get a DateTimeZoneNotFoundException either way.)
 
         /// <inheritdoc />
-        [NotNull] public string GetSystemDefaultId() => TimeZoneInfoInterceptor.Local?.Id;
+        [NotNull] public string? GetSystemDefaultId() => TimeZoneInfoInterceptor.Local?.Id;
     }
 }

--- a/src/NodaTime/TimeZones/CachingZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/CachingZoneIntervalMap.cs
@@ -100,7 +100,7 @@ namespace NodaTime.TimeZones
 
                 internal int Period { get; }
 
-                internal HashCacheNode Previous { get; }
+                internal HashCacheNode? Previous { get; }
 
                 /// <summary>
                 /// Creates a hash table node with all the information for this period.
@@ -138,7 +138,7 @@ namespace NodaTime.TimeZones
                 /// <param name="interval">The zone interval.</param>
                 /// <param name="period"></param>
                 /// <param name="previous">The previous <see cref="HashCacheNode"/> node.</param>
-                private HashCacheNode(ZoneInterval interval, int period, HashCacheNode previous)
+                private HashCacheNode(ZoneInterval interval, int period, HashCacheNode? previous)
                 {
                     this.Period = period;
                     this.Interval = interval;

--- a/src/NodaTime/TimeZones/Cldr/MapZone.cs
+++ b/src/NodaTime/TimeZones/Cldr/MapZone.cs
@@ -18,7 +18,7 @@ namespace NodaTime.TimeZones.Cldr
     /// </summary>
     /// <threadsafety>This type is immutable reference type. See the thread safety section of the user guide for more information.</threadsafety>
     [Immutable]
-    public sealed class MapZone : IEquatable<MapZone>
+    public sealed class MapZone : IEquatable<MapZone?>
     {
         /// <summary>
         /// Identifier used for the primary territory of each Windows time zone. A zone mapping with
@@ -126,7 +126,7 @@ namespace NodaTime.TimeZones.Cldr
         }
 
         /// <inheritdoc />
-        public bool Equals(MapZone other) =>
+        public bool Equals(MapZone? other) =>
             other != null &&
             WindowsId == other.WindowsId &&
             Territory == other.Territory &&
@@ -144,7 +144,7 @@ namespace NodaTime.TimeZones.Cldr
         }
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => Equals(obj as MapZone);
+        public override bool Equals(object? obj) => Equals(obj as MapZone);
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/NodaTime/TimeZones/DateTimeZoneCache.cs
+++ b/src/NodaTime/TimeZones/DateTimeZoneCache.cs
@@ -28,7 +28,7 @@ namespace NodaTime.TimeZones
     public sealed class DateTimeZoneCache : IDateTimeZoneProvider
     {
         private readonly IDateTimeZoneSource source;
-        private readonly ConcurrentDictionary<string, DateTimeZone> timeZoneMap = new ConcurrentDictionary<string, DateTimeZone>();
+        private readonly ConcurrentDictionary<string, DateTimeZone?> timeZoneMap = new ConcurrentDictionary<string, DateTimeZone?>();
 
         /// <summary>
         /// Gets the version ID of this provider. This is simply the <see cref="IDateTimeZoneSource.VersionId"/> returned by
@@ -81,7 +81,7 @@ namespace NodaTime.TimeZones
         [NotNull]
         public DateTimeZone GetSystemDefault()
         {
-            string id = source.GetSystemDefaultId();
+            string? id = source.GetSystemDefaultId();
             if (id is null)
             {
                 throw new DateTimeZoneNotFoundException($"System default time zone is unknown to source {VersionId}");
@@ -90,15 +90,15 @@ namespace NodaTime.TimeZones
         }
 
         /// <inheritdoc />
-        [CanBeNull] public DateTimeZone GetZoneOrNull([NotNull] string id)
+        [CanBeNull] public DateTimeZone? GetZoneOrNull([NotNull] string id)
         {
             Preconditions.CheckNotNull(id, nameof(id));
             return GetZoneFromSourceOrNull(id) ?? FixedDateTimeZone.GetFixedZoneOrNull(id);
         }
 
-        private DateTimeZone GetZoneFromSourceOrNull(string id)
+        private DateTimeZone? GetZoneFromSourceOrNull(string id)
         {
-            if (!timeZoneMap.TryGetValue(id, out DateTimeZone zone))
+            if (!timeZoneMap.TryGetValue(id, out DateTimeZone? zone))
             {
                 return null;
             }

--- a/src/NodaTime/TimeZones/FixedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/FixedDateTimeZone.cs
@@ -13,8 +13,6 @@ namespace NodaTime.TimeZones
     // Implementation note: this implemented IEquatable<FixedDateTimeZone> for the sake of fitting in with our test infrastructure
     // more than anything else...
 
-    // TODO(nullable): Validate that implementing IEquatable<T?> really is the most appropriate approach
-
     /// <summary>
     /// Basic <see cref="DateTimeZone" /> implementation that has a fixed name key and offset i.e.
     /// no daylight savings.

--- a/src/NodaTime/TimeZones/FixedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/FixedDateTimeZone.cs
@@ -13,12 +13,14 @@ namespace NodaTime.TimeZones
     // Implementation note: this implemented IEquatable<FixedDateTimeZone> for the sake of fitting in with our test infrastructure
     // more than anything else...
 
+    // TODO(nullable): Validate that implementing IEquatable<T?> really is the most appropriate approach
+
     /// <summary>
     /// Basic <see cref="DateTimeZone" /> implementation that has a fixed name key and offset i.e.
     /// no daylight savings.
     /// </summary>
     /// <threadsafety>This type is immutable reference type. See the thread safety section of the user guide for more information.</threadsafety>
-    internal sealed class FixedDateTimeZone : DateTimeZone, IEquatable<FixedDateTimeZone>
+    internal sealed class FixedDateTimeZone : DateTimeZone, IEquatable<FixedDateTimeZone?>
     {
         private readonly ZoneInterval interval;
 
@@ -73,7 +75,7 @@ namespace NodaTime.TimeZones
         /// </summary>
         /// <param name="id">ID </param>
         /// <returns>The parsed time zone, or null if the ID doesn't match.</returns>
-        internal static DateTimeZone GetFixedZoneOrNull(string id)
+        internal static DateTimeZone? GetFixedZoneOrNull(string id)
         {
             if (!id.StartsWith(UtcId))
             {
@@ -155,9 +157,9 @@ namespace NodaTime.TimeZones
         /// <param name="obj">Another object to compare to.</param> 
         /// <filterpriority>2</filterpriority>
         /// <returns>True if the specified value is a <see cref="FixedDateTimeZone"/> with the same name, ID and offset; otherwise, false.</returns>
-        public override bool Equals(object obj) => Equals(obj as FixedDateTimeZone);
+        public override bool Equals(object? obj) => Equals(obj as FixedDateTimeZone);
 
-        public bool Equals(FixedDateTimeZone other) =>
+        public bool Equals(FixedDateTimeZone? other) =>
             other != null &&
             Offset == other.Offset &&
             Id == other.Id &&

--- a/src/NodaTime/TimeZones/IDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/IDateTimeZoneSource.cs
@@ -102,6 +102,6 @@ namespace NodaTime.TimeZones
         /// The ID for the system default time zone for this source,
         /// or null if the system default time zone has no mapping in this source.
         /// </returns>
-        [CanBeNull] string GetSystemDefaultId();
+        [CanBeNull] string? GetSystemDefaultId();
     }
 }

--- a/src/NodaTime/TimeZones/IO/DateTimeZoneReader.cs
+++ b/src/NodaTime/TimeZones/IO/DateTimeZoneReader.cs
@@ -21,14 +21,19 @@ namespace NodaTime.TimeZones.IO
         /// account of bufferedByte as well.
         /// </summary>
         private readonly Stream input;
-        private readonly IList<string> stringPool;
+
+        /// <summary>
+        /// String pool to use, or null if no string pool is in use.
+        /// </summary>
+        private readonly IList<string>? stringPool;
+
         /// <summary>
         /// Sometimes we need to buffer a byte in memory, e.g. to check if there is any
         /// more data. Anything reading directly from the stream should check here first.
         /// </summary>
         private byte? bufferedByte; 
 
-        internal DateTimeZoneReader(Stream input, IList<string> stringPool)
+        internal DateTimeZoneReader(Stream input, IList<string>? stringPool)
         {
             this.input = input;
             this.stringPool = stringPool;

--- a/src/NodaTime/TimeZones/IO/DateTimeZoneWriter.cs
+++ b/src/NodaTime/TimeZones/IO/DateTimeZoneWriter.cs
@@ -48,14 +48,14 @@ namespace NodaTime.TimeZones.IO
         }
 
         private readonly Stream output;
-        private readonly IList<string> stringPool; 
+        private readonly IList<string>? stringPool; 
 
         /// <summary>
         /// Constructs a DateTimeZoneWriter.
         /// </summary>
         /// <param name="output">Where to send the serialized output.</param>
         /// <param name="stringPool">String pool to add strings to, or null for no pool</param>
-        internal DateTimeZoneWriter(Stream output, IList<string> stringPool)
+        internal DateTimeZoneWriter(Stream output, IList<string>? stringPool)
         {
             this.output = output;
             this.stringPool = stringPool;

--- a/src/NodaTime/TimeZones/IO/TzdbStreamData.cs
+++ b/src/NodaTime/TimeZones/IO/TzdbStreamData.cs
@@ -54,13 +54,13 @@ namespace NodaTime.TimeZones.IO
         /// Returns the zone locations for the source, or null if no location data is available.
         /// This needn't be a read-only collection; it won't be exposed directly.
         /// </summary>
-        public IList<TzdbZoneLocation> ZoneLocations { get; }
+        public IList<TzdbZoneLocation>? ZoneLocations { get; }
 
         /// <summary>
         /// Returns the "zone 1970" locations for the source, or null if no such location data is available.
         /// This needn't be a read-only collection; it won't be exposed directly.
         /// </summary>
-        public IList<TzdbZone1970Location> Zone1970Locations { get; }
+        public IList<TzdbZone1970Location>? Zone1970Locations { get; }
 
         private TzdbStreamData(Builder builder)
         {
@@ -106,7 +106,7 @@ namespace NodaTime.TimeZones.IO
         }
 
         // Like Preconditions.CheckNotNull, but specifically for incomplete data.
-        private static T CheckNotNull<T>(T input, string name) where T : class
+        private static T CheckNotNull<T>(T? input, string name) where T : class
         {
             if (input is null)
             {
@@ -140,12 +140,12 @@ namespace NodaTime.TimeZones.IO
         /// </summary>
         private class Builder
         {
-            internal IList<string> stringPool;
-            internal string tzdbVersion;
-            internal IDictionary<string, string> tzdbIdMap;
-            internal IList<TzdbZoneLocation> zoneLocations = null;
-            internal IList<TzdbZone1970Location> zone1970Locations = null;
-            internal WindowsZones windowsMapping;
+            internal IList<string>? stringPool;
+            internal string? tzdbVersion;
+            internal IDictionary<string, string>? tzdbIdMap;
+            internal IList<TzdbZoneLocation>? zoneLocations = null;
+            internal IList<TzdbZone1970Location>? zone1970Locations = null;
+            internal WindowsZones? windowsMapping;
             internal readonly IDictionary<string, TzdbStreamField> zoneFields = new Dictionary<string, TzdbStreamField>();
 
             internal void HandleStringPoolField(TzdbStreamField field)
@@ -232,7 +232,7 @@ namespace NodaTime.TimeZones.IO
                 }
             }
 
-            private void CheckSingleField(TzdbStreamField field, object expectedNullField)
+            private void CheckSingleField(TzdbStreamField field, object? expectedNullField)
             {
                 if (expectedNullField != null)
                 {

--- a/src/NodaTime/TimeZones/IO/TzdbStreamField.cs
+++ b/src/NodaTime/TimeZones/IO/TzdbStreamField.cs
@@ -28,7 +28,7 @@ namespace NodaTime.TimeZones.IO
         /// </summary>
         internal Stream CreateStream() => new MemoryStream(data, false);
 
-        internal T ExtractSingleValue<T>(Func<DateTimeZoneReader, T> readerFunction, IList<string> stringPool)
+        internal T ExtractSingleValue<T>(Func<DateTimeZoneReader, T> readerFunction, IList<string>? stringPool)
         {
             using (var stream = CreateStream())
             {

--- a/src/NodaTime/TimeZones/PartialZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/PartialZoneIntervalMap.cs
@@ -99,7 +99,7 @@ namespace NodaTime.TimeZones
         internal static IZoneIntervalMap ConvertToFullMap(IEnumerable<PartialZoneIntervalMap> maps)
         {
             var coalescedMaps = new List<PartialZoneIntervalMap>();
-            PartialZoneIntervalMap current = null;
+            PartialZoneIntervalMap? current = null;
             foreach (var next in maps)
             {
                 if (current is null)
@@ -160,10 +160,10 @@ namespace NodaTime.TimeZones
                 }
             }
             Preconditions.DebugCheckArgument(current != null, nameof(maps), "Collection of maps must not be empty");
-            Preconditions.DebugCheckArgument(current.End == Instant.AfterMaxValue, nameof(maps), "Collection of maps must end at the end of time");
+            Preconditions.DebugCheckArgument(current!.End == Instant.AfterMaxValue, nameof(maps), "Collection of maps must end at the end of time");
 
             // We're left with a map extending to the end of time, which couldn't have been coalesced with its predecessors.
-            coalescedMaps.Add(current);
+            coalescedMaps.Add(current!);
             return new CombinedPartialZoneIntervalMap(coalescedMaps.ToArray());
         }
 

--- a/src/NodaTime/TimeZones/PrecalculatedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/PrecalculatedDateTimeZone.cs
@@ -19,12 +19,12 @@ namespace NodaTime.TimeZones
     internal sealed class PrecalculatedDateTimeZone : DateTimeZone
     {
         private readonly ZoneInterval[] periods;
-        private readonly IZoneIntervalMapWithMinMax tailZone;
+        private readonly IZoneIntervalMapWithMinMax? tailZone;
         /// <summary>
         /// The first instant covered by the tail zone, or Instant.AfterMaxValue if there's no tail zone.
         /// </summary>
         private readonly Instant tailZoneStart;
-        private readonly ZoneInterval firstTailZoneInterval;
+        private readonly ZoneInterval? firstTailZoneInterval;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PrecalculatedDateTimeZone"/> class.
@@ -34,7 +34,7 @@ namespace NodaTime.TimeZones
         /// <param name="tailZone">The tail zone - which can be any IZoneIntervalMap for normal operation,
         /// but must be a StandardDaylightAlternatingMap if the result is to be serialized.</param>
         [VisibleForTesting]
-        internal PrecalculatedDateTimeZone([NotNull] string id, [NotNull] ZoneInterval[] intervals, IZoneIntervalMapWithMinMax tailZone)
+        internal PrecalculatedDateTimeZone([NotNull] string id, [NotNull] ZoneInterval[] intervals, IZoneIntervalMapWithMinMax? tailZone)
             : base(id, false,
                    ComputeOffset(intervals, tailZone, Offset.Min),
                    ComputeOffset(intervals, tailZone, Offset.Max))
@@ -56,7 +56,7 @@ namespace NodaTime.TimeZones
         /// </summary>
         /// <remarks>This is only called from the constructors, but is internal to make it easier to test.</remarks>
         /// <exception cref="ArgumentException">The periods specified are invalid.</exception>
-        internal static void ValidatePeriods(ZoneInterval[] periods, IZoneIntervalMap tailZone)
+        internal static void ValidatePeriods(ZoneInterval[] periods, IZoneIntervalMap? tailZone)
         {
             Preconditions.CheckArgument(periods.Length > 0, nameof(periods), "No periods specified in precalculated time zone");
             Preconditions.CheckArgument(!periods[0].HasStart, nameof(periods), "Periods in precalculated time zone must start with the beginning of time");
@@ -81,7 +81,7 @@ namespace NodaTime.TimeZones
                 // Clamp the tail zone interval to start at the end of our final period, if necessary, so that the
                 // join is seamless.
                 ZoneInterval intervalFromTailZone = tailZone.GetZoneInterval(instant);
-                return intervalFromTailZone.RawStart < tailZoneStart ? firstTailZoneInterval : intervalFromTailZone;
+                return intervalFromTailZone.RawStart < tailZoneStart ? firstTailZoneInterval! : intervalFromTailZone;
             }
             
             int lower = 0; // Inclusive
@@ -180,7 +180,7 @@ namespace NodaTime.TimeZones
         // Reasonably simple way of computing the maximum/minimum offset
         // from either periods or transitions, with or without a tail zone.
         private static Offset ComputeOffset([NotNull] ZoneInterval[] intervals,
-            IZoneIntervalMapWithMinMax tailZone,
+            IZoneIntervalMapWithMinMax? tailZone,
             OffsetAggregator aggregator)
         {
             Preconditions.CheckNotNull(intervals, nameof(intervals));

--- a/src/NodaTime/TimeZones/StandardDaylightAlternatingMap.cs
+++ b/src/NodaTime/TimeZones/StandardDaylightAlternatingMap.cs
@@ -31,7 +31,7 @@ namespace NodaTime.TimeZones
     /// only be used as part of a zone which will only ask it for values within the right
     /// portion of the timeline.
     /// </remarks>
-    internal sealed class StandardDaylightAlternatingMap : IEquatable<StandardDaylightAlternatingMap>, IZoneIntervalMapWithMinMax
+    internal sealed class StandardDaylightAlternatingMap : IEquatable<StandardDaylightAlternatingMap?>, IZoneIntervalMapWithMinMax
     {
         private readonly Offset standardOffset;
         private readonly ZoneRecurrence standardRecurrence;
@@ -71,9 +71,9 @@ namespace NodaTime.TimeZones
             standardRecurrence = standard;
         }
 
-        public override bool Equals(object other) => Equals(other as StandardDaylightAlternatingMap);
+        public override bool Equals(object? other) => Equals(other as StandardDaylightAlternatingMap);
 
-        public bool Equals(StandardDaylightAlternatingMap other) =>
+        public bool Equals(StandardDaylightAlternatingMap? other) =>
             other != null &&
             standardOffset == other.standardOffset && 
             dstRecurrence.Equals(other.dstRecurrence) &&

--- a/src/NodaTime/TimeZones/TimeZoneInfoInterceptor.cs
+++ b/src/NodaTime/TimeZones/TimeZoneInfoInterceptor.cs
@@ -21,13 +21,13 @@ namespace NodaTime.TimeZones
         /// </summary>
         internal static ITimeZoneInfoShim Shim { get; set; } = new BclShim();
 
-        internal static TimeZoneInfo Local => Shim.Local;
+        internal static TimeZoneInfo? Local => Shim.Local;
         internal static TimeZoneInfo FindSystemTimeZoneById(string id) => Shim.FindSystemTimeZoneById(id);
         internal static ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones() => Shim.GetSystemTimeZones();
 
         internal interface ITimeZoneInfoShim
         {
-            TimeZoneInfo Local { get; }
+            TimeZoneInfo? Local { get; }
             TimeZoneInfo FindSystemTimeZoneById(string id);
             ReadOnlyCollection<TimeZoneInfo> GetSystemTimeZones();
         }
@@ -37,7 +37,7 @@ namespace NodaTime.TimeZones
         /// </summary>
         private class BclShim : ITimeZoneInfoShim
         {
-            public TimeZoneInfo Local => TimeZoneInfo.Local;
+            public TimeZoneInfo? Local => TimeZoneInfo.Local;
 
             public TimeZoneInfo FindSystemTimeZoneById(string id) => TimeZoneInfo.FindSystemTimeZoneById(id);
 

--- a/src/NodaTime/TimeZones/TzdbDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/TzdbDateTimeZoneSource.cs
@@ -99,7 +99,7 @@ namespace NodaTime.TimeZones
         /// has been validated).
         /// </remarks>
         /// <value>A read-only list of zone locations known to this source.</value>
-        [CanBeNull] public IList<TzdbZoneLocation> ZoneLocations { get; }
+        [CanBeNull] public IList<TzdbZoneLocation>? ZoneLocations { get; }
 
         /// <summary>
         /// Gets a read-only list of "zone 1970" locations known to this source, or null if the original source data
@@ -125,7 +125,7 @@ namespace NodaTime.TimeZones
         /// </p>
         /// </remarks>
         /// <value>A read-only list of zone locations known to this source.</value>
-        [CanBeNull] public IList<TzdbZone1970Location> Zone1970Locations { get; }
+        [CanBeNull] public IList<TzdbZone1970Location>? Zone1970Locations { get; }
 
         /// <inheritdoc />
         /// <remarks>
@@ -196,10 +196,10 @@ namespace NodaTime.TimeZones
         [NotNull] public IEnumerable<string> GetIds() => CanonicalIdMap.Keys;
 
         /// <inheritdoc />
-        [CanBeNull] public string GetSystemDefaultId() => MapTimeZoneInfoId(TimeZoneInfoInterceptor.Local);
+        [CanBeNull] public string? GetSystemDefaultId() => MapTimeZoneInfoId(TimeZoneInfoInterceptor.Local);
 
         [VisibleForTesting, CanBeNull]
-        internal string MapTimeZoneInfoId([CanBeNull] TimeZoneInfo timeZone)
+        internal string? MapTimeZoneInfoId([CanBeNull] TimeZoneInfo? timeZone)
         {
             // Unusual, but can happen in some Mono installations.
             if (timeZone is null)
@@ -222,10 +222,10 @@ namespace NodaTime.TimeZones
             return GuessZoneIdByTransitions(timeZone);
         }
 
-        private readonly ConcurrentDictionary<string, string> guesses = new ConcurrentDictionary<string, string>();
+        private readonly ConcurrentDictionary<string, string?> guesses = new ConcurrentDictionary<string, string?>();
 
         // Cache around GuessZoneIdByTransitionsUncached
-        private string GuessZoneIdByTransitions(TimeZoneInfo zone)
+        private string? GuessZoneIdByTransitions(TimeZoneInfo zone)
         {
             // FIXME: Stop using StandardName! (We have Id now...)
             return guesses.GetOrAdd(zone.StandardName, _ =>
@@ -253,7 +253,7 @@ namespace NodaTime.TimeZones
         /// <param name="zone">Zone to resolve in a best-effort fashion.</param>
         /// <param name="candidates">All the Noda Time zones to consider - normally a list 
         /// obtained from this source.</param>
-        internal string GuessZoneIdByTransitionsUncached(TimeZoneInfo zone, List<DateTimeZone> candidates)
+        internal string? GuessZoneIdByTransitionsUncached(TimeZoneInfo zone, List<DateTimeZone> candidates)
         {
             // See https://github.com/nodatime/nodatime/issues/686 for performance observations.
             // Very rare use of the system clock! Windows time zone updates sometimes sacrifice past
@@ -270,7 +270,7 @@ namespace NodaTime.TimeZones
             // - so if we get to that number (or whatever our "best" so far is)
             // we know we can stop for any particular zone.
             int lowestFailureScore = (instants.Count * 30) / 100;
-            DateTimeZone bestZone = null;
+            DateTimeZone? bestZone = null;
             foreach (var candidate in candidates)
             {
                 int failureScore = 0;

--- a/src/NodaTime/TimeZones/TzdbZone1970Location.cs
+++ b/src/NodaTime/TimeZones/TzdbZone1970Location.cs
@@ -144,12 +144,14 @@ namespace NodaTime.TimeZones
             }
         }
 
+        // TODO(nullable): Validate that implementing IEquatable<T?> really is the most appropriate approach
+
         /// <summary>
         /// A country represented within an entry in the "zone1970.tab" file, with the English name
         /// mapped from the "iso3166.tab" file.
         /// </summary>
         [Immutable]
-        public sealed class Country : IEquatable<Country>
+        public sealed class Country : IEquatable<Country?>
         {
             /// <summary>
             /// Gets the English name of the country.
@@ -181,14 +183,14 @@ namespace NodaTime.TimeZones
             /// </summary>
             /// <param name="other">The country to compare with this one.</param>
             /// <returns><c>true</c> if the given country has the same name and code as this one; <c>false</c> otherwise.</returns>
-            public bool Equals(Country other) => other != null && other.Code == Code && other.Name == Name;
+            public bool Equals(Country? other) => other != null && other.Code == Code && other.Name == Name;
 
             /// <summary>
             /// Compares countries for equality, by name and code.
             /// </summary>
             /// <param name="obj">The object to compare this one with.</param>
             /// <returns><c>true</c> if the given object is a country with the same name and code as this one; <c>false</c> otherwise.</returns>
-            public override bool Equals(object obj) => Equals(obj as Country);
+            public override bool Equals(object? obj) => Equals(obj as Country);
 
             /// <summary>
             /// Returns a hash code for this country.

--- a/src/NodaTime/TimeZones/TzdbZone1970Location.cs
+++ b/src/NodaTime/TimeZones/TzdbZone1970Location.cs
@@ -144,8 +144,6 @@ namespace NodaTime.TimeZones
             }
         }
 
-        // TODO(nullable): Validate that implementing IEquatable<T?> really is the most appropriate approach
-
         /// <summary>
         /// A country represented within an entry in the "zone1970.tab" file, with the English name
         /// mapped from the "iso3166.tab" file.

--- a/src/NodaTime/TimeZones/ZoneEqualityComparer.cs
+++ b/src/NodaTime/TimeZones/ZoneEqualityComparer.cs
@@ -22,7 +22,7 @@ namespace NodaTime.TimeZones
     /// <see cref="WithOptions"/> method.
     /// </remarks>
     [Immutable]
-    public sealed class ZoneEqualityComparer : IEqualityComparer<DateTimeZone>
+    public sealed class ZoneEqualityComparer : IEqualityComparer<DateTimeZone?>
     {
         /// <summary>
         /// Options to use when comparing time zones for equality. Each option makes the comparison more restrictive.
@@ -180,7 +180,7 @@ namespace NodaTime.TimeZones
         /// <param name="x">The first <see cref="DateTimeZone"/> to compare.</param>
         /// <param name="y">The second <see cref="DateTimeZone"/> to compare.</param>
         /// <returns><c>true</c> if the specified time zones are equal under the options and interval of this comparer; otherwise, <c>false</c>.</returns>
-        public bool Equals(DateTimeZone x, DateTimeZone y)
+        public bool Equals(DateTimeZone? x, DateTimeZone? y)
         {
             if (ReferenceEquals(x, y))
             {
@@ -206,13 +206,13 @@ namespace NodaTime.TimeZones
         /// </remarks>
         /// <param name="obj">The time zone to compute a hash code for.</param>
         /// <returns>A hash code for the specified object.</returns>
-        public int GetHashCode([NotNull] DateTimeZone obj)
+        public int GetHashCode([NotNull] DateTimeZone? obj)
         {
-            Preconditions.CheckNotNull(obj, nameof(obj));
+            Preconditions.CheckNotNull(obj!, nameof(obj));
             unchecked
             {
                 int hash = 19;
-                foreach (var zoneInterval in GetIntervals(obj))
+                foreach (var zoneInterval in GetIntervals(obj!))
                 {
                     hash = hash * 31 + zoneIntervalComparer.GetHashCode(zoneInterval);
                 }

--- a/src/NodaTime/TimeZones/ZoneEqualityComparer.cs
+++ b/src/NodaTime/TimeZones/ZoneEqualityComparer.cs
@@ -239,7 +239,7 @@ namespace NodaTime.TimeZones
 
             internal IEnumerable<ZoneInterval> CoalesceIntervals(IEnumerable<ZoneInterval> zoneIntervals)
             {
-                ZoneInterval current = null;
+                ZoneInterval? current = null;
                 foreach (var zoneInterval in zoneIntervals)
                 {
                     if (current is null)

--- a/src/NodaTime/TimeZones/ZoneInterval.cs
+++ b/src/NodaTime/TimeZones/ZoneInterval.cs
@@ -15,7 +15,7 @@ namespace NodaTime.TimeZones
     /// </summary>
     /// <threadsafety>This type is an immutable reference type. See the thread safety section of the user guide for more information.</threadsafety>
     [Immutable]
-    public sealed class ZoneInterval : IEquatable<ZoneInterval>
+    public sealed class ZoneInterval : IEquatable<ZoneInterval?>
     {
 
         /// <summary>
@@ -262,7 +262,7 @@ namespace NodaTime.TimeZones
         /// <param name="other">An object to compare with this object.
         /// </param>
         [DebuggerStepThrough]
-        public bool Equals(ZoneInterval other)
+        public bool Equals(ZoneInterval? other)
         {
             if (other is null)
             {

--- a/src/NodaTime/TimeZones/ZoneRecurrence.cs
+++ b/src/NodaTime/TimeZones/ZoneRecurrence.cs
@@ -25,7 +25,7 @@ namespace NodaTime.TimeZones
     /// Immutable, thread safe.
     /// </para>
     /// </remarks>
-    internal sealed class ZoneRecurrence : IEquatable<ZoneRecurrence>
+    internal sealed class ZoneRecurrence : IEquatable<ZoneRecurrence?>
     {
         private readonly LocalInstant maxLocalInstant;
         private readonly LocalInstant minLocalInstant;
@@ -86,7 +86,7 @@ namespace NodaTime.TimeZones
         /// true if the current object is equal to the <paramref name="other"/> parameter;
         /// otherwise, false.
         /// </returns>
-        public bool Equals(ZoneRecurrence other)
+        public bool Equals(ZoneRecurrence? other)
         {
             if (other is null)
             {
@@ -315,7 +315,7 @@ namespace NodaTime.TimeZones
         /// <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance;
         /// otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj) => Equals(obj as ZoneRecurrence);
+        public override bool Equals(object? obj) => Equals(obj as ZoneRecurrence);
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/NodaTime/TimeZones/ZoneYearOffset.cs
+++ b/src/NodaTime/TimeZones/ZoneYearOffset.cs
@@ -36,7 +36,7 @@ namespace NodaTime.TimeZones
     /// Immutable, thread safe
     /// </para>
     /// </remarks>
-    internal sealed class ZoneYearOffset : IEquatable<ZoneYearOffset>
+    internal sealed class ZoneYearOffset : IEquatable<ZoneYearOffset?>
     {
         /// <summary>
         /// An offset that specifies the beginning of the year.
@@ -150,7 +150,7 @@ namespace NodaTime.TimeZones
         /// <returns>
         /// true if the current object is equal to the <paramref name="other"/> parameter; otherwise, false.
         /// </returns>
-        public bool Equals(ZoneYearOffset other)
+        public bool Equals(ZoneYearOffset? other)
         {
             if (other is null)
             {
@@ -294,7 +294,7 @@ namespace NodaTime.TimeZones
         /// <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance;
         /// otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj) => Equals(obj as ZoneYearOffset);
+        public override bool Equals(object? obj) => Equals(obj as ZoneYearOffset);
 
         /// <summary>
         /// Returns a hash code for this instance.

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -542,7 +542,7 @@ namespace NodaTime
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>
-        public string ToString(string patternText, IFormatProvider formatProvider) =>
+        public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             ZonedDateTimePattern.Patterns.BclSupport.Format(this, patternText, formatProvider);
         #endregion Formatting
 

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -785,7 +785,7 @@ namespace NodaTime
 
         #region XML serialization
         /// <inheritdoc />
-        XmlSchema IXmlSerializable.GetSchema() => null;
+        XmlSchema? IXmlSerializable.GetSchema() => null;
 
         /// <inheritdoc />
         void IXmlSerializable.ReadXml([NotNull] XmlReader reader)


### PR DESCRIPTION
This PR is now "complete" in terms of applying nullable reference types to all the projects in NodaTime-All.sln.

Further work:

- Remove the existing nullability annotations and tests for them (probably, anyway)
- Review complete API after merging; that will be simpler than looking at the diff
- Update web-based projects too

It's expected that AppVeyor fails right now, as it [doesn't support VS2019 preview 2 just yet](https://github.com/appveyor/ci/issues/2834). I'm happy to merge based on Travis and local builds. (It's not like this code will be going GA any time soon.)