### PR TITLE
Update benchmark targets to net471 and netcoreapp3.0

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
+++ b/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net471;netcoreapp3.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <AssemblyOriginatorKeyFile>../../NodaTime Release.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
net461 doesn't work when the machine has net471 installed, due to
https://github.com/dotnet/standard/issues/567 (which is very
unfortunate).