### PR TITLE
Attempt to workaround analyzer detection of CA2119.

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTimeTests/StandardDaylightAlternatingMapBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/StandardDaylightAlternatingMapBenchmarks.cs
@@ -33,10 +33,10 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         }
 
         [Benchmark]
-        public ZoneInterval GetZoneInterval_Winter() => SampleZone.GetZoneInterval(February1st);
+        public ZoneInterval GetZoneInterval_Winter() => SampleZone.GetZoneIntervalInternal(February1st);
 
         [Benchmark]
-        public ZoneInterval GetZoneInterval_Summer() => SampleZone.GetZoneInterval(July1st);
+        public ZoneInterval GetZoneInterval_Summer() => SampleZone.GetZoneIntervalInternal(July1st);
     }
 }
 #endif

--- a/src/NodaTime.Test/TimeZones/PartialZoneIntervalMapTest.cs
+++ b/src/NodaTime.Test/TimeZones/PartialZoneIntervalMapTest.cs
@@ -82,7 +82,7 @@ namespace NodaTime.Test.TimeZones
             var current = Instant.MinValue;
             while (current < Instant.AfterMaxValue)
             {
-                var zoneInterval = map.GetZoneInterval(current);
+                var zoneInterval = map.GetZoneIntervalInternal(current);
                 yield return zoneInterval;
                 // If this is the end of time, this will just fail on the next comparison.
                 current = zoneInterval.RawEnd;

--- a/src/NodaTime.Test/TimeZones/PrecalculatedDateTimeZoneTest.cs
+++ b/src/NodaTime.Test/TimeZones/PrecalculatedDateTimeZoneTest.cs
@@ -35,7 +35,7 @@ namespace NodaTime.Test.TimeZones
 
         // We don't actually want an interval from the beginning of time when we ask our composite time zone for an interval
         // - because that could give the wrong idea. So we clamp it at the end of the precalculated interval.
-        private static readonly ZoneInterval ClampedTailZoneInterval = TailZone.GetZoneInterval(ThirdInterval.End).WithStart(ThirdInterval.End);
+        private static readonly ZoneInterval ClampedTailZoneInterval = TailZone.GetZoneIntervalInternal(ThirdInterval.End).WithStart(ThirdInterval.End);
 
         private static readonly PrecalculatedDateTimeZone TestZone =
             new PrecalculatedDateTimeZone("Test", new[] { FirstInterval, SecondInterval, ThirdInterval }, TailZone);

--- a/src/NodaTime.Test/TimeZones/StandardDaylightAlternatingMapTest.cs
+++ b/src/NodaTime.Test/TimeZones/StandardDaylightAlternatingMapTest.cs
@@ -45,7 +45,7 @@ namespace NodaTime.Test.TimeZones
         [Test]
         public void GetZoneInterval_Instant_Summer()
         {
-            var interval = TestMap.GetZoneInterval(Instant.FromUtc(2010, 6, 1, 0, 0));
+            var interval = TestMap.GetZoneIntervalInternal(Instant.FromUtc(2010, 6, 1, 0, 0));
             Assert.AreEqual("Summer", interval.Name);
             Assert.AreEqual(Offset.FromHours(6), interval.WallOffset);
             Assert.AreEqual(Offset.FromHours(5), interval.StandardOffset);
@@ -57,7 +57,7 @@ namespace NodaTime.Test.TimeZones
         [Test]
         public void GetZoneInterval_Instant_Winter()
         {
-            var interval = TestMap.GetZoneInterval(Instant.FromUtc(2010, 11, 1, 0, 0));
+            var interval = TestMap.GetZoneIntervalInternal(Instant.FromUtc(2010, 11, 1, 0, 0));
             Assert.AreEqual("Winter", interval.Name);
             Assert.AreEqual(Offset.FromHours(5), interval.WallOffset);
             Assert.AreEqual(Offset.FromHours(5), interval.StandardOffset);
@@ -71,7 +71,7 @@ namespace NodaTime.Test.TimeZones
         {
             // This is only just about valid
             var firstSummer = Instant.FromUtc(2000, 3, 9, 20, 0);
-            var interval = TestMap.GetZoneInterval(firstSummer);
+            var interval = TestMap.GetZoneIntervalInternal(firstSummer);
             Assert.AreEqual("Summer", interval.Name);
         }
 
@@ -266,16 +266,16 @@ namespace NodaTime.Test.TimeZones
             var lastSummer = new ZoneInterval("Summer", lastSpring, lastAutumn, dstOffset, dstOffset);
             var lastWinter = new ZoneInterval("Winter", lastAutumn, Instant.AfterMaxValue, Offset.Zero, Offset.Zero);
 
-            Assert.AreEqual(firstWinter, zone.GetZoneInterval(Instant.MinValue));
-            Assert.AreEqual(firstWinter, zone.GetZoneInterval(Instant.FromUtc(-9998, 2, 1, 0, 0)));
-            Assert.AreEqual(firstSummer, zone.GetZoneInterval(firstSpring));
-            Assert.AreEqual(firstSummer, zone.GetZoneInterval(Instant.FromUtc(-9998, 5, 1, 0, 0)));
+            Assert.AreEqual(firstWinter, zone.GetZoneIntervalInternal(Instant.MinValue));
+            Assert.AreEqual(firstWinter, zone.GetZoneIntervalInternal(Instant.FromUtc(-9998, 2, 1, 0, 0)));
+            Assert.AreEqual(firstSummer, zone.GetZoneIntervalInternal(firstSpring));
+            Assert.AreEqual(firstSummer, zone.GetZoneIntervalInternal(Instant.FromUtc(-9998, 5, 1, 0, 0)));
 
-            Assert.AreEqual(lastSummer, zone.GetZoneInterval(lastSpring));
-            Assert.AreEqual(lastSummer, zone.GetZoneInterval(Instant.FromUtc(9999, 5, 1, 0, 0)));
-            Assert.AreEqual(lastWinter, zone.GetZoneInterval(lastAutumn));
-            Assert.AreEqual(lastWinter, zone.GetZoneInterval(Instant.FromUtc(9999, 11, 1, 0, 0)));
-            Assert.AreEqual(lastWinter, zone.GetZoneInterval(Instant.MaxValue));
+            Assert.AreEqual(lastSummer, zone.GetZoneIntervalInternal(lastSpring));
+            Assert.AreEqual(lastSummer, zone.GetZoneIntervalInternal(Instant.FromUtc(9999, 5, 1, 0, 0)));
+            Assert.AreEqual(lastWinter, zone.GetZoneIntervalInternal(lastAutumn));
+            Assert.AreEqual(lastWinter, zone.GetZoneIntervalInternal(Instant.FromUtc(9999, 11, 1, 0, 0)));
+            Assert.AreEqual(lastWinter, zone.GetZoneIntervalInternal(Instant.MaxValue));
         }
 
         [Test]
@@ -290,7 +290,7 @@ namespace NodaTime.Test.TimeZones
 
             var map = new StandardDaylightAlternatingMap(Offset.Zero, r1, r2);
 
-            Assert.Throws<InvalidOperationException>(() => map.GetZoneInterval(Instant.FromUtc(2017, 8, 25, 0, 0, 0)));
+            Assert.Throws<InvalidOperationException>(() => map.GetZoneIntervalInternal(Instant.FromUtc(2017, 8, 25, 0, 0, 0)));
         }
 
         private void CheckMapping(ZoneLocalMapping mapping, string earlyIntervalName, string lateIntervalName, int count)

--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -220,6 +220,18 @@ namespace NodaTime
         public abstract ZoneInterval GetZoneInterval(Instant instant);
 
         /// <summary>
+        /// IZoneIntervalMap is internal, and a Microsoft internal analyzer flags a public abstract implementation
+        /// of that as a security vulnerability (CA2119). This approach silences the analyzer, without making any really
+        /// significant difference. If someone provides a bad DateTimeZone implementation, then yes, time zone
+        /// calculations will be broken. If they provide a malicious DateTimeZone implementation, then yes, bad things
+        /// may happen if it's used. We don't "trust" IZoneIntervalMap particularly more than DateTimeZone in general.
+        /// For further information, see:
+        /// - https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2119
+        /// - https://github.com/nodatime/nodatime/issues/1583
+        /// </summary>
+        ZoneInterval IZoneIntervalMap.GetZoneIntervalInternal(Instant instant) => GetZoneInterval(instant);
+
+        /// <summary>
         /// Returns complete information about how the given <see cref="LocalDateTime" /> is mapped in this time zone.
         /// </summary>
         /// <remarks>

--- a/src/NodaTime/TimeZones/BclDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZone.cs
@@ -69,7 +69,7 @@ namespace NodaTime.TimeZones
         /// <inheritdoc />
         public override ZoneInterval GetZoneInterval(Instant instant)
         {
-            return map.GetZoneInterval(instant);
+            return map.GetZoneIntervalInternal(instant);
         }
 
         /// <summary>
@@ -318,9 +318,9 @@ namespace NodaTime.TimeZones
                     this.daylightName = daylightName;
                 }
 
