### PR TITLE
Add GeneralIso pattern to LocalTimePattern

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTimeTests/Text/LocalTimePatternBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/Text/LocalTimePatternBenchmarks.cs
@@ -15,9 +15,6 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
         private static readonly string SampleIsoFormattedTime = "15:12:10";
         private static readonly string SampleIsoFormattedTimeWithNanos = "15:12:10.123456789";
 
-        // TODO: Make this a standard pattern.
-        private static readonly LocalTimePattern IsoPatternToSecond = LocalTimePattern.CreateWithInvariantCulture("HH:mm:ss");
-
         [Benchmark]
         public void ExtendedIso_Format() =>
             LocalTimePattern.ExtendedIso.Format(SampleLocalTimeToNanos);
@@ -28,10 +25,10 @@ namespace NodaTime.Benchmarks.NodaTimeTests.Text
 
         [Benchmark]
         public void IsoPatternToSecond_Format() =>
-            IsoPatternToSecond.Format(SampleLocalTimeToSecond);
+            LocalTimePattern.GeneralIso.Format(SampleLocalTimeToSecond);
 
         [Benchmark]
         public void IsoPatternToSecond_Parse() =>
-            IsoPatternToSecond.Parse(SampleIsoFormattedTime);
+            LocalTimePattern.GeneralIso.Parse(SampleIsoFormattedTime);
     }
 }

--- a/src/NodaTime.Test/Text/LocalTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalTimePatternTest.cs
@@ -264,6 +264,7 @@ namespace NodaTime.Test.Text
             new Data(14, 15, 16, 789) { StandardPattern = LocalTimePattern.LongExtendedIso, Culture = Cultures.DotTimeSeparator, Text = "14:15:16.789000000", Pattern = "O" },
             new Data(14, 15, 16, 789) { StandardPattern = LocalTimePattern.LongExtendedIso, Culture = Cultures.EnUs, Text = "14:15:16.789000000", Pattern = "O" },
             new Data(14, 15, 16) { StandardPattern = LocalTimePattern.LongExtendedIso, Culture = Cultures.Invariant, Text = "14:15:16.000000000", Pattern = "O" },
+            new Data(14, 15, 16) { StandardPattern = LocalTimePattern.GeneralIso, Culture = Cultures.Invariant, Text = "14:15:16", Pattern = "HH:mm:ss" },
 
             // ------------ Template value tests ----------
             // Mixtures of 12 and 24 hour times

--- a/src/NodaTime/Text/LocalTimePattern.cs
+++ b/src/NodaTime/Text/LocalTimePattern.cs
@@ -43,6 +43,13 @@ namespace NodaTime.Text
         /// <value>An invariant local time pattern which is ISO-8601 compatible, providing exactly 9 decimal places.</value>
         public static LocalTimePattern LongExtendedIso => Patterns.LongExtendedIsoPatternImpl;
 
+        /// <summary>
+        /// Gets an invariant local time pattern which is ISO-8601 compatible, with precision of just seconds.
+        /// This corresponds to the text pattern "HH':'mm':'ss".
+        /// </summary>
+        /// <value>An invariant local time pattern which is ISO-8601 compatible, with no sub-second precision.</value>
+        public static LocalTimePattern GeneralIso => Patterns.GeneralIsoPatternImpl;
+
         private const string DefaultFormatPattern = "T"; // Long
 
         internal static readonly PatternBclSupport<LocalTime> BclSupport =
@@ -56,6 +63,7 @@ namespace NodaTime.Text
         {
             internal static readonly LocalTimePattern ExtendedIsoPatternImpl = CreateWithInvariantCulture("HH':'mm':'ss;FFFFFFFFF");
             internal static readonly LocalTimePattern LongExtendedIsoPatternImpl = CreateWithInvariantCulture("HH':'mm':'ss;fffffffff");
+            internal static readonly LocalTimePattern GeneralIsoPatternImpl = CreateWithInvariantCulture("HH':'mm':'ss");
         }
 
         /// <summary>


### PR DESCRIPTION
(The property name is chosen to match LocalDateTimePattern.GeneralIso, which also only has second precision.)

I haven't introduced a standard pattern for this yet. There's no particularly obvious choice.