### PR TITLE
Prevent robots from trawling where we don't want them to

### DIFF
--- a/src/NodaTime.Web/Views/Downloads/Index.cshtml
+++ b/src/NodaTime.Web/Views/Downloads/Index.cshtml
@@ -41,7 +41,7 @@
                             <td rowspan="@release.Count()">@LocalDatePattern.Iso.Format(file.ReleaseDate)</td>
                             first = false;
                         }
-                        <td><a href="@file.DownloadUrl">@file.File</a></td>
+                        <td><a href="@file.DownloadUrl" rel="nofollow">@file.File</a></td>
                         <td>@file.Sha256Hash</td>
                     </tr>
                 }

--- a/src/NodaTime.Web/wwwroot/robots.txt
+++ b/src/NodaTime.Web/wwwroot/robots.txt
@@ -2,3 +2,6 @@
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
 User-agent: *
+Disallow: /tzvalidate/
+Disallow: /benchmarks/
+Disallow: /tzdb/


### PR DESCRIPTION
I suspect that removing benchmarks may well make a significant difference on its own.

Fixes #1266 (at least mostly)