### PR TITLE
Fix a typo in Interval documentation

### DIFF
--- a/src/NodaTime/Interval.cs
+++ b/src/NodaTime/Interval.cs
@@ -18,7 +18,7 @@ namespace NodaTime
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Equality is defined in a component-wise fashion: two date intervals are considered equal if their start instants are
+    /// Equality is defined in a component-wise fashion: two intervals are considered equal if their start instants are
     /// equal to each other and their end instants are equal to each other. Ordering between intervals is not defined.
     /// </para>
     /// <para>


### PR DESCRIPTION
1fb657c fixed up the documentation for various types' equality/ordering, but accidentally uses "date interval" for both `DateInterval` and `Interval`.