### PR TITLE
Update documentation to clarify availability of BclDateTimeZone in 3.0.

### DIFF
--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -63,12 +63,12 @@ namespace NodaTime
     /// To obtain a <see cref="DateTimeZone"/> representing the system default time zone, you can either call
     /// <see cref="IDateTimeZoneProvider.GetSystemDefault"/> on a provider to obtain the <see cref="DateTimeZone"/> that
     /// the provider considers matches the system default time zone, or you can construct a
-    /// <c>BclDateTimeZone</c> via <c>BclDateTimeZone.ForSystemDefault</c>, which returns a
+    /// <see cref="BclDateTimeZone"/> via <see cref="BclDateTimeZone.ForSystemDefault"/>, which returns a
     /// <see cref="DateTimeZone"/> that wraps the system local <see cref="TimeZoneInfo"/>. The latter will always
     /// succeed, but has access only to that information available via the .NET time zone; the former may contain more
     /// complete data, but may (in uncommon cases) fail to find a matching <see cref="DateTimeZone"/>.
-    /// Note that <c>BclDateTimeZone</c> is not available on the .NET Standard 1.3 build of Noda Time, so this fallback strategy can
-    /// only be used with the desktop version.
+    /// Note that <c>BclDateTimeZone</c> may not be available in all versions of Noda Time 1.x and 2.x; see the class
+    /// documentation for more details.
     /// </para>
     /// <para>
     /// Note that Noda Time does not require that <see cref="DateTimeZone"/> instances be singletons.

--- a/src/NodaTime/DateTimeZoneProviders.cs
+++ b/src/NodaTime/DateTimeZoneProviders.cs
@@ -45,7 +45,13 @@ namespace NodaTime
         /// This property is not available on the .NET Standard 1.3 build of Noda Time.
         /// </summary>
         /// <remarks>
-        /// <para>See note on <see cref="BclDateTimeZone"/> for details of some incompatibilities with the BCL.</para>
+        /// <para>
+        /// See note on <see cref="BclDateTimeZone"/> for details of some incompatibilities with the BCL.
+        /// </para>
+        /// <para>
+        /// In Noda Time 1.x and 2.x, this property is only available on the .NET Framework builds of Noda Time, and not
+        /// the PCL (Noda Time 1.x) or .NET Standard 1.3 (Noda Time 2.x) builds.
+        /// </para>
         /// </remarks>
         /// <value>A time zone provider which uses a <c>BclDateTimeZoneSource</c>.</value>
         public static IDateTimeZoneProvider Bcl => BclHolder.BclImpl;

--- a/src/NodaTime/IDateTimeZoneProvider.cs
+++ b/src/NodaTime/IDateTimeZoneProvider.cs
@@ -62,8 +62,9 @@ namespace NodaTime
         /// If it is necessary to handle this case, callers can construct a
         /// <see cref="BclDateTimeZone"/> via <see cref="BclDateTimeZone.ForSystemDefault"/>, which returns a
         /// <see cref="DateTimeZone"/> that wraps the system local <see cref="TimeZoneInfo"/>, and which always
-        /// succeeds. Note that <c>BclDateTimeZone</c> is not available on the .NET Standard 1.3 build of Noda Time, so
-        /// this fallback strategy can only be used with the desktop version.
+        /// succeeds.
+        /// Note that <c>BclDateTimeZone</c> may not be available in all versions of Noda Time 1.x and 2.x; see
+        /// the class documentation for more details.
         /// </para>
         /// </remarks>
         /// <exception cref="DateTimeZoneNotFoundException">The system default time zone is not mapped by

--- a/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
@@ -19,7 +19,8 @@ namespace NodaTime.TimeZones
     /// (i.e. "UTC" and "UTC+/-Offset").
     /// </para>
     /// <para>
-    /// This class is not available in the .NET Standard 1.3 version.
+    /// In Noda Time 1.x and 2.x, this class is only available on the .NET Framework builds of Noda Time, and not the
+    /// PCL (Noda Time 1.x) or .NET Standard 1.3 (Noda Time 2.x) builds.
     /// </para>
     /// </remarks>
     /// <threadsafety>This type maintains no state, and all members are thread-safe. See the thread safety section of the user guide for more information.</threadsafety>


### PR DESCRIPTION
As originally noted in nodatime/nodatime.org#78, there are a few places that still talk about the (non-)availability of `BclDateTimeZone`. This updates all of them to use the same prose (and also add a `<see cref=""/>` that I assume was omitted before due to conditional compilation).