### PR TITLE
Copy inherited docs in the Testing project

### DIFF
--- a/src/NodaTime.Testing/TimeZones/FakeDateTimeZoneSource.cs
+++ b/src/NodaTime.Testing/TimeZones/FakeDateTimeZoneSource.cs
@@ -34,13 +34,47 @@ namespace NodaTime.Testing.TimeZones
         /// <returns>A provider backed by this source.</returns>
         public IDateTimeZoneProvider ToProvider() => new DateTimeZoneCache(this);
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns an unordered enumeration of the IDs available from this source.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Every value in this enumeration must return a valid time zone from <see cref="ForId"/> for the life of the source.
+        /// The enumeration may be empty, but must not be null, and must not contain any elements which are null.  It
+        /// should not contain duplicates: this is not enforced, and while it may not have a significant impact on
+        /// clients in some cases, it is generally unfriendly.  The built-in implementations never return duplicates.
+        /// </para>
+        /// <para>
+        /// The source is not required to provide the IDs in any particular order, although they should be distinct.
+        /// </para>
+        /// <para>
+        /// Note that this list may optionally contain any of the fixed-offset timezones (with IDs "UTC" and
+        /// "UTC+/-Offset"), but there is no requirement they be included.
+        /// </para>
+        /// </remarks>
+        /// <returns>The IDs available from this source.</returns>
         public IEnumerable<string> GetIds() => zones.Keys;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns an appropriate version ID for diagnostic purposes, which must not be null.
+        /// </summary>
+        /// <remarks>
+        /// This doesn't have any specific format; it's solely for diagnostic purposes.
+        /// The included sources return strings of the format "source identifier: source version" indicating where the
+        /// information comes from and which version of the source information has been loaded.
+        /// </remarks>
+        /// <value>An appropriate version ID for diagnostic purposes.</value>
         public string VersionId { get; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Returns the time zone definition associated with the given ID.
+        /// </summary>
+        /// <remarks>
+        /// </remarks>
+        /// <param name="id">The ID of the time zone to return. This must be one of the IDs
+        /// returned by <see cref="GetIds"/>.</param>
+        /// <returns>The <see cref="DateTimeZone"/> for the given ID.</returns>
+        /// <exception cref="ArgumentException"><paramref name="id"/> is not supported by this source.</exception>
         public DateTimeZone ForId(string id)
         {
             Preconditions.CheckNotNull(id, nameof(id));
@@ -50,8 +84,6 @@ namespace NodaTime.Testing.TimeZones
             }
             throw new ArgumentException("Unknown ID: " + id);
         }
-
-        // TODO: Work out why inheritdoc doesn't work here. What's special about this method?
 
         /// <summary>
         /// Returns this source's ID for the system default time zone.

--- a/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
+++ b/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
@@ -35,7 +35,15 @@ namespace NodaTime.Testing.TimeZones
             Transitions = new ReadOnlyCollection<Instant>(intervals.Skip(1).Select(x => x.Start).ToList());
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets the zone interval for the given instant; the range of time around the instant in which the same Offset
+        /// applies (with the same split between standard time and daylight saving time, and with the same offset).
+        /// </summary>
+        /// <remarks>
+        /// This will always return a valid zone interval, as time zones cover the whole of time.
+        /// </remarks>
+        /// <param name="instant">The <see cref="T:NodaTime.Instant" /> to query.</param>
+        /// <returns>The defined <see cref="T:NodaTime.TimeZones.ZoneInterval" />.</returns>
         public override ZoneInterval GetZoneInterval(Instant instant)
         {
             int lower = 0; // Inclusive

--- a/src/NodaTime.Testing/TimeZones/SingleTransitionDateTimeZone.cs
+++ b/src/NodaTime.Testing/TimeZones/SingleTransitionDateTimeZone.cs
@@ -67,10 +67,16 @@ namespace NodaTime.Testing.TimeZones
                 offsetAfter, Offset.Zero);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets the zone interval for the given instant; the range of time around the instant in which the same Offset
+        /// applies (with the same split between standard time and daylight saving time, and with the same offset).
+        /// </summary>
         /// <remarks>
+        /// This will always return a valid zone interval, as time zones cover the whole of time.
         /// This returns either the zone interval before or after the transition, based on the instant provided.
         /// </remarks>
+        /// <param name="instant">The <see cref="T:NodaTime.Instant" /> to query.</param>
+        /// <returns>The defined <see cref="T:NodaTime.TimeZones.ZoneInterval" />.</returns>
         public override ZoneInterval GetZoneInterval(Instant instant) => EarlyInterval.Contains(instant) ? EarlyInterval : LateInterval;
     }
 }


### PR DESCRIPTION
The new way of building documentation doesn't work with cross-project inheritdoc tags (until docfx supports it).