### PR TITLE
Add TypeConverters for Offset types

### DIFF
--- a/src/NodaTime.Test/Text/TypeConvertersTest.cs
+++ b/src/NodaTime.Test/Text/TypeConvertersTest.cs
@@ -40,7 +40,7 @@ namespace NodaTime.Test.Text
             {
                 Assert.DoesNotThrow(() => converter.ConvertToString(Activator.CreateInstance(type)));
             }
-        }        
+        }
 
         [Test]
         [TestCase(01, 01, "01-01")]
@@ -87,28 +87,28 @@ namespace NodaTime.Test.Text
         [TestCase(0, "Z")]
         [TestCase(20700, "+05:45")]
         public void Offset_Roundtrip(int seconds, string text) =>
-	        AssertRoundtrip(text, new Offset(seconds));
+            AssertRoundtrip(text, new Offset(seconds));
 
         [Test]
         [TestCase(2019, 1, 1, -25200, "2019-01-01-07")]
         [TestCase(2018, 12, 31, 0, "2018-12-31Z")]
         [TestCase(2020, 2, 29, 20700, "2020-02-29+05:45")]
         public void OffsetDate_Roundtrip(int year, int month, int day, int seconds, string text) =>
-	        AssertRoundtrip(text, new OffsetDate(new LocalDate(year, month, day), new Offset(seconds)));
+            AssertRoundtrip(text, new OffsetDate(new LocalDate(year, month, day), new Offset(seconds)));
 
         [Test]
         [TestCase(2019, 1, 1, 4, 59, -25200, "2019-01-01T04:59:00-07")]
         [TestCase(2020, 2, 29, 23, 59, 0, "2020-02-29T23:59:00Z")]
         [TestCase(2018, 12, 31, 13, 30, 20700, "2018-12-31T13:30:00+05:45")]
         public void OffsetDateTime_Roundtrip(int year, int month, int day, int hour, int minute, int seconds, string text) =>
-	        AssertRoundtrip(text, new OffsetDateTime(new LocalDateTime(year, month, day, hour, minute), new Offset(seconds)));
+            AssertRoundtrip(text, new OffsetDateTime(new LocalDateTime(year, month, day, hour, minute), new Offset(seconds)));
 
         [Test]
         [TestCase(0, 0, 0, 0, -25200, "00:00:00-07")]
         [TestCase(0, 0, 0, 1, 0, "00:00:00.001Z")]
         [TestCase(23, 59, 59, 999, 20700, "23:59:59.999+05:45")]
         public void OffsetTime_Roundtrip(int hour, int minute, int second, int millisecond, int seconds, string text) =>
-	        AssertRoundtrip(text, new OffsetTime(new LocalTime(hour, minute, second, millisecond), new Offset(seconds)));
+            AssertRoundtrip(text, new OffsetTime(new LocalTime(hour, minute, second, millisecond), new Offset(seconds)));
 
         [Test]
         [TestCase(00, 00, 00, 00, 00, 00, 00, 00, 00, 00, "P")]
@@ -120,6 +120,7 @@ namespace NodaTime.Test.Text
         {
             var converter = TypeDescriptor.GetConverter(typeof(T));
             var actual = (T)converter.ConvertFrom(input);
+
             Assert.NotNull(actual);
             Assert.AreEqual(expected, actual);
 
@@ -127,6 +128,6 @@ namespace NodaTime.Test.Text
 
             Assert.NotNull(serialized);
             Assert.AreEqual(input, serialized);
-        }        
+        }
     }
 }

