### PR TITLE
Add equality operators for Period and ZoneInterval

### DIFF
--- a/src/NodaTime.Test/ConsistencyTest.cs
+++ b/src/NodaTime.Test/ConsistencyTest.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2020 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.TimeZones.Cldr;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace NodaTime.Test
+{
+    /// <summary>
+    /// Tests using reflection to check that types are consistent.
+    /// </summary>
+    public class ConsistencyTest
+    {
+        private static IEnumerable<Type> AllPublicTypes = typeof(LocalDate).Assembly
+            .GetTypes()
+            .Where(t => t.IsPublic)
+            .ToList();
+
+        [Test]
+        public void EqualityOperatorForEquatable()
+        {
+            var expectedExceptions = new[] { typeof(MapZone) };
+
+            var failures = AllPublicTypes
+                .Where(t => typeof(IEquatable<>).MakeGenericType(t).IsAssignableFrom(t))
+                .Where(t => t.GetMethod("op_Equality") is null)
+                .Except(expectedExceptions)
+                .ToList();
+            Assert.IsEmpty(failures);
+        }
+    }
+}

--- a/src/NodaTime.Test/ConsistencyTest.cs
+++ b/src/NodaTime.Test/ConsistencyTest.cs
@@ -33,5 +33,18 @@ namespace NodaTime.Test
                 .ToList();
             Assert.IsEmpty(failures);
         }
+
+        [Test]
+        public void ComparisonOperatorForComparable()
+        {
+            var expectedExceptions = new Type[] { };
+
+            var failures = AllPublicTypes
+                .Where(t => typeof(IComparable<>).MakeGenericType(t).IsAssignableFrom(t))
+                .Where(t => t.GetMethod("op_LessThan") is null || t.GetMethod("op_LessThanOrEqual") is null)
+                .Except(expectedExceptions)
+                .ToList();
+            Assert.IsEmpty(failures);
+        }
     }
 }

--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -438,6 +438,28 @@ namespace NodaTime.Test
         }
 
         [Test]
+        public void EqualityOperators()
+        {
+            Period val1 = Period.FromHours(1);
+            Period val2 = Period.FromHours(1);
+            Period val3 = Period.FromHours(2);
+            Period? val4 = null;
+            Assert.IsTrue(val1 == val2);
+            Assert.IsFalse(val1 == val3);
+            Assert.IsFalse(val1 == val4);
+            Assert.IsFalse(val4 == val1);
+            Assert.IsTrue(val4 == null);
+            Assert.IsTrue(null == val4);
+
+            Assert.IsFalse(val1 != val2);
+            Assert.IsTrue(val1 != val3);
+            Assert.IsTrue(val1 != val4);
+            Assert.IsTrue(val4 != val1);
+            Assert.IsFalse(val4 != null);
+            Assert.IsFalse(null != val4);
+        }
+
+        [Test]
         [TestCase(PeriodUnits.Years, false)]
         [TestCase(PeriodUnits.Weeks, false)]
         [TestCase(PeriodUnits.Months, false)]

--- a/src/NodaTime.Test/TimeZones/ZoneIntervalTest.cs
+++ b/src/NodaTime.Test/TimeZones/ZoneIntervalTest.cs
@@ -127,6 +127,29 @@ namespace NodaTime.Test.TimeZones
         }
 
         [Test]
