### PR TITLE
Fix tests when running on Ubuntu 20.04

### DIFF
--- a/src/NodaTime.Test/Text/Cultures.cs
+++ b/src/NodaTime.Test/Text/Cultures.cs
@@ -62,7 +62,9 @@ namespace NodaTime.Test.Text
                 LongDatePattern = "d MMMM yyyy",
                 LongTimePattern = "HH:mm:ss",
                 ShortDatePattern = "yyyy-MM-dd",
-                ShortTimePattern = "HH:mm"
+                ShortTimePattern = "HH:mm",
+                // Some flavours of Linux have a very odd setting here.
+                TimeSeparator = ":"
             }
         });
 


### PR DESCRIPTION
The French-Canadian culture appears to have some odd settings by default.