### PR TITLE
Fix benchmark runs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,11 @@
   
   <!-- Common properties across all projects (or ones that at least aren't harmful) -->
   <PropertyGroup>
+    <!-- Make the repository root available for other properties -->
+    <RepoRoot>$([System.IO.Path]::GetDirectoryName('$(MSBuildThisFileDirectory)'))</RepoRoot>
+
     <!-- Build properties -->
-    <AssemblyOriginatorKeyFile>../../NodaTime Release.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(RepoRoot)/NodaTime Release.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>


### PR DESCRIPTION
I'm not sure how they worked before, but using a relative path for a signing file in Directory.Build.props caused the execution-time building of benchmarks to fail.
This fix finds the repository root and uses the key from there instead.