### PR TITLE
Remove netcoreapp2.0 benchmarks

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
+++ b/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1;net471;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net471;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 


### PR DESCRIPTION
It's EOL now, so irrelevant.

Fixes #1568 