### PR TITLE
Clean up some more documentation in preparation for a 3.0 release.

### DIFF
--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -186,7 +186,7 @@ namespace NodaTime
         /// purely mathematical calculator, applied proleptically to the period where the real calendar was observational. 
         /// </summary>
         /// <remarks>
-        /// <para>Please note that in version 1.3.0 of Noda Time, support for the Hebrew calendar is somewhat experimental,
+        /// <para>Please note that support for the Hebrew calendar is somewhat experimental,
         /// particularly in terms of calculations involving adding or subtracting years. Additionally, text formatting
         /// and parsing using month names is not currently supported, due to the challenges of handling leap months.
         /// It is hoped that this will be improved in future versions.</para>

--- a/src/NodaTime/DateTimeZoneProviders.cs
+++ b/src/NodaTime/DateTimeZoneProviders.cs
@@ -42,7 +42,6 @@ namespace NodaTime
 
         /// <summary>
         /// Gets a time zone provider which uses a <see cref="BclDateTimeZoneSource"/>.
-        /// This property is not available on the .NET Standard 1.3 build of Noda Time.
         /// </summary>
         /// <remarks>
         /// <para>


### PR DESCRIPTION
(This is partly a followup to 5046177, which added some extra paragraphs
about DateTimeZoneProviders.Bcl.)