### PR TITLE
Fix AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,10 @@ environment:
   COVERALLS_REPO_TOKEN:
     secure: 0MrjEwujECMnIaBkI76fNmCpKy5jr9rZx0rAFOM+41frhVfy2r0ldzzoFC4bvGig
 
+install:
+  # Make sure we get the bash that comes with git, not WSL bash
+  - ps: $env:Path = "C:\Program Files\Git\bin;$env:Path"
+
 # Perform the build.
 build_script:
   - bash build/appveyor.sh


### PR DESCRIPTION
AppVeyor now includes WSL, which means that just "bash" refers to WSL bash.

Our build scripts expect mingw64 bash (running the Windows .NET Core
SDK rather than the Linux one, etc) so we just need to put that
earlier in the path.
