### PR TITLE
Date and time parsing optimization

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTimeTests/Text/LocalDatePatternBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Text/LocalDatePatternBenchmarks.cs
@@ -12,6 +12,7 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
     public class LocalDatePatternBenchmarks
     {
         private static readonly LocalDate SampleLocalDate = new LocalDate(2009, 12, 26);
+        private static readonly string SampleIsoFormattedDate = "2009-12-26";
         private static readonly LocalDatePattern PatternWithLongMonth = LocalDatePattern.CreateWithInvariantCulture("MMMM dd uuuu");
         private static readonly LocalDatePattern PatternWithShortMonth = LocalDatePattern.CreateWithInvariantCulture("MMM dd uuuu");
         private static readonly LocalDatePattern PatternWithLongDay = LocalDatePattern.CreateWithInvariantCulture("dddd MM dd uuuu");
@@ -56,6 +57,12 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
         public void FormatWithShortDay()
         {
             PatternWithShortDay.Format(SampleLocalDate);
+        }
+
+        [Benchmark]
+        public void ParseIsoDate()
+        {
+            LocalDatePattern.Iso.Parse(SampleIsoFormattedDate);
         }
     }
 }

--- a/src/NodaTime.Benchmarks/NodaTimeTests/Text/LocalTimePatternBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Text/LocalTimePatternBenchmarks.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2013 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using BenchmarkDotNet.Attributes;
+using NodaTime.Text;
+
+namespace NodaTime.Benchmarks.NodaTimeTests.Text
+{
+    [Category("Text")]
+    public class LocalTimePatternBenchmarks
+    {
+        private static readonly LocalTime SampleLocalTimeToSecond = new LocalTime(15, 12, 10);
+        private static readonly LocalTime SampleLocalTimeToNanos = LocalTime.FromHourMinuteSecondNanosecond(15, 12, 10, 123456789L);
+        private static readonly string SampleIsoFormattedTime = "15:12:10";
+        private static readonly string SampleIsoFormattedTimeWithNanos = "15:12:10.123456789";
+
+        // TODO: Make this a standard pattern.
+        private static readonly LocalTimePattern IsoPatternToSecond = LocalTimePattern.CreateWithInvariantCulture("HH:mm:ss");
+
+        [Benchmark]
+        public void ExtendedIso_Format() =>
+            LocalTimePattern.ExtendedIso.Format(SampleLocalTimeToNanos);
+
+        [Benchmark]
+        public void ExtendedIso_Parse() =>
+            LocalTimePattern.ExtendedIso.Parse(SampleIsoFormattedTimeWithNanos);
+
+        [Benchmark]
+        public void IsoPatternToSecond_Format() =>
+            IsoPatternToSecond.Format(SampleLocalTimeToSecond);
+
+        [Benchmark]
+        public void IsoPatternToSecond_Parse() =>
+            IsoPatternToSecond.Parse(SampleIsoFormattedTime);
+    }
+}

--- a/src/NodaTime.Test/Text/PatternTestData.cs
+++ b/src/NodaTime.Test/Text/PatternTestData.cs
@@ -145,7 +145,7 @@ namespace NodaTime.Test.Text
             string expectedMessage = FormatMessage(Message!, Parameters.ToArray());
             IPattern<T> pattern = CreatePattern();
             var result = pattern.Parse(Text!);
-            Assert.IsFalse(result.Success, "Expected parsing to failed, but it succeeded");
+            Assert.IsFalse(result.Success, "Expected parsing to fail, but it succeeded");
             try
             {
                 result.GetValueOrThrow();

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -226,12 +226,20 @@ namespace NodaTime
                 Preconditions.CheckArgumentRange(nameof(second), second, 0, SecondsPerMinute - 1);
                 Preconditions.CheckArgumentRange(nameof(nanosecondWithinSecond), nanosecondWithinSecond, 0, NanosecondsPerSecond - 1);
             }
-            return new LocalTime(unchecked(
+            return FromHourMinuteSecondNanosecondTrusted(hour, minute, second, nanosecondWithinSecond);
+        }
+
+        /// <summary>
+        /// Factory method for creating a local time from the hour of day, minute of hour, second of minute, and nanosecond of second
+        /// where the values have already been validated.
+        /// </summary>
+        internal static LocalTime FromHourMinuteSecondNanosecondTrusted(
+            [Trusted] int hour, [Trusted] int minute, [Trusted] int second, [Trusted] long nanosecondWithinSecond) =>
+            new LocalTime(unchecked(
                 hour * NanosecondsPerHour +
                 minute * NanosecondsPerMinute +
                 second * NanosecondsPerSecond +
                 nanosecondWithinSecond));
-        }
 
         /// <summary>
         /// Constructor only called from other parts of Noda Time - trusted to be the range [0, NanosecondsPerDay).


### PR DESCRIPTION
Gets the benefits of #1444, but changing everything else turns out not to be useful.

Will only merge after I've got benchmarks working on Bagpuss again.