### PR TITLE
Swap the standard patterns for LocalDate r/R

### DIFF
--- a/src/NodaTime.Test/Text/LocalDatePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalDatePatternTest.cs
@@ -132,9 +132,9 @@ namespace NodaTime.Test.Text
             new Data(2011, 10, 20) { Pattern = "d", Text = "10/20/2011" },
             new Data(2011, 10, 20) { Pattern = "D", Text = "Thursday, 20 October 2011" },
             // ISO pattern uses a sensible format
-            new Data(2011, 10, 20) { StandardPattern = LocalDatePattern.Iso, Pattern = "r", Text = "2011-10-20" },
+            new Data(2011, 10, 20) { StandardPattern = LocalDatePattern.Iso, Pattern = "R", Text = "2011-10-20" },
             // Round trip with calendar system
-            new Data(2011, 10, 20, CalendarSystem.Coptic) { StandardPattern = LocalDatePattern.FullRoundtrip, Pattern = "R", Text = "2011-10-20 (Coptic)" },
+            new Data(2011, 10, 20, CalendarSystem.Coptic) { StandardPattern = LocalDatePattern.FullRoundtrip, Pattern = "r", Text = "2011-10-20 (Coptic)" },
 
             // Custom patterns
             new Data(2011, 10, 3) { Pattern = "yyyy/MM/dd", Text = "2011/10/03" },

--- a/src/NodaTime/Text/LocalDatePattern.cs
+++ b/src/NodaTime/Text/LocalDatePattern.cs
@@ -34,7 +34,7 @@ namespace NodaTime.Text
         /// This corresponds to the text pattern "uuuu'-'MM'-'dd".
         /// </summary>
         /// <remarks>
-        /// This pattern corresponds to the 'r' standard pattern.
+        /// This pattern corresponds to the 'R' standard pattern.
         /// </remarks>
         /// <value>An invariant local date pattern which is ISO-8601 compatible.</value>
         public static LocalDatePattern Iso => Patterns.IsoPatternImpl;
@@ -44,7 +44,7 @@ namespace NodaTime.Text
         /// This corresponds to the text pattern "uuuu'-'MM'-'dd '('c')'".
         /// </summary>
         /// <remarks>
-        /// This pattern corresponds to the 'R' standard pattern.
+        /// This pattern corresponds to the 'r' standard pattern.
         /// </remarks>
         /// <value>An invariant local date pattern which round trips values including the calendar system.</value>
         public static LocalDatePattern FullRoundtrip => Patterns.FullRoundtripPatternImpl;

--- a/src/NodaTime/Text/LocalDatePatternParser.cs
+++ b/src/NodaTime/Text/LocalDatePatternParser.cs
@@ -63,8 +63,8 @@ namespace NodaTime.Text
                 return patternText[0] switch
                 {
                     // Invariant standard patterns return cached implementations.
-                    'r' => LocalDatePattern.Patterns.IsoPatternImpl,
-                    'R' => LocalDatePattern.Patterns.FullRoundtripPatternImpl,
+                    'R' => LocalDatePattern.Patterns.IsoPatternImpl,
+                    'r' => LocalDatePattern.Patterns.FullRoundtripPatternImpl,
                     // Other standard patterns expand the pattern text to the appropriate custom pattern.
                     // Note: we don't just recurse, as otherwise a ShortDatePattern of 'd' (for example) would cause a stack overflow.
                     'd' => ParseNoStandardExpansion(formatInfo.DateTimeFormat.ShortDatePattern),


### PR DESCRIPTION
(These were only introduced very recently.)

When documenting them, I found that LocalDateTime has r and R as well, but with "r" meaning "full round trip including calendar" and "R" meaning "no calendar" so it makes sense to make LocalDate conform too.