### PR TITLE
Fix for phrasing: "notional global timeline"

### DIFF
--- a/src/NodaTime.Web/Markdown/1.0.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/1.0.x/core-types.md
@@ -8,7 +8,7 @@ If you're not familiar with the core concepts, read that page first.
 Instant
 -------
 
-An [`Instant`][Instant] is a point on notional a global time-line, regardless of calendar system and time zone.
+An [`Instant`][Instant] is a point on a notional global time-line, regardless of calendar system and time zone.
 It's simply a number of "ticks" since some arbitrary epoch, where a tick in Noda Time is 100 nanoseconds (a definition
 inherited from the BCL). Noda Time always uses the Unix epoch, which corresponds to midnight on January 1st 1970 UTC.
 (This is merely one way of expressing the epoch - it would be equally valid to express it using other calendar systems

--- a/src/NodaTime.Web/Markdown/2.0.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/2.0.x/core-types.md
@@ -8,7 +8,7 @@ If you're not familiar with the core concepts, read that page first.
 Instant
 -------
 
-An [`Instant`][Instant] is a point on notional a global time-line, regardless of calendar system and time zone.
+An [`Instant`][Instant] is a point on a notional global time-line, regardless of calendar system and time zone.
 It's simply a number of nanoseconds since some arbitrary epoch. Noda Time always uses the Unix epoch, which corresponds to midnight on January 1st 1970 UTC.
 (This is merely one way of expressing the epoch - it would be equally valid to express it using other calendar systems
 and time zones; the epoch itself has no notion of a time zone or calendar system.)

--- a/src/NodaTime.Web/Markdown/2.3.x/core-types.md
+++ b/src/NodaTime.Web/Markdown/2.3.x/core-types.md
@@ -8,7 +8,7 @@ If you're not familiar with the core concepts, read that page first.
 Instant
 -------
 
-An [`Instant`][Instant] is a point on notional a global time-line, regardless of calendar system and time zone.
+An [`Instant`][Instant] is a point on a notional global time-line, regardless of calendar system and time zone.
 It's simply a number of nanoseconds since some arbitrary epoch. Noda Time always uses the Unix epoch, which corresponds to midnight on January 1st 1970 UTC.
 (This is merely one way of expressing the epoch - it would be equally valid to express it using other calendar systems
 and time zones; the epoch itself has no notion of a time zone or calendar system.)


### PR DESCRIPTION
Was reading the docs and saw the phrase (emphasis mine)

> An Instant is a point on **notional a** global time-line

And I believe you may have meant:

> An Instant is a point on **a notional** global time-line

So I figured I'd do a quick PR to suggest it.