-                public ZoneInterval GetZoneInterval(Instant instant)
+                public ZoneInterval GetZoneIntervalInternal(Instant instant)
                 {
-                    var interval = originalMap.GetZoneInterval(instant);
+                    var interval = originalMap.GetZoneIntervalInternal(instant);
                     return interval.Name == daylightName
                         ? new ZoneInterval(daylightName, interval.RawStart, interval.RawEnd, interval.WallOffset, Offset.FromHours(1))
                         : interval;

--- a/src/NodaTime/TimeZones/CachedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/CachedDateTimeZone.cs
@@ -68,7 +68,7 @@ namespace NodaTime.TimeZones
         /// </summary>
         public override ZoneInterval GetZoneInterval(Instant instant)
         {
-            return map.GetZoneInterval(instant);
+            return map.GetZoneIntervalInternal(instant);
         }
     }
 }

--- a/src/NodaTime/TimeZones/CachingZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/CachingZoneIntervalMap.cs
@@ -69,7 +69,7 @@ namespace NodaTime.TimeZones
             /// </summary>
             /// <param name="instant">The Instant to test.</param>
             /// <returns>The defined ZoneOffsetPeriod or null.</returns>
-            public ZoneInterval GetZoneInterval(Instant instant)
+            public ZoneInterval GetZoneIntervalInternal(Instant instant)
             {
                 int period = instant.DaysSinceEpoch >> PeriodShift;
                 int index = period & CachePeriodMask;
@@ -114,7 +114,7 @@ namespace NodaTime.TimeZones
                     var periodStart = Instant.FromTrustedDuration(new Duration(Math.Max(days, Instant.MinDays), 0L));
                     var nextPeriodStartDays = days + (1 << PeriodShift);
 
-                    var interval = map.GetZoneInterval(periodStart);
+                    var interval = map.GetZoneIntervalInternal(periodStart);
                     var node = new HashCacheNode(interval, period, null);
 
                     // Keep going while the current interval ends before the period.
@@ -124,7 +124,7 @@ namespace NodaTime.TimeZones
                     // evaluate to false.
                     while (interval.RawEnd.DaysSinceEpoch < nextPeriodStartDays)
                     {
-                        interval = map.GetZoneInterval(interval.End);
+                        interval = map.GetZoneIntervalInternal(interval.End);
                         node = new HashCacheNode(interval, period, node);
                     }
 

--- a/src/NodaTime/TimeZones/IZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/IZoneIntervalMap.cs
@@ -15,7 +15,7 @@ namespace NodaTime.TimeZones
     /// </remarks>
     internal interface IZoneIntervalMap
     {
-        ZoneInterval GetZoneInterval(Instant instant);
+        ZoneInterval GetZoneIntervalInternal(Instant instant);
     }
 
     // This is slightly ugly, but it allows us to use any time zone as the tail

--- a/src/NodaTime/TimeZones/PartialZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/PartialZoneIntervalMap.cs
@@ -53,7 +53,7 @@ namespace NodaTime.TimeZones
         {
             Preconditions.DebugCheckArgument(instant >= Start && instant < End, nameof(instant),
                 "Value {0} was not in the range [{0}, {1})", instant, Start, End);
-            var interval = map.GetZoneInterval(instant);
+            var interval = map.GetZoneIntervalInternal(instant);
             // Clamp the interval for the sake of sanity. Checking this every time isn't very efficient,
             // but we're not expecting this to be called too often, due to caching.
             if (interval.RawStart < Start)
@@ -70,7 +70,7 @@ namespace NodaTime.TimeZones
         /// <summary>
         /// Returns true if this map only contains a single interval; that is, if the first interval includes the end of the map.
         /// </summary>
-        private bool IsSingleInterval => map.GetZoneInterval(Start).RawEnd >= End;
+        private bool IsSingleInterval => map.GetZoneIntervalInternal(Start).RawEnd >= End;
 
         /// <summary>
         /// Returns a partial zone interval map equivalent to this one, but with the given start point.
@@ -178,7 +178,7 @@ namespace NodaTime.TimeZones
                 this.partialMaps = partialMaps;
             }
 
-            public ZoneInterval GetZoneInterval(Instant instant)
+            public ZoneInterval GetZoneIntervalInternal(Instant instant)
             {
                 // We assume the maps are ordered, and start with "beginning of time"
                 // which means we only need to find the first partial map which ends after

--- a/src/NodaTime/TimeZones/PrecalculatedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/PrecalculatedDateTimeZone.cs
@@ -44,7 +44,7 @@ namespace NodaTime.TimeZones
             if (tailZone != null)
             {
                 // Cache a "clamped" zone interval for use at the start of the tail zone.
-                firstTailZoneInterval = tailZone.GetZoneInterval(tailZoneStart).WithStart(tailZoneStart);
+                firstTailZoneInterval = tailZone.GetZoneIntervalInternal(tailZoneStart).WithStart(tailZoneStart);
             }
             ValidatePeriods(intervals, tailZone);
         }
@@ -79,7 +79,7 @@ namespace NodaTime.TimeZones
             {
                 // Clamp the tail zone interval to start at the end of our final period, if necessary, so that the
                 // join is seamless.
-                ZoneInterval intervalFromTailZone = tailZone.GetZoneInterval(instant);
+                ZoneInterval intervalFromTailZone = tailZone.GetZoneIntervalInternal(instant);
                 return intervalFromTailZone.RawStart < tailZoneStart ? firstTailZoneInterval! : intervalFromTailZone;
             }
 

--- a/src/NodaTime/TimeZones/SingleZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/SingleZoneIntervalMap.cs
@@ -17,6 +17,6 @@ namespace NodaTime.TimeZones
             this.interval = interval;
         }
 
-        public ZoneInterval GetZoneInterval(Instant instant) => interval;
+        public ZoneInterval GetZoneIntervalInternal(Instant instant) => interval;
     }
 }

--- a/src/NodaTime/TimeZones/StandardDaylightAlternatingMap.cs
+++ b/src/NodaTime/TimeZones/StandardDaylightAlternatingMap.cs
@@ -88,7 +88,7 @@ namespace NodaTime.TimeZones
         /// <returns>The ZoneInterval in effect at the given instant.</returns>
         /// <exception cref="ArgumentOutOfRangeException">The instant falls outside the bounds
         /// of the recurrence rules of the zone.</exception>
-        public ZoneInterval GetZoneInterval(Instant instant)
+        public ZoneInterval GetZoneIntervalInternal(Instant instant)
         {
             var next = NextTransition(instant, out ZoneRecurrence recurrence);
             // Now we know the recurrence we're in, we can work out when we went into it. (We'll never have


### PR DESCRIPTION
I don't believe this is actually a vulnerability, but it can be
worked around just by separating the internal interface method on
IZoneIntervalMap from the abstract method in DateTimeZone.