### PR TITLE
Use 'S' as the extended ISO standard pattern specifier

### DIFF
--- a/src/NodaTime.Test/Text/LocalDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalDateTimePatternTest.cs
@@ -97,8 +97,11 @@ namespace NodaTime.Test.Text
             new Data(MsdnStandardExample) { Pattern = "r", Text = "2009-06-15T13:45:30.090000000 (ISO)", Culture = Cultures.EnUs },
             new Data(SampleLocalDateTimeCoptic) { Pattern = "r", Text = "1976-06-19T21:13:34.123456789 (Coptic)", Culture = Cultures.EnUs },
             // Note: No RFC1123, as that requires a time zone.
-            // Sortable / ISO8601
+            // Short Sortable / ISO8601
             new Data(MsdnStandardExampleNoMillis) { Pattern = "s", Text = "2009-06-15T13:45:30", Culture = Cultures.EnUs },
+            // Long Sortable / ISO8601-extended
+            new Data(MsdnStandardExample) { Pattern = "S", Text = "2009-06-15T13:45:30.09", Culture = Cultures.EnUs },
+            new Data(MsdnStandardExampleNoMillis) { Pattern = "S", Text = "2009-06-15T13:45:30", Culture = Cultures.EnUs },
 
             // Standard patterns (French)
             new Data(MsdnStandardExampleNoSeconds) { Pattern = "f", Text = "lundi 15 juin 2009 13:45", Culture = Cultures.FrFr },
@@ -111,6 +114,7 @@ namespace NodaTime.Test.Text
             new Data(MsdnStandardExample) { StandardPattern = LocalDateTimePattern.FullRoundtripWithoutCalendar, Pattern = "R", Text = "2009-06-15T13:45:30.090000000", Culture = Cultures.FrFr },
             new Data(MsdnStandardExample) { StandardPattern = LocalDateTimePattern.FullRoundtrip, Pattern = "r", Text = "2009-06-15T13:45:30.090000000 (ISO)", Culture = Cultures.FrFr },
             new Data(MsdnStandardExampleNoMillis) { StandardPattern = LocalDateTimePattern.GeneralIso, Pattern = "s", Text = "2009-06-15T13:45:30", Culture = Cultures.FrFr },
+            new Data(MsdnStandardExample) { StandardPattern = LocalDateTimePattern.ExtendedIso, Pattern = "S", Text = "2009-06-15T13:45:30.09", Culture = Cultures.FrFr },
             new Data(SampleLocalDateTime) { StandardPattern = LocalDateTimePattern.FullRoundtripWithoutCalendar, Pattern = "R", Text = "1976-06-19T21:13:34.123456789", Culture = Cultures.FrFr },
             new Data(SampleLocalDateTime) { StandardPattern = LocalDateTimePattern.FullRoundtrip, Pattern = "r", Text = "1976-06-19T21:13:34.123456789 (ISO)", Culture = Cultures.FrFr },
 

--- a/src/NodaTime/Text/LocalDateTimePattern.cs
+++ b/src/NodaTime/Text/LocalDateTimePattern.cs
@@ -32,9 +32,11 @@ namespace NodaTime.Text
 
         /// <summary>
         /// Gets an invariant local date/time pattern which is ISO-8601 compatible, down to the second.
-        /// This corresponds to the text pattern "uuuu'-'MM'-'dd'T'HH':'mm':'ss", and is also used as the "sortable"
-        /// standard pattern.
+        /// This corresponds to the text pattern "uuuu'-'MM'-'dd'T'HH':'mm':'ss".
         /// </summary>
+        /// <remarks>
+        /// This pattern corresponds to the 's' standard pattern ("shorter sortable").
+        /// </remarks>
         /// <value>An invariant local date/time pattern which is ISO-8601 compatible, down to the second.</value>
         public static LocalDateTimePattern GeneralIso => Patterns.GeneralIsoPatternImpl;
 
