### PR TITLE
Create method 'PlusMonths()'

### DIFF
--- a/src/NodaTime.Test/YearMonthTest.Misc.cs
+++ b/src/NodaTime.Test/YearMonthTest.Misc.cs
@@ -39,5 +39,18 @@ namespace NodaTime.Test
             var yearMonth = new YearMonth(year, month, calendar);
             Assert.Throws<ArgumentOutOfRangeException>(() => yearMonth.OnDayOfMonth(day));
         }
+               
+        [Test]
+        [TestCase(2014, 8, 4, 2014, 12)]
+        [TestCase(2014, 8, 5, 2015, 1)]
+        [TestCase(2014, 8, 0, 2014, 8)]
+        [TestCase(2014, 8, -1, 2014, 7)]
+        [TestCase(2014, 8, -8, 2013, 12)]
+        public void PlusMonths(int year, int month, int monthsToAdd, int expectedYear, int expectedMonth)
+        {
+            var yearMonth = new YearMonth(year, month);
+            var expected = new YearMonth(expectedYear, expectedMonth);
+            Assert.AreEqual(expected, yearMonth.PlusMonths(monthsToAdd));
+        }
     }
 }

--- a/src/NodaTime/YearMonth.cs
+++ b/src/NodaTime/YearMonth.cs
@@ -147,6 +147,16 @@ namespace NodaTime
         public DateInterval ToDateInterval() => new DateInterval(StartDate, EndDate);
 
         /// <summary>
+        /// Returns a <see cref="YearMonth"/> object which is the result of adding the specified number
+        /// of months to this object.
+        /// </summary>
+        /// <param name="months">The number of months to add to this object.</param>
+        /// <returns>The resulting <see cref="YearMonth"/> after adding the specified number of months.</returns>
+        [Pure]
+        public YearMonth PlusMonths(int months) =>
+            OnDayOfMonth(1).PlusMonths(months).ToYearMonth();
+   
+        /// <summary>
         /// Returns a <see cref="LocalDate"/> with the year/month of this value, and the given day of month.
         /// </summary>
         /// <param name="day">The day within the month.</param>


### PR DESCRIPTION
I've added a new method to the YearMonth structure called 'PlusMonths', which is a shortcut to obtaining a new YearMonth object representing the current one plus a number of months.

Addresses #1536 