+        public void EqualityOperators()
+        {
+            ZoneInterval val1 = new ZoneInterval("name", SampleStart, SampleEnd, Offset.FromHours(1), Offset.FromHours(2));
+            ZoneInterval val2 = new ZoneInterval("name", SampleStart, SampleEnd, Offset.FromHours(1), Offset.FromHours(2));
+            ZoneInterval val3 = new ZoneInterval("name2", SampleStart, SampleEnd, Offset.FromHours(1), Offset.FromHours(2));
+            ZoneInterval? val4 = null;
+
+            Assert.IsTrue(val1 == val2);
+            Assert.IsFalse(val1 == val3);
+            Assert.IsFalse(val1 == val4);
+            Assert.IsFalse(val4 == val1);
+            Assert.IsTrue(val4 == null);
+            Assert.IsTrue(null == val4);
+
+            Assert.IsFalse(val1 != val2);
+            Assert.IsTrue(val1 != val3);
+            Assert.IsTrue(val1 != val4);
+            Assert.IsTrue(val4 != val1);
+            Assert.IsFalse(val4 != null);
+            Assert.IsFalse(null != val4);
+        }
+
+        [Test]
         public void ZoneIntervalToString()
         {
             using (CultureSaver.SetCultures(CultureInfo.InvariantCulture))

--- a/src/NodaTime.Test/YearMonthTest.Comparison.cs
+++ b/src/NodaTime.Test/YearMonthTest.Comparison.cs
@@ -70,11 +70,9 @@ namespace NodaTime.Test
         {
             YearMonth yearMonth1 = new YearMonth(2011, 1);
             YearMonth yearMonth2 = new YearMonth(2011, 1);
-            YearMonth date3 = new YearMonth(2011, 2);
+            YearMonth yearMonth3 = new YearMonth(2011, 2);
 
-            Assert.That(yearMonth1.CompareTo(yearMonth2), Is.EqualTo(0));
-            Assert.That(yearMonth1.CompareTo(date3), Is.LessThan(0));
-            Assert.That(date3.CompareTo(yearMonth2), Is.GreaterThan(0));
+            TestHelper.TestOperatorComparisonEquality(yearMonth1, yearMonth2, yearMonth3);
         }
 
         [Test]
@@ -86,6 +84,7 @@ namespace NodaTime.Test
 
             Assert.Throws<ArgumentException>(() => yearMonth1.CompareTo(yearMonth2));
             Assert.Throws<ArgumentException>(() => ((IComparable) yearMonth1).CompareTo(yearMonth2));
+            Assert.Throws<ArgumentException>(() => (yearMonth1 > yearMonth2).ToString());
         }
 
         /// <summary>

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -823,6 +823,24 @@ namespace NodaTime
             Milliseconds == other.Milliseconds &&
             Ticks == other.Ticks &&
             Nanoseconds == other.Nanoseconds;
+
+        /// <summary>
+        /// Implements the operator == (equality).
+        /// See the type documentation for a description of equality semantics.
+        /// </summary>
+        /// <param name="left">The left hand side of the operator.</param>
+        /// <param name="right">The right hand side of the operator.</param>
+        /// <returns><c>true</c> if values are equal to each other, otherwise <c>false</c>.</returns>
+        public static bool operator ==(Period? left, Period? right) => ReferenceEquals(left, right) || (left is object && left.Equals(right));
+
+        /// <summary>
+        /// Implements the operator != (inequality).
+        /// See the type documentation for a description of equality semantics.
+        /// </summary>
+        /// <param name="left">The left hand side of the operator.</param>
+        /// <param name="right">The right hand side of the operator.</param>
+        /// <returns><c>true</c> if values are not equal to each other, otherwise <c>false</c>.</returns>
+        public static bool operator !=(Period? left, Period? right) => !(left == right);
         #endregion
 
         /// <summary>

--- a/src/NodaTime/TimeZones/ZoneInterval.cs
+++ b/src/NodaTime/TimeZones/ZoneInterval.cs
@@ -283,6 +283,24 @@ namespace NodaTime.TimeZones
             return Name == other.Name && RawStart == other.RawStart && RawEnd == other.RawEnd
                 && WallOffset == other.WallOffset && Savings == other.Savings;
         }
+
+        /// <summary>
+        /// Implements the operator == (equality).
+        /// See the type documentation for a description of equality semantics.
+        /// </summary>
+        /// <param name="left">The left hand side of the operator.</param>
+        /// <param name="right">The right hand side of the operator.</param>
+        /// <returns><c>true</c> if values are equal to each other, otherwise <c>false</c>.</returns>
+        public static bool operator ==(ZoneInterval? left, ZoneInterval? right) => ReferenceEquals(left, right) || (left is object && left.Equals(right));
+
+        /// <summary>
+        /// Implements the operator != (inequality).
+        /// See the type documentation for a description of equality semantics.
+        /// </summary>
+        /// <param name="left">The left hand side of the operator.</param>
+        /// <param name="right">The right hand side of the operator.</param>
+        /// <returns><c>true</c> if values are not equal to each other, otherwise <c>false</c>.</returns>
+        public static bool operator !=(ZoneInterval? left, ZoneInterval? right) => !(left == right);
         #endregion
 
         #region object Overrides

