### PR TITLE
Fix XmlSchemaDemo on .NET Framework

### DIFF
--- a/src/NodaTime.Demo/XmlSchemaDemo.XmlCodeExporterAssemblyCreator.cs
+++ b/src/NodaTime.Demo/XmlSchemaDemo.XmlCodeExporterAssemblyCreator.cs
@@ -80,13 +80,13 @@ namespace NodaTime.Demo
                 }
                 CodeGenerator.ValidateIdentifiers(codeNamespace);
 #else
-                throw new PlatformNotSupportedException($"{nameof(XmlCodeExporterAssemblyCreator)} is not available");
+                throw new PlatformNotSupportedException($"{nameof(XmlCodeExporterAssemblyCreator)} is only available on .NET Framework");
 #endif
             }
 
             private static Assembly Compile(CodeNamespace codeNamespace)
             {
-                var referencedAssemblies = new List<string> { typeof(Instant).Assembly.Location, "System", "System.Xml" };
+                var referencedAssemblies = new List<string> { typeof(Instant).Assembly.Location, "System.dll", "System.Xml.dll" };
                 try
                 {
                     // mono needs the absolute path to netstandard.dll, but Assembly.Load("netstandard") fails on .NET Framework

--- a/src/NodaTime.Demo/XmlSchemaDemo.XmlSchemaClassGeneratorAssemblyCreator.cs
+++ b/src/NodaTime.Demo/XmlSchemaDemo.XmlSchemaClassGeneratorAssemblyCreator.cs
@@ -75,15 +75,23 @@ namespace NodaTime.Demo
 
                 generator.Generate(schemaSet);
 
-                var systemDependencies = new List<string> { "netstandard", "System.ComponentModel.Primitives", "System.Diagnostics.Tools", "System.Runtime", "System.Xml.XmlSerializer" };
+                var systemDependencies = new List<string>
+                {
 #if NETFRAMEWORK
-                systemDependencies.Add("mscorlib");
-                systemDependencies.Add("System");
-                systemDependencies.Add("System.Xml");
+                    "netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51",
+                    "mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
+                    "System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
 #else
-                systemDependencies.Add("System.Private.CoreLib");
-                systemDependencies.Add("System.Private.Xml");
+                    "netstandard",
+                    "System.ComponentModel.Primitives",
+                    "System.Diagnostics.Tools",
+                    "System.Private.CoreLib",
+                    "System.Private.Xml",
+                    "System.Runtime",
+                    "System.Xml.XmlSerializer",
 #endif
+                };
                 var references = systemDependencies.Select(e => Assembly.Load(e).Location)
                     .Append(typeof(Instant).Assembly.Location)
                     .Select(p => MetadataReference.CreateFromFile(p));


### PR DESCRIPTION
Mono is cool about loading system assemblies by just providing a simple name. But .NET Framework on Windows is more strict and needs the full assembly name, including the version, culture and public key token.

Without the full assembly name, exception like this would be thrown:
System.IO.FileNotFoundException : Could not load file or assembly 'System' or one of its dependencies. The system cannot find the file specified.

Note that Mono seems to completely ignore the additional version, culture and public key token information when loading the assemblies. It's even possible to change the version to a non existing version (e.g. 6.6.6.6) and Mono loads the assembly anyway.