### PR TITLE
Extract conversion settings from DateTimeZoneProviders

### DIFF
--- a/src/NodaTime.Test/DateTimeZoneProvidersTest.cs
+++ b/src/NodaTime.Test/DateTimeZoneProvidersTest.cs
@@ -3,6 +3,8 @@
 // as found in the LICENSE.txt file.
 
 using System.Linq;
+using NodaTime.Testing.TimeZones;
+using NodaTime.Xml;
 using NUnit.Framework;
 
 namespace NodaTime.Test
@@ -30,6 +32,29 @@ namespace NodaTime.Test
         public void BclProviderUsesTimeZoneInfoSource()
         {
             Assert.IsTrue(DateTimeZoneProviders.Bcl.VersionId.StartsWith("TimeZoneInfo: "));
+        }
+
+        [Test]
+        public void SerializationDelegatesToXmlSerializerSettings()
+        {
+            var original = XmlSerializationSettings.DateTimeZoneProvider;
+
+            try
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                var provider1 = new FakeDateTimeZoneSource.Builder().Build().ToProvider();
+                DateTimeZoneProviders.Serialization = provider1;
+                Assert.AreSame(provider1, XmlSerializationSettings.DateTimeZoneProvider);
+
+                var provider2 = new FakeDateTimeZoneSource.Builder().Build().ToProvider();
+                XmlSerializationSettings.DateTimeZoneProvider = provider2;
+                Assert.AreSame(provider2, DateTimeZoneProviders.Serialization);
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+            finally
+            {
+                XmlSerializationSettings.DateTimeZoneProvider = original;
+            }
         }
     }
 }

