### PR TITLE
Update docfx and fix serialization docfx input

### DIFF
--- a/build/docfx/docfx-unstable.json
+++ b/build/docfx/docfx-unstable.json
@@ -5,13 +5,28 @@
         {
           "files": [
             "NodaTime/*.csproj",
-            "NodaTime.Serialization.JsonNet/*.csproj",
             "NodaTime.Testing/*.csproj"
           ],
           "exclude": [ "**/bin/**", "**/obj/**" ],
           "cwd": "unstable/src"
         }
       ],
+      "dest": "obj/unstable/api",
+      "shouldSkipMarkup": true
+    },
+    {
+      "src": [
+        {
+          "files": [
+            "NodaTime.Serialization.JsonNet/*.csproj",
+          ],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
+          "cwd": "unstable/src"
+        }
+      ],
+      "properties": {
+         "TargetFramework": "net45"
+      },
       "dest": "obj/unstable/api",
       "shouldSkipMarkup": true
     }

--- a/build/docfx_functions.sh
+++ b/build/docfx_functions.sh
@@ -2,7 +2,7 @@
 # any scripts that use tools.
 
 declare -r BUILD_ROOT=$(realpath $(dirname ${BASH_SOURCE}))
-declare -r DOCFX_VERSION=2.38.1
+declare -r DOCFX_VERSION=2.40.6
 
 # Path to the version of docfx to use
 declare -r DOCFX="$BUILD_ROOT/packages/docfx-$DOCFX_VERSION/docfx.exe"
@@ -18,8 +18,6 @@ install_docfx() {
      cd docfx-$DOCFX_VERSION;
      curl -sSL https://github.com/dotnet/docfx/releases/download/v${DOCFX_VERSION}/docfx.zip -o tmp.zip;
      unzip -q tmp.zip;
-     # Workaround for https://github.com/dotnet/docfx/issues/2491
-     cp -f "$VSINSTALLDIR"/MSBuild/15.0/Bin/Microsoft.Build*.dll .;
      rm tmp.zip)
   fi
 }


### PR DESCRIPTION
(For NodaTime.Serialization.JsonNet we need to specify the target framework, which we don't with any other project now.)

This partially addresses #1245, but doesn't fix it fully.