### PR TITLE
Implement a TypeConverter for YearMonth

### DIFF
--- a/src/NodaTime.Test/Text/TypeConvertersTest.cs
+++ b/src/NodaTime.Test/Text/TypeConvertersTest.cs
@@ -2,12 +2,10 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using NodaTime.Text;
+using NUnit.Framework;
 using System;
 using System.ComponentModel;
-using NodaTime.Testing.TimeZones;
-using NodaTime.Text;
-using NodaTime.TimeZones;
-using NUnit.Framework;
 
 namespace NodaTime.Test.Text
 {
@@ -25,6 +23,8 @@ namespace NodaTime.Test.Text
         [TestCase(typeof(OffsetDateTime))]
         [TestCase(typeof(OffsetTime))]
         [TestCase(typeof(Period))]
+        [TestCase(typeof(YearMonth))]
+        [TestCase(typeof(ZonedDateTime))]
         public void HasConverter(Type type)
         {
             var converter = TypeDescriptor.GetConverter(type);
@@ -129,6 +129,12 @@ namespace NodaTime.Test.Text
             var zone = DateTimeZoneProviders.Tzdb[zoneId];
             AssertRoundtrip(text, new LocalDateTime(year, month, day, hour, minute).InZoneStrictly(zone));
         }
+
+        [Test]
+        [TestCase(2020, 5, "2020-05")]
+        [TestCase(1976, 6, "1976-06")]
+        public void YearMonth_RoundTrip(int year, int month, string text) =>
+            AssertRoundtrip(text, new YearMonth(year, month));
 
         private static void AssertRoundtrip<T>(string textEquivalent, T nodaValue)
         {

--- a/src/NodaTime/Text/TypeConverters.cs
+++ b/src/NodaTime/Text/TypeConverters.cs
@@ -61,6 +61,11 @@ namespace NodaTime.Text
         public PeriodTypeConverter() : base(PeriodPattern.Roundtrip) { }
     }
 
+    internal sealed class YearMonthTypeConverter : TypeConverterBase<YearMonth>
+    {
+        public YearMonthTypeConverter() : base(YearMonthPattern.Iso) { }
+    }
+
     internal sealed class ZonedDateTimeTypeConverter : TypeConverterBase<ZonedDateTime>
     {
         /// <summary>

--- a/src/NodaTime/YearMonth.cs
+++ b/src/NodaTime/YearMonth.cs
@@ -8,6 +8,7 @@ using NodaTime.Calendars;
 using NodaTime.Text;
 using NodaTime.Utility;
 using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -30,6 +31,7 @@ namespace NodaTime
     /// </remarks>
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
     [XmlSchemaProvider(nameof(AddSchema))]
+    [TypeConverter(typeof(YearMonthTypeConverter))]
     public struct YearMonth : IEquatable<YearMonth>, IComparable<YearMonth>, IComparable, IFormattable, IXmlSerializable
     {
         /// <summary>


### PR DESCRIPTION
(Like the other converters, this only handles the ISO calendar system.)

Fixes #1539.