@@ -43,6 +45,9 @@ namespace NodaTime.Text
         /// of sub-second accuracy. (These digits are omitted when unnecessary.)
         /// This corresponds to the text pattern "uuuu'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFFF".
         /// </summary>
+        /// <remarks>
+        /// This pattern corresponds to the 'S' standard pattern ("longer sortable").
+        /// </remarks>
         /// <value>An invariant local date/time pattern which is ISO-8601 compatible, providing up to 9 decimal places
         /// of sub-second accuracy.</value>
         public static LocalDateTimePattern ExtendedIso => Patterns.ExtendedIsoPatternImpl;
@@ -55,6 +60,9 @@ namespace NodaTime.Text
         /// round-trip all <c>LocalDateTime</c> values as it will lose sub-tick information. Use
         /// <see cref="FullRoundtripWithoutCalendar"/>
         /// </summary>
+        /// <remarks>
+        /// This pattern corresponds to the 'o' and 'O' standard patterns.
+        /// </remarks>
         /// <value>An invariant local date/time pattern which is ISO-8601 compatible, providing up to 7 decimal places
         /// of sub-second accuracy which are always present (including trailing zeroes).</value>
         public static LocalDateTimePattern BclRoundtrip => Patterns.BclRoundtripPatternImpl;
@@ -66,6 +74,9 @@ namespace NodaTime.Text
         /// round-trip all <see cref="LocalDateTime"/> values if the calendar system of the template value is the same
         /// as the calendar system of the original value.
         /// </summary>
+        /// <remarks>
+        /// This pattern corresponds to the 'r' standard pattern.
+        /// </remarks>
         /// <value>An invariant local date/time pattern which is ISO-8601 compatible, providing up to 7 decimal places
         /// of sub-second accuracy which are always present (including trailing zeroes).</value>
         public static LocalDateTimePattern FullRoundtripWithoutCalendar => Patterns.FullRoundtripWithoutCalendarImpl;
@@ -74,6 +85,9 @@ namespace NodaTime.Text
         /// Gets an invariant local date/time pattern which round trips values including the calendar system.
         /// This corresponds to the text pattern "uuuu'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffff '('c')'".
         /// </summary>
+        /// <remarks>
+        /// This pattern corresponds to the 'R' standard pattern.
+        /// </remarks>
         /// <value>An invariant local date/time pattern which round trips values including the calendar system.</value>
         public static LocalDateTimePattern FullRoundtrip => Patterns.FullRoundtripPatternImpl;
 

--- a/src/NodaTime/Text/LocalDateTimePatternParser.cs
+++ b/src/NodaTime/Text/LocalDateTimePatternParser.cs
@@ -78,6 +78,7 @@ namespace NodaTime.Text
                     'r' => LocalDateTimePattern.Patterns.FullRoundtripPatternImpl,
                     'R' => LocalDateTimePattern.Patterns.FullRoundtripWithoutCalendarImpl,
                     's' => LocalDateTimePattern.Patterns.GeneralIsoPatternImpl,
+                    'S' => LocalDateTimePattern.Patterns.ExtendedIsoPatternImpl,
                     // Other standard patterns expand the pattern text to the appropriate custom pattern.
                     // Note: we don't just recurse, as otherwise a FullDateTimePattern of 'F' would cause a stack overflow.
                     'f' => ParseNoStandardExpansion(formatInfo.DateTimeFormat.LongDatePattern + " " + formatInfo.DateTimeFormat.ShortTimePattern),


### PR DESCRIPTION
Fixes #1219

Also standardize the comment format in LocalDateTimePattern. (I'll revisit this for the other patterns later...)

PR review notes:

We currently have 's' as 'sorted' and 'general ISO', which has no subsecond units. 'S' feels like a natural extension of that, and is still 'longer sorted' in that shorter strings sort before longer strings... is that a reasonable justification?

Note: documentation changes will be in a PR in the nodatime.org repo - that's one of the downsides of splitting the two out...
