### PR TITLE
Fix Markdown use within tables.

### DIFF
--- a/src/NodaTime.Web/Markdown/1.0.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/localtime-patterns.md
@@ -133,7 +133,7 @@ for general notes on custom patterns, including characters used for escaping and
     <tr>
       <td><code>;</code></td>
       <td>
-        This is always *formatted* as a period, but can *parse* either a period or a comma.
+        This is always <em>formatted</em> as a period, but can <em>parse</em> either a period or a comma.
         In all other respects it behaves as the period custom specifier. The purpose of
         this specifier is to properly parse ISO-8601 times, where a comma is allowed as
         the separator for subsecond values.

--- a/src/NodaTime.Web/Markdown/1.0.x/offset-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/offset-patterns.md
@@ -138,7 +138,7 @@ for general notes on custom patterns, including characters used for escaping and
 	<tr>
 	  <td><code>.</code></td>
 	  <td>
-	    This is *always* a period ("."); not a culture-sensitive decimal separator as one might expect. This
+	    This is <em>always</em> a period ("."); not a culture-sensitive decimal separator as one might expect. This
 		follows the example of other standard libraries, however odd it may appear. The only difference
 		between a period and any other literal character is that when followed by a series of "F" characters,
 		the period will be removed if there are no fractional seconds.

--- a/src/NodaTime.Web/Markdown/1.1.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/1.1.x/localtime-patterns.md
@@ -137,7 +137,7 @@ for general notes on custom patterns, including characters used for escaping and
     <tr>
       <td><code>;</code></td>
       <td>
-        This is always *formatted* as a period, but can *parse* either a period or a comma.
+        This is always <em>formatted</em> as a period, but can <em>parse</em> either a period or a comma.
         In all other respects it behaves as the period custom specifier. The purpose of
         this specifier is to properly parse ISO-8601 times, where a comma is allowed as
         the separator for subsecond values.

--- a/src/NodaTime.Web/Markdown/2.0.x/localtime-patterns.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/localtime-patterns.md
@@ -137,7 +137,7 @@ for general notes on custom patterns, including characters used for escaping and
     <tr>
       <td><code>;</code></td>
       <td>
-        This is always *formatted* as a period, but can *parse* either a period or a comma.
+        This is always <em>formatted</em> as a period, but can <em>parse</em> either a period or a comma.
         In all other respects it behaves as the period custom specifier. The purpose of
         this specifier is to properly parse ISO-8601 times, where a comma is allowed as
         the separator for subsecond values.


### PR DESCRIPTION
Specifically, replace occurrences of `*foo*` with `<em>foo</em>` when it occurs within a table, as HTML elements inhibit Markdown processing.