### PR TITLE
Fix CheckNotNull<T> cref

### DIFF
--- a/src/NodaTime/Utility/Preconditions.cs
+++ b/src/NodaTime/Utility/Preconditions.cs
@@ -28,8 +28,7 @@ namespace NodaTime.Utility
         }
 
         /// <summary>
-        /// Like <see cref="Preconditions.CheckNotNull"/>, but only checked in debug builds. (This means it can't return
-        /// anything...)
+        /// Like <see cref="CheckNotNull{T}"/>, but only checked in debug builds. (This means it can't return anything...)
         /// </summary>
         [Conditional("DEBUG")]
         [ContractAnnotation("argument:null => halt")]


### PR DESCRIPTION
The reference was missing the `<T>` thus making JetBrains Rider complain that it "cannot resolve symbol CheckNotNull".