### PR TITLE
Add standard "month/day" pattern.

### DIFF
--- a/src/NodaTime.Test/Text/LocalDatePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalDatePatternTest.cs
@@ -134,6 +134,8 @@ namespace NodaTime.Test.Text
             // Invariant culture uses the crazy MM/dd/yyyy format. Blech.
             new Data(2011, 10, 20) { Pattern = "d", Text = "10/20/2011" },
             new Data(2011, 10, 20) { Pattern = "D", Text = "Thursday, 20 October 2011" },
+            // Year comes from the template
+            new Data(2000, 10, 20) { Pattern = "M", Text = "October 20" },
             // ISO pattern uses a sensible format
             new Data(2011, 10, 20) { StandardPattern = LocalDatePattern.Iso, Pattern = "R", Text = "2011-10-20" },
             // Round trip with calendar system

--- a/src/NodaTime/Text/LocalDatePatternParser.cs
+++ b/src/NodaTime/Text/LocalDatePatternParser.cs
@@ -69,6 +69,7 @@ namespace NodaTime.Text
                     // Note: we don't just recurse, as otherwise a ShortDatePattern of 'd' (for example) would cause a stack overflow.
                     'd' => ParseNoStandardExpansion(formatInfo.DateTimeFormat.ShortDatePattern),
                     'D' => ParseNoStandardExpansion(formatInfo.DateTimeFormat.LongDatePattern),
+                    'M' => ParseNoStandardExpansion(formatInfo.DateTimeFormat.MonthDayPattern),
                     // Unknown standard patterns fail.
                     _ => throw new InvalidPatternException(TextErrorMessages.UnknownStandardFormat, patternText, typeof(LocalDate))
                 };


### PR DESCRIPTION
Fixes #1408.

Another commit will add documentation, but that needs to be in the nodatime.org repo.