### PR TITLE
Reduce the noise in production logging

### DIFF
--- a/src/NodaTime.Web/appsettings.json
+++ b/src/NodaTime.Web/appsettings.json
@@ -4,7 +4,11 @@
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",
-      "Microsoft": "Information"
+      "Microsoft": "Information",
+      "Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker": "Warning",
+      "Microsoft.AspNetCore.Mvc.Infrastructure.ContentResultExecutor": "Warning",
+      "Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware": "Warning",
+      "Microsoft.AspNetCore.Mvc.ViewFeatures.ViewResultExecutor": "Warning"
     }
   },
 


### PR DESCRIPTION
Unfortunately we still have two log lines per request, but that
would require custom code to fix; let's not worry about it for now.