--- a/src/NodaTime/YearMonth.cs
+++ b/src/NodaTime/YearMonth.cs
@@ -195,6 +195,66 @@ namespace NodaTime
         }
 
         /// <summary>
+        /// Compares two YearMonth values to see if the left one is strictly earlier than the right one.
+        /// See the type documentation for a description of ordering semantics.
+        /// </summary>
+        /// <param name="lhs">First operand of the comparison</param>
+        /// <param name="rhs">Second operand of the comparison</param>
+        /// <exception cref="ArgumentException">The calendar system of <paramref name="rhs"/> is not the same
+        /// as the calendar of <paramref name="lhs"/>.</exception>
+        /// <returns>true if the <paramref name="lhs"/> is strictly earlier than <paramref name="rhs"/>, false otherwise.</returns>
+        public static bool operator <(YearMonth lhs, YearMonth rhs)
+        {
+            Preconditions.CheckArgument(lhs.Calendar.Equals(rhs.Calendar), nameof(rhs), "Only values in the same calendar can be compared");
+            return lhs.CompareTo(rhs) < 0;
+        }
+
+        /// <summary>
+        /// Compares two YearMonth values to see if the left one is earlier than or equal to the right one.
+        /// See the type documentation for a description of ordering semantics.
+        /// </summary>
+        /// <param name="lhs">First operand of the comparison</param>
+        /// <param name="rhs">Second operand of the comparison</param>
+        /// <exception cref="ArgumentException">The calendar system of <paramref name="rhs"/> is not the same
+        /// as the calendar of <paramref name="lhs"/>.</exception>
+        /// <returns>true if the <paramref name="lhs"/> is earlier than or equal to <paramref name="rhs"/>, false otherwise.</returns>
+        public static bool operator <=(YearMonth lhs, YearMonth rhs)
+        {
+            Preconditions.CheckArgument(lhs.Calendar.Equals(rhs.Calendar), nameof(rhs), "Only values in the same calendar can be compared");
+            return lhs.CompareTo(rhs) <= 0;
+        }
+
+        /// <summary>
+        /// Compares two YearMonth values to see if the left one is strictly later than the right one.
+        /// See the type documentation for a description of ordering semantics.
+        /// </summary>
+        /// <param name="lhs">First operand of the comparison</param>
+        /// <param name="rhs">Second operand of the comparison</param>
+        /// <exception cref="ArgumentException">The calendar system of <paramref name="rhs"/> is not the same
+        /// as the calendar of <paramref name="lhs"/>.</exception>
+        /// <returns>true if the <paramref name="lhs"/> is strictly later than <paramref name="rhs"/>, false otherwise.</returns>
+        public static bool operator >(YearMonth lhs, YearMonth rhs)
+        {
+            Preconditions.CheckArgument(lhs.Calendar.Equals(rhs.Calendar), nameof(rhs), "Only values in the same calendar can be compared");
+            return lhs.CompareTo(rhs) > 0;
+        }
+
+        /// <summary>
+        /// Compares two YearMonth values to see if the left one is later than or equal to the right one.
+        /// See the type documentation for a description of ordering semantics.
+        /// </summary>
+        /// <param name="lhs">First operand of the comparison</param>
+        /// <param name="rhs">Second operand of the comparison</param>
+        /// <exception cref="ArgumentException">The calendar system of <paramref name="rhs"/> is not the same
+        /// as the calendar of <paramref name="lhs"/>.</exception>
+        /// <returns>true if the <paramref name="lhs"/> is later than or equal to <paramref name="rhs"/>, false otherwise.</returns>
+        public static bool operator >=(YearMonth lhs, YearMonth rhs)
+        {
+            Preconditions.CheckArgument(lhs.Calendar.Equals(rhs.Calendar), nameof(rhs), "Only values in the same calendar can be compared");
+            return lhs.CompareTo(rhs) >= 0;
+        }
+
+        /// <summary>
         /// Returns a hash code for this year/month.
         /// See the type documentation for a description of equality semantics.
         /// </summary>


### PR DESCRIPTION
Additionally, add a check to ensure we don't miss this again, at
least for anything implementing `IEquatable<T>`

Fixes #1529.