### PR TITLE
Add rollForward=latestMinor in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.0.100"
+    "version": "3.0.100",
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
So that people can work with NodaTIme with any .NET Core 3.x SDK, see https://andrewlock.net/exploring-the-new-rollforward-and-allowprerelease-settings-in-global-json/ 

Note that rollForward policies are not (yet) supported by Rider: https://youtrack.jetbrains.com/issue/RIDER-38533