### PR TITLE
Introduce a date adjuster to add a period when invoked

### DIFF
--- a/src/NodaTime.Test/DateAdjustersTest.cs
+++ b/src/NodaTime.Test/DateAdjustersTest.cs
@@ -120,5 +120,23 @@ namespace NodaTime.Test
             Assert.Throws<ArgumentOutOfRangeException>(() => DateAdjusters.Previous(invalid));
             Assert.Throws<ArgumentOutOfRangeException>(() => DateAdjusters.PreviousOrSame(invalid));
         }
+
+        [Test]
+        public void AddPeriod_Valid()
+        {
+            var period = Period.FromMonths(1) + Period.FromDays(3);
+            var adjuster = DateAdjusters.AddPeriod(period);
+            var start = new LocalDate(2019, 5, 4);
+            Assert.AreEqual(new LocalDate(2019, 6, 7), start.With(adjuster));
+        }
+
+        [Test]
+        public void AddPeriod_Null() =>
+            Assert.Throws<ArgumentNullException>(() => DateAdjusters.AddPeriod(null!));
+
+
+        [Test]
+        public void AddPeriod_IncludingTimeUnits() =>
+            Assert.Throws<ArgumentException>(() => DateAdjusters.AddPeriod(Period.FromDays(1) + Period.FromHours(1)));
     }
 }

--- a/src/NodaTime/DateAdjusters.cs
+++ b/src/NodaTime/DateAdjusters.cs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using NodaTime.Utility;
 using System;
 
 namespace NodaTime
@@ -128,6 +129,23 @@ namespace NodaTime
                 throw new ArgumentOutOfRangeException(nameof(dayOfWeek));
             }
             return date => date.Previous(dayOfWeek);
+        }
+
+        /// <summary>
+        /// Creates a date adjuster to add the specified period to the date.
+        /// </summary>
+        /// <remarks>
+        /// This is the adjuster equivalent of <see cref="LocalDate.Plus(Period)"/>.
+        /// </remarks>
+        /// <param name="period">The period to add when the adjuster is invoked. Must not contain any (non-zero) time units.</param>
+        /// <returns>An adjuster which adds the specified period.</returns>
+        public static Func<LocalDate, LocalDate> AddPeriod(Period period)
+        {
+            Preconditions.CheckNotNull(period, nameof(period));
+            // Perform this validation eagerly. It will be performed on each invocation as well,
+            // but it's good to throw an exception now rather than waiting for the first invocation.
+            Preconditions.CheckArgument(!period.HasTimeComponent, nameof(period), "Cannot add a period with a time component to a date");
+            return date => date + period;
         }
     }
 }


### PR DESCRIPTION
I'm not fixed on the name; we could potentially omit "Period" from the name, and change "Add" to "Addition", or "Adder" etc.

I looked at introducing a similar adjuster for LocalTime, but that
could cause confusion:

```csharp
// If this were valid...
TimeAdjuster adjuster = TimeAdjuster.AddPeriod(Period.FromHours(2));
LocalDateTime start = new LocalDateTime(2019, 5, 4, 23, 0); // 11pm on May 4th

// Expectation: result is 1am on May 5th.
// Reality: result is 1am on May 4th, as the adjuster is only applied to time.
LocalDateTime result = start.With(Adjuster);
```

Fixing that would require a "LocalDateTimeAdjuster" which we don't currently have, and I'm not sure it's worth it.