### PR TITLE
AppVeyor: Install the .NET Core SDK on the fly, and use VS2017 image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 # it elsewhere...
 version: 1.0.{build}-appveyor
 
-image: Visual Studio 2019 Preview
+image: Visual Studio 2017
 
 branches:
   only:
@@ -12,6 +12,17 @@ branches:
 environment:
   COVERALLS_REPO_TOKEN:
     secure: 0MrjEwujECMnIaBkI76fNmCpKy5jr9rZx0rAFOM+41frhVfy2r0ldzzoFC4bvGig
+
+install:
+- ps: |
+    Write-Host "Installing .NET Core SDK..." -ForegroundColor Cyan
+    Write-Host "Downloading..."
+    $exePath = "$env:TEMP\dotnet-sdk.exe"
+    (New-Object Net.WebClient).DownloadFile('https://download.visualstudio.microsoft.com/download/pr/a7e73d05-4e75-4543-ac41-fc69d2f617e5/3f65a44f90c9df66664b44e86b0e6d29/dotnet-sdk-3.0.100-preview-010184-win-x64.exe', $exePath)
+    Write-Host "Installing..."
+    cmd /c start /wait "$exePath" /quiet /norestart
+    del $exePath
+    Write-Host "Installed" -ForegroundColor Green
 
 # Perform the build.
 build_script:


### PR DESCRIPTION
Note that we don't install the runtime separately, as that's
installed as part of the SDK.