--- a/src/NodaTime.Test/Text/TypeConvertersTest.cs
+++ b/src/NodaTime.Test/Text/TypeConvertersTest.cs
@@ -124,7 +124,7 @@ namespace NodaTime.Test.Text
         [TestCase(2018, 12, 31, 13, 30, "Asia/Kathmandu", "2018-12-31T13:30:00 Asia/Kathmandu (+05:45)")]
         public void ZonedDateTime_Roundtrip(int year, int month, int day, int hour, int minute, string zoneId, string text)
         {
-            Assert.AreSame(DateTimeZoneProviders.Tzdb, DateTimeZoneProviders.ForTypeConverter,
+            Assert.AreSame(DateTimeZoneProviders.Tzdb, TypeConverterSettings.DateTimeZoneProvider,
                 "Expected no other test to change DateTimeZoneProviders.ForTypeConverter");
             var zone = DateTimeZoneProviders.Tzdb[zoneId];
             AssertRoundtrip(text, new LocalDateTime(year, month, day, hour, minute).InZoneStrictly(zone));

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -9,6 +9,7 @@ using NodaTime.Calendars;
 using NodaTime.Testing.TimeZones;
 using NodaTime.Text;
 using NodaTime.TimeZones;
+using NodaTime.Xml;
 using NUnit.Framework;
 
 namespace NodaTime.Test
@@ -402,7 +403,7 @@ namespace NodaTime.Test
         [Test]
         public void XmlSerialization_Iso()
         {
-            DateTimeZoneProviders.Serialization = DateTimeZoneProviders.Tzdb;
+            XmlSerializationSettings.DateTimeZoneProvider = DateTimeZoneProviders.Tzdb;
             var zone = DateTimeZoneProviders.Tzdb["America/New_York"];
             var value = new ZonedDateTime(new LocalDateTime(2013, 4, 12, 17, 53, 23).WithOffset(Offset.FromHours(-4)), zone);
             TestHelper.AssertXmlRoundtrip(value, "<value zone=\"America/New_York\">2013-04-12T17:53:23-04</value>");
@@ -424,7 +425,7 @@ namespace NodaTime.Test
                 return;
             }
 
-            DateTimeZoneProviders.Serialization = DateTimeZoneProviders.Bcl;
+            XmlSerializationSettings.DateTimeZoneProvider = DateTimeZoneProviders.Bcl;
             var value = new ZonedDateTime(new LocalDateTime(2013, 4, 12, 17, 53, 23).WithOffset(Offset.FromHours(-4)), zone);
             TestHelper.AssertXmlRoundtrip(value, "<value zone=\"Eastern Standard Time\">2013-04-12T17:53:23-04</value>");
         }
@@ -432,7 +433,7 @@ namespace NodaTime.Test
         [Test]
         public void XmlSerialization_NonIso()
         {
-            DateTimeZoneProviders.Serialization = DateTimeZoneProviders.Tzdb;
+            XmlSerializationSettings.DateTimeZoneProvider = DateTimeZoneProviders.Tzdb;
             var zone = DateTimeZoneProviders.Tzdb["America/New_York"];
             var localDateTime = new LocalDateTime(2013, 6, 12, 17, 53, 23, CalendarSystem.Julian);
             var value = new ZonedDateTime(localDateTime.WithOffset(Offset.FromHours(-4)), zone);
@@ -447,7 +448,7 @@ namespace NodaTime.Test
         [TestCase("<value zone=\"Europe/London\">2013-04-12T17:53:23-04</value>", typeof(UnparsableValueException), Description = "Incorrect offset")]
         public void XmlSerialization_Invalid(string xml, Type expectedExceptionType)
         {
-            DateTimeZoneProviders.Serialization = DateTimeZoneProviders.Tzdb;
+            XmlSerializationSettings.DateTimeZoneProvider = DateTimeZoneProviders.Tzdb;
             TestHelper.AssertXmlInvalid<ZonedDateTime>(xml, expectedExceptionType);
         }
 

--- a/src/NodaTime/DateTimeZoneProviders.cs
+++ b/src/NodaTime/DateTimeZoneProviders.cs
@@ -4,6 +4,7 @@
 
 using NodaTime.TimeZones;
 using NodaTime.Utility;
+using System;
 
 namespace NodaTime
 {
@@ -49,71 +50,17 @@ namespace NodaTime
         /// <value>A time zone provider which uses a <c>BclDateTimeZoneSource</c>.</value>
         public static IDateTimeZoneProvider Bcl => BclHolder.BclImpl;
 
-        private static readonly object serializationProviderLock = new object();
-        private static IDateTimeZoneProvider? serializationProvider;
-
-        private static readonly object typeConverterProviderLock = new object();
-        private static IDateTimeZoneProvider? typeConverterProvider;
-
         /// <summary>
         /// Gets the <see cref="IDateTimeZoneProvider"/> to use to interpret a time zone ID read as part of
-        /// XML or binary serialization.
+        /// XML serialization. This property is obsolete as of version 3.0; the functionality still exists
+        /// in <see cref="Xml.XmlSerializationSettings.DateTimeZoneProvider"/>, which this property delegates
+        /// to. (The behavior has not changed; this is purely an exercise in moving/renaming.)
         /// </summary>
-        /// <remarks>
-        /// This property defaults to <see cref="DateTimeZoneProviders.Tzdb"/>. The mere existence of
-        /// this property is unfortunate, but XML serialization in .NET provides no simple way of configuring
-        /// appropriate context. It is expected that any single application is unlikely to want to serialize
-        /// <c>ZonedDateTime</c> values using different time zone providers.
-        /// </remarks>
-        /// <value>The <c>IDateTimeZoneProvider</c> to use to interpret a time zone ID read as part of
-        /// XML serialization.</value>
+        [Obsolete("This property exists primarily for binary backward compatibility. Please use NodaTime.Xml.XmlSerializationSettings.DateTimeZoneProvider instead.")]
         public static IDateTimeZoneProvider Serialization
         {
-            get
-            {
-                lock (serializationProviderLock)
-                {
-                    return serializationProvider ?? (serializationProvider = Tzdb);
-                }
-            }
-            set
-            {
-                lock (serializationProviderLock)
-                {
-                    serializationProvider = Preconditions.CheckNotNull(value, nameof(value));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="IDateTimeZoneProvider"/> to use to interpret a time zone ID read as part of
-        /// conversion using the default <see cref="System.ComponentModel.TypeConverter"/> for <see cref="ZonedDateTime"/>.
-        /// Note that if a value other than <see cref="DateTimeZoneProviders.Tzdb"/> is required, it should be set on
-        /// application startup, before any type converters are used. Type converters are cached internally by the framework,
-        /// so changes to this property after the first type converter for <see cref="ZonedDateTime"/> is created will
-        /// not generally be visible.
-        /// </summary>
-        /// <remarks>
-        /// This property defaults to <see cref="DateTimeZoneProviders.Tzdb"/>.
-        /// </remarks>
-        /// <value>The <c>IDateTimeZoneProvider</c> to use to interpret a time zone ID read as part of
-        /// conversion using the default <see cref="System.ComponentModel.TypeConverter"/>.</value>
-        public static IDateTimeZoneProvider ForTypeConverter
-        {
-            get
-            {
-                lock (typeConverterProviderLock)
-                {
-                    return typeConverterProvider ?? (typeConverterProvider = Tzdb);
-                }
-            }
-            set
-            {
-                lock (typeConverterProviderLock)
-                {
-                    typeConverterProvider = Preconditions.CheckNotNull(value, nameof(value));
-                }
-            }
+            get => Xml.XmlSerializationSettings.DateTimeZoneProvider;
+            set => Xml.XmlSerializationSettings.DateTimeZoneProvider = value;
         }
     }
 }

--- a/src/NodaTime/Text/TypeConverterSettings.cs
+++ b/src/NodaTime/Text/TypeConverterSettings.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2020 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Utility;
+
+namespace NodaTime.Text
+{
+    /// <summary>
+    /// Ambient settings applied for the default type converters. There's no simple context
+    /// to express this information in a more elegant way, although users can create their
+    /// own type converters to apply if they wish to.
+    /// </summary>
+    public static class TypeConverterSettings
+    {
+        private static readonly object stateLock = new object();
+
+        private static IDateTimeZoneProvider dateTimeZoneProvider = DateTimeZoneProviders.Tzdb;
+
+        /// <summary>
+        /// Gets the <see cref="IDateTimeZoneProvider"/> to use to interpret a time zone ID read as part of
+        /// a TypeConverter operation for a <see cref="ZonedDateTime"/>.
+        /// Note that if a value other than <see cref="DateTimeZoneProviders.Tzdb"/> is required, it should be set on
+        /// application startup, before any type converters are used. Type converters are cached internally by the framework,
+        /// so changes to this property after the first type converter for <see cref="ZonedDateTime"/> is created will
+        /// not generally be visible.
+        /// </summary>
+        /// <remarks>
+        /// This property defaults to <see cref="DateTimeZoneProviders.Tzdb"/>.
+        /// </remarks>
+        /// <value>The <c>IDateTimeZoneProvider</c> to use to interpret a time zone ID read as part of
+        /// XML serialization.</value>
+        public static IDateTimeZoneProvider DateTimeZoneProvider
+        {
+            get
+            {
+                lock (stateLock)
+                {
+                    return dateTimeZoneProvider;
+                }
+            }
+            set
+            {
+                lock (stateLock)
+                {
+                    dateTimeZoneProvider = Preconditions.CheckNotNull(value, nameof(value));
+                }
+            }
+        }
+    }
+}

--- a/src/NodaTime/Text/TypeConverters.cs
+++ b/src/NodaTime/Text/TypeConverters.cs
@@ -64,9 +64,9 @@ namespace NodaTime.Text
     internal sealed class ZonedDateTimeTypeConverter : TypeConverterBase<ZonedDateTime>
     {
         /// <summary>
-        /// Cached pattern based on <see cref="DateTimeZoneProviders.ForTypeConverter"/>.
+        /// Cached pattern based on <see cref="TypeConverterSettings.DateTimeZoneProvider"/>.
         /// This avoids us creating more patterns than we need, but still allows changes in
-        /// <see cref="DateTimeZoneProviders.ForTypeConverter"/> to be reflected appropriately.
+        /// <see cref="TypeConverterSettings.DateTimeZoneProvider"/> to be reflected appropriately.
         /// </summary>
         private static ZonedDateTimePattern? cachedPattern;
 
@@ -79,7 +79,7 @@ namespace NodaTime.Text
             // It's also unlikely that this will ever be called more than once, due to framework caching
             // of type converters. But at least we'll make it feasible.
             ZonedDateTimePattern? cached = cachedPattern;
-            IDateTimeZoneProvider provider = DateTimeZoneProviders.ForTypeConverter;
+            IDateTimeZoneProvider provider = TypeConverterSettings.DateTimeZoneProvider;
             if (cached?.ZoneProvider != provider)
             {
                 cached = ZonedDateTimePattern.ExtendedFormatOnlyIso.WithZoneProvider(provider);

--- a/src/NodaTime/Xml/XmlSchemaDefinition.cs
+++ b/src/NodaTime/Xml/XmlSchemaDefinition.cs
@@ -62,7 +62,7 @@ namespace NodaTime.Xml
             var calendarRestriction = CreateEnumerationRestriction("calendar", xsStringType, CalendarSystem.Ids);
             var localDateRestriction = CreatePatternRestriction("localDate", xsStringType, $"{YearPattern}-{MonthPattern}-{DayPattern}");
             var localDateTimeRestriction = CreatePatternRestriction("localDateTime", xsStringType,  $"{YearPattern}-{MonthPattern}-{DayPattern}T{TimePattern}");
-            var zoneIds = CreateEnumerationRestriction("zoneIds", xsStringType, DateTimeZoneProviders.Serialization.GetAllZones().Select(e => e.Id));
+            var zoneIds = CreateEnumerationRestriction("zoneIds", xsStringType, XmlSerializationSettings.DateTimeZoneProvider.GetAllZones().Select(e => e.Id));
             // The "zoneIds" purpose is to document the known zone identifiers. The "zone" restriction is a union between known zone ids and
             // xs:string so that validation won't fail when a new zone identifier is added to the Time Zone Database.
             var zoneRestriction = QualifySchemaType(new XmlSchemaSimpleType

--- a/src/NodaTime/Xml/XmlSerializationSettings.cs
+++ b/src/NodaTime/Xml/XmlSerializationSettings.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2020 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Utility;
+
+namespace NodaTime.Xml
+{
+    /// <summary>
+    /// Ambient settings applied during XML serialization and deserialization.
+    /// XML serialization in .NET does not provide any "hooks" for advanced configuration.
+    /// Most of the time that's a good thing, in terms of compatibility: we want
+    /// the same data to be serialized the same way across multiple programs for
+    /// interoperability. There are some exceptions to this however, where decisions
+    /// need to be made and there's no single "right for everyone" choice.
+    /// </summary>
+    public static class XmlSerializationSettings
+    {
+        private static readonly object stateLock = new object();
+
+        private static IDateTimeZoneProvider dateTimeZoneProvider = DateTimeZoneProviders.Tzdb;
+
+        /// <summary>
+        /// Gets the <see cref="IDateTimeZoneProvider"/> to use to interpret a time zone ID read as part of
+        /// XML serialization.
+        /// </summary>
+        /// <remarks>
+        /// This property defaults to <see cref="DateTimeZoneProviders.Tzdb"/>.
+        /// </remarks>
+        /// <value>The <c>IDateTimeZoneProvider</c> to use to interpret a time zone ID read as part of
+        /// XML serialization.</value>
+        public static IDateTimeZoneProvider DateTimeZoneProvider
+        {
+            get
+            {
+                lock (stateLock)
+                {
+                    return dateTimeZoneProvider;
+                }
+            }
+            set
+            {
+                lock (stateLock)
+                {
+                    dateTimeZoneProvider = Preconditions.CheckNotNull(value, nameof(value));
+                }
+            }
+        }
+    }
+}

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -809,7 +809,7 @@ namespace NodaTime
             {
                 throw new ArgumentException("No zone specified in XML for ZonedDateTime");
             }
-            DateTimeZone newZone = DateTimeZoneProviders.Serialization[reader.Value];
+            DateTimeZone newZone = Xml.XmlSerializationSettings.DateTimeZoneProvider[reader.Value];
             if (reader.MoveToAttribute("calendar"))
             {
                 string newCalendarId = reader.Value;


### PR DESCRIPTION
Fixes #1505.

I've left a deprecated property for DateTimeZoneProviders.Serialization.
While moving to 3.0 means we *can* break anything, we actually
restricted the breaking changes to "removing binary serialization"
(and removing incorrectly named method that's been deprecated since
2.1 was released in 2017).

The ForTypeConverter property is new in 3.0, so doesn't need
deprecation. I'll add it to release notes for any existing beta
users, but it should be okay to move. (I'll release a new beta
shortly after this goes in.)

cc @0xced 