### PR TITLE
Add snippet for Deconstruct

### DIFF
--- a/src/NodaTime.Demo/DateIntervalDemo.cs
+++ b/src/NodaTime.Demo/DateIntervalDemo.cs
@@ -71,7 +71,7 @@ namespace NodaTime.Demo
         }
 
         [Test]
-        public void Deconstruct()
+        public void Deconstruction()
         {
             var calendar = CalendarSystem.Gregorian;
             LocalDate start = new LocalDate(2017, 1, 1);

--- a/src/NodaTime.Demo/DateIntervalDemo.cs
+++ b/src/NodaTime.Demo/DateIntervalDemo.cs
@@ -84,5 +84,25 @@ namespace NodaTime.Demo
             Assert.AreEqual(start, actualStart);
             Assert.AreEqual(end, actualEnd);
         }
+
+        [Test]
+        public void Union()
+        {
+            DateInterval firstInterval = new DateInterval(
+                new LocalDate(2014, 3, 7),
+                new LocalDate(2014, 3, 20));
+
+            DateInterval secondInterval = new DateInterval(
+                new LocalDate(2014, 3, 15),
+                new LocalDate(2014, 3, 23));
+
+            DateInterval? overlappingInterval = Snippet.For(firstInterval.Union(secondInterval));
+
+            Assert.AreEqual(
+                new DateInterval(
+                    new LocalDate(2014, 3, 7),
+                    new LocalDate(2014, 3, 23)),
+                overlappingInterval);
+        }
     }
 }

--- a/src/NodaTime.Demo/DateIntervalDemo.cs
+++ b/src/NodaTime.Demo/DateIntervalDemo.cs
@@ -73,12 +73,12 @@ namespace NodaTime.Demo
         [Test]
         public void Deconstruction()
         {
-            var calendar = CalendarSystem.Gregorian;
             LocalDate start = new LocalDate(2017, 1, 1);
             LocalDate end = new LocalDate(2017, 12, 31);
 
             DateInterval value = new DateInterval(start, end);
 
+            Snippet.SilentForAction(() => value.Deconstruct(out var _, out var _));
             value.Deconstruct(out LocalDate actualStart, out LocalDate actualEnd);
 
             Assert.AreEqual(start, actualStart);

--- a/src/NodaTime.Demo/DateIntervalDemo.cs
+++ b/src/NodaTime.Demo/DateIntervalDemo.cs
@@ -69,5 +69,20 @@ namespace NodaTime.Demo
             var result = Snippet.For(interval.Contains(june));
             Assert.AreEqual(true, result);
         }
+
+        [Test]
+        public void Deconstruct()
+        {
+            var calendar = CalendarSystem.Gregorian;
+            LocalDate start = new LocalDate(2017, 1, 1);
+            LocalDate end = new LocalDate(2017, 12, 31);
+
+            DateInterval interval = new DateInterval(start, end);
+
+            interval.Deconstruct(out LocalDate startDeconstructed, out LocalDate endDeconstructed);
+
+            Assert.AreEqual(start, startDeconstructed);
+            Assert.AreEqual(end, endDeconstructed);
+        }
     }
 }

--- a/src/NodaTime.Demo/DateIntervalDemo.cs
+++ b/src/NodaTime.Demo/DateIntervalDemo.cs
@@ -81,11 +81,8 @@ namespace NodaTime.Demo
 
             value.Deconstruct(out LocalDate actualStart, out LocalDate actualEnd);
 
-            Assert.Multiple(() =>
-            {
-                Assert.AreEqual(start, actualStart);
-                Assert.AreEqual(end, actualEnd);
-            });
+            Assert.AreEqual(start, actualStart);
+            Assert.AreEqual(end, actualEnd);
         }
     }
 }

--- a/src/NodaTime.Demo/DateIntervalDemo.cs
+++ b/src/NodaTime.Demo/DateIntervalDemo.cs
@@ -77,12 +77,15 @@ namespace NodaTime.Demo
             LocalDate start = new LocalDate(2017, 1, 1);
             LocalDate end = new LocalDate(2017, 12, 31);
 
-            DateInterval interval = new DateInterval(start, end);
+            DateInterval value = new DateInterval(start, end);
 
-            interval.Deconstruct(out LocalDate startDeconstructed, out LocalDate endDeconstructed);
+            value.Deconstruct(out LocalDate actualStart, out LocalDate actualEnd);
 
-            Assert.AreEqual(start, startDeconstructed);
-            Assert.AreEqual(end, endDeconstructed);
+            Assert.Multiple(() =>
+            {
+                Assert.AreEqual(start, actualStart);
+                Assert.AreEqual(end, actualEnd);
+            });
         }
     }
 }


### PR DESCRIPTION
Adds snippet for `Deconstruct` in `DateInterval`.

`Snippet.For()` doesn't have support for void-methods, so any ideas for how to support that with a new signature for `Snippet.For()` would be appreciated :) I can add that into this PR.