### PR TITLE
Use Nullable msbuild property

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
+++ b/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
@@ -9,6 +9,7 @@
     <IsPackable>False</IsPackable>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Demo/NodaTime.Demo.csproj
+++ b/src/NodaTime.Demo/NodaTime.Demo.csproj
@@ -7,6 +7,7 @@
     <IsPackable>False</IsPackable>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.NzdPrinter/NodaTime.NzdPrinter.csproj
+++ b/src/NodaTime.NzdPrinter/NodaTime.NzdPrinter.csproj
@@ -9,6 +9,7 @@
     <IsPackable>False</IsPackable>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -6,7 +6,8 @@
     <Deterministic>True</Deterministic>
     <IsPackable>False</IsPackable>
     <LangVersion>preview</LangVersion>
-    <NullableContextOptions>enable</NullableContextOptions>    
+    <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Testing/NodaTime.Testing.csproj
+++ b/src/NodaTime.Testing/NodaTime.Testing.csproj
@@ -15,6 +15,7 @@
     <Deterministic>True</Deterministic>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Tools.Common/NodaTime.Tools.Common.csproj
+++ b/src/NodaTime.Tools.Common/NodaTime.Tools.Common.csproj
@@ -7,6 +7,7 @@
     <IsPackable>False</IsPackable>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Tools.DumpTimeZoneInfo/NodaTime.Tools.DumpTimeZoneInfo.csproj
+++ b/src/NodaTime.Tools.DumpTimeZoneInfo/NodaTime.Tools.DumpTimeZoneInfo.csproj
@@ -6,5 +6,6 @@
     <IsPackable>False</IsPackable>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/src/NodaTime.Tools.ValidateHistoricalNzd/NodaTime.Tools.ValidateHistoricalNzd.csproj
+++ b/src/NodaTime.Tools.ValidateHistoricalNzd/NodaTime.Tools.ValidateHistoricalNzd.csproj
@@ -6,6 +6,7 @@
     <IsPackable>False</IsPackable>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />

--- a/src/NodaTime.TzValidate.NodaDump/NodaTime.TzValidate.NodaDump.csproj
+++ b/src/NodaTime.TzValidate.NodaDump/NodaTime.TzValidate.NodaDump.csproj
@@ -7,6 +7,7 @@
     <IsPackable>False</IsPackable>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
+++ b/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
@@ -7,6 +7,7 @@
     <IsPackable>False</IsPackable>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
+++ b/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
@@ -9,6 +9,7 @@
     <IsPackable>False</IsPackable>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -18,6 +18,7 @@
     <Deterministic>True</Deterministic>
     <LangVersion>preview</LangVersion>
     <NullableContextOptions>enable</NullableContextOptions>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is required by recent previews of the .NET Core SDK, but VS still needs the old property. We can go down to just this one when .NET Core 3.0 is released, I suspect.