--- a/src/NodaTime/Offset.cs
+++ b/src/NodaTime/Offset.cs
@@ -7,6 +7,7 @@ using NodaTime.Annotations;
 using NodaTime.Text;
 using NodaTime.Utility;
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Xml;
@@ -34,6 +35,7 @@ namespace NodaTime
     /// but only in very rare historical cases (or fictional ones).</para>
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
+    [TypeConverter(typeof(OffsetTypeConverter))]
     public readonly struct Offset : IEquatable<Offset>, IComparable<Offset>, IFormattable, IComparable, IXmlSerializable
     {
         /// <summary>

--- a/src/NodaTime/OffsetDate.cs
+++ b/src/NodaTime/OffsetDate.cs
@@ -8,6 +8,7 @@ using NodaTime.Calendars;
 using NodaTime.Text;
 using NodaTime.Utility;
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Xml;
@@ -21,6 +22,7 @@ namespace NodaTime
     /// a date at a specific offset from UTC but without any time-of-day information.
     /// </summary>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
+    [TypeConverter(typeof(OffsetDateTypeConverter))]
     public readonly struct OffsetDate : IEquatable<OffsetDate>, IXmlSerializable, IFormattable
     {
         private readonly LocalDate date;

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -9,6 +9,7 @@ using NodaTime.Text;
 using NodaTime.Utility;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Xml;
@@ -31,6 +32,7 @@ namespace NodaTime
     /// </para>
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
+    [TypeConverter(typeof(OffsetDateTimeTypeConverter))]
     public readonly struct OffsetDateTime : IEquatable<OffsetDateTime>, IFormattable, IXmlSerializable
     {
         private const int MinBclOffsetMinutes = -14 * MinutesPerHour;

--- a/src/NodaTime/OffsetTime.cs
+++ b/src/NodaTime/OffsetTime.cs
@@ -7,6 +7,7 @@ using NodaTime.Annotations;
 using NodaTime.Text;
 using NodaTime.Utility;
 using System;
+using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Xml;
@@ -21,6 +22,7 @@ namespace NodaTime
     /// a time-of-day at a specific offset from UTC but without any date information.
     /// </summary>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
+    [TypeConverter(typeof(OffsetTimeTypeConverter))]
     public readonly struct OffsetTime : IEquatable<OffsetTime>, IXmlSerializable, IFormattable
     {
         private const int NanosecondsBits = 47;

--- a/src/NodaTime/Text/TypeConverters.cs
+++ b/src/NodaTime/Text/TypeConverters.cs
@@ -36,6 +36,26 @@ namespace NodaTime.Text
         public LocalTimeTypeConverter() : base(LocalTimePattern.ExtendedIso) {}
     }
 
+    internal sealed class OffsetTypeConverter : TypeConverterBase<Offset>
+    {
+	    public OffsetTypeConverter() : base(OffsetPattern.GeneralInvariantWithZ) { }
+    }
+
+    internal sealed class OffsetDateTimeTypeConverter : TypeConverterBase<OffsetDateTime>
+    {
+	    public OffsetDateTimeTypeConverter() : base(OffsetDateTimePattern.ExtendedIso) { }
+    }
+
+    internal sealed class OffsetDateTypeConverter : TypeConverterBase<OffsetDate>
+    {
+	    public OffsetDateTypeConverter() : base(OffsetDatePattern.GeneralIso) { }
+    }
+
+    internal sealed class OffsetTimeTypeConverter : TypeConverterBase<OffsetTime>
+    {
+	    public OffsetTimeTypeConverter() : base(OffsetTimePattern.ExtendedIso) { }
+    }
+
     internal sealed class PeriodTypeConverter : TypeConverterBase<Period>
     {
         public PeriodTypeConverter() : base(PeriodPattern.Roundtrip) {}

--- a/src/NodaTime/Text/TypeConverters.cs
+++ b/src/NodaTime/Text/TypeConverters.cs
@@ -38,22 +38,22 @@ namespace NodaTime.Text
 
     internal sealed class OffsetTypeConverter : TypeConverterBase<Offset>
     {
-	    public OffsetTypeConverter() : base(OffsetPattern.GeneralInvariantWithZ) { }
+        public OffsetTypeConverter() : base(OffsetPattern.GeneralInvariantWithZ) {}
     }
 
     internal sealed class OffsetDateTimeTypeConverter : TypeConverterBase<OffsetDateTime>
     {
-	    public OffsetDateTimeTypeConverter() : base(OffsetDateTimePattern.ExtendedIso) { }
+        public OffsetDateTimeTypeConverter() : base(OffsetDateTimePattern.ExtendedIso) {}
     }
 
     internal sealed class OffsetDateTypeConverter : TypeConverterBase<OffsetDate>
     {
-	    public OffsetDateTypeConverter() : base(OffsetDatePattern.GeneralIso) { }
+        public OffsetDateTypeConverter() : base(OffsetDatePattern.GeneralIso) {}
     }
 
     internal sealed class OffsetTimeTypeConverter : TypeConverterBase<OffsetTime>
     {
-	    public OffsetTimeTypeConverter() : base(OffsetTimePattern.ExtendedIso) { }
+        public OffsetTimeTypeConverter() : base(OffsetTimePattern.ExtendedIso) {}
     }
 
     internal sealed class PeriodTypeConverter : TypeConverterBase<Period>


### PR DESCRIPTION
This PR just builds on the work from @austindrenski in [PR1237](https://github.com/nodatime/nodatime/pull/1237) the goal here is just to have complete coverage on all NodaTime types that have formatter & parser support.