### PR TITLE
Add FxCop and fix the errors it produces

### DIFF
--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -394,6 +394,7 @@ namespace NodaTime.Test
             Period p2 = Period.FromHours(2);
             Period sum = p1 + p2;
             Assert.AreEqual(5, sum.Hours);
+            Assert.AreEqual(sum, Period.Add(p1, p2));
         }
 
         [Test]
@@ -442,9 +443,10 @@ namespace NodaTime.Test
         {
             Period p1 = Period.FromHours(3);
             Period p2 = Period.FromMinutes(20);
-            Period sum = p1 - p2;
-            Assert.AreEqual(3, sum.Hours);
-            Assert.AreEqual(-20, sum.Minutes);
+            Period difference = p1 - p2;
+            Assert.AreEqual(3, difference.Hours);
+            Assert.AreEqual(-20, difference.Minutes);
+            Assert.AreEqual(difference, Period.Subtract(p1, p2));
         }
 
         [Test]
@@ -452,8 +454,9 @@ namespace NodaTime.Test
         {
             Period p1 = Period.FromHours(3);
             Period p2 = Period.FromHours(2);
-            Period sum = p1 - p2;
-            Assert.AreEqual(1, sum.Hours);
+            Period difference = p1 - p2;
+            Assert.AreEqual(1, difference.Hours);
+            Assert.AreEqual(difference, Period.Subtract(p1, p2));
         }
 
         [Test]

--- a/src/NodaTime.Test/TimeZones/IO/IoStream.cs
+++ b/src/NodaTime.Test/TimeZones/IO/IoStream.cs
@@ -161,9 +161,9 @@ namespace NodaTime.Test.TimeZones.IO
             /// <returns>
             ///   A long value representing the length of the stream in bytes.
             /// </returns>
-            /// <exception cref="T:System.NotSupportedException">A class derived from Stream does not support seeking. 
+            /// <exception cref="System.NotSupportedException">A class derived from Stream does not support seeking. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>1</filterpriority>
             public override long Length
@@ -177,11 +177,11 @@ namespace NodaTime.Test.TimeZones.IO
             /// <returns>
             ///   The current position within the stream.
             /// </returns>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
-            /// <exception cref="T:System.NotSupportedException">The stream does not support seeking. 
+            /// <exception cref="System.NotSupportedException">The stream does not support seeking. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>1</filterpriority>
             public override long Position
@@ -193,7 +193,7 @@ namespace NodaTime.Test.TimeZones.IO
             /// <summary>
             ///   When overridden in a derived class, clears all buffers for this stream and causes any buffered data to be written to the underlying device.
             /// </summary>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
             /// <filterpriority>2</filterpriority>
             public override void Flush()
@@ -212,17 +212,17 @@ namespace NodaTime.Test.TimeZones.IO
             /// </param>
             /// <param name="count">The maximum number of bytes to be read from the current stream. 
             /// </param>
-            /// <exception cref="T:System.ArgumentException">The sum of <paramref name = "offset" /> and <paramref name = "count" /> is larger than the buffer length. 
+            /// <exception cref="System.ArgumentException">The sum of <paramref name = "offset" /> and <paramref name = "count" /> is larger than the buffer length. 
             /// </exception>
-            /// <exception cref="T:System.ArgumentNullException"><paramref name = "buffer" /> is null. 
+            /// <exception cref="System.ArgumentNullException"><paramref name = "buffer" /> is null. 
             /// </exception>
-            /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name = "offset" /> or <paramref name = "count" /> is negative. 
+            /// <exception cref="System.ArgumentOutOfRangeException"><paramref name = "offset" /> or <paramref name = "count" /> is negative. 
             /// </exception>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
-            /// <exception cref="T:System.NotSupportedException">The stream does not support reading. 
+            /// <exception cref="System.NotSupportedException">The stream does not support reading. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>1</filterpriority>
             public override int Read(byte[] buffer, int offset, int count)
@@ -243,13 +243,13 @@ namespace NodaTime.Test.TimeZones.IO
             /// </returns>
             /// <param name="offset">A byte offset relative to the <paramref name = "origin" /> parameter. 
             /// </param>
-            /// <param name="origin">A value of type <see cref="T:System.IO.SeekOrigin" /> indicating the reference point used to obtain the new position. 
+            /// <param name="origin">A value of type <see cref="System.IO.SeekOrigin" /> indicating the reference point used to obtain the new position. 
             /// </param>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
-            /// <exception cref="T:System.NotSupportedException">The stream does not support seeking, such as if the stream is constructed from a pipe or console output. 
+            /// <exception cref="System.NotSupportedException">The stream does not support seeking, such as if the stream is constructed from a pipe or console output. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>1</filterpriority>
             public override long Seek(long offset, SeekOrigin origin)
@@ -262,11 +262,11 @@ namespace NodaTime.Test.TimeZones.IO
             /// </summary>
             /// <param name="value">The desired length of the current stream in bytes. 
             /// </param>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
-            /// <exception cref="T:System.NotSupportedException">The stream does not support both writing and seeking, such as if the stream is constructed from a pipe or console output. 
+            /// <exception cref="System.NotSupportedException">The stream does not support both writing and seeking, such as if the stream is constructed from a pipe or console output. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>2</filterpriority>
             public override void SetLength(long value)
@@ -283,17 +283,17 @@ namespace NodaTime.Test.TimeZones.IO
             /// </param>
             /// <param name="count">The number of bytes to be written to the current stream. 
             /// </param>
-            /// <exception cref="T:System.ArgumentException">The sum of <paramref name = "offset" /> and <paramref name = "count" /> is greater than the buffer length. 
+            /// <exception cref="System.ArgumentException">The sum of <paramref name = "offset" /> and <paramref name = "count" /> is greater than the buffer length. 
             /// </exception>
-            /// <exception cref="T:System.ArgumentNullException"><paramref name = "buffer" /> is null. 
+            /// <exception cref="System.ArgumentNullException"><paramref name = "buffer" /> is null. 
             /// </exception>
-            /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name = "offset" /> or <paramref name = "count" /> is negative. 
+            /// <exception cref="System.ArgumentOutOfRangeException"><paramref name = "offset" /> or <paramref name = "count" /> is negative. 
             /// </exception>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
-            /// <exception cref="T:System.NotSupportedException">The stream does not support writing. 
+            /// <exception cref="System.NotSupportedException">The stream does not support writing. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>1</filterpriority>
             public override void Write(byte[] buffer, int offset, int count)
@@ -353,9 +353,9 @@ namespace NodaTime.Test.TimeZones.IO
             /// <returns>
             ///   A long value representing the length of the stream in bytes.
             /// </returns>
-            /// <exception cref="T:System.NotSupportedException">A class derived from Stream does not support seeking. 
+            /// <exception cref="System.NotSupportedException">A class derived from Stream does not support seeking. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>1</filterpriority>
             public override long Length
@@ -369,11 +369,11 @@ namespace NodaTime.Test.TimeZones.IO
             /// <returns>
             ///   The current position within the stream.
             /// </returns>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
-            /// <exception cref="T:System.NotSupportedException">The stream does not support seeking. 
+            /// <exception cref="System.NotSupportedException">The stream does not support seeking. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>1</filterpriority>
             public override long Position
@@ -385,7 +385,7 @@ namespace NodaTime.Test.TimeZones.IO
             /// <summary>
             ///   When overridden in a derived class, clears all buffers for this stream and causes any buffered data to be written to the underlying device.
             /// </summary>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
             /// <filterpriority>2</filterpriority>
             public override void Flush()
@@ -404,17 +404,17 @@ namespace NodaTime.Test.TimeZones.IO
             /// </param>
             /// <param name="count">The maximum number of bytes to be read from the current stream. 
             /// </param>
-            /// <exception cref="T:System.ArgumentException">The sum of <paramref name = "offset" /> and <paramref name = "count" /> is larger than the buffer length. 
+            /// <exception cref="System.ArgumentException">The sum of <paramref name = "offset" /> and <paramref name = "count" /> is larger than the buffer length. 
             /// </exception>
-            /// <exception cref="T:System.ArgumentNullException"><paramref name = "buffer" /> is null. 
+            /// <exception cref="System.ArgumentNullException"><paramref name = "buffer" /> is null. 
             /// </exception>
-            /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name = "offset" /> or <paramref name = "count" /> is negative. 
+            /// <exception cref="System.ArgumentOutOfRangeException"><paramref name = "offset" /> or <paramref name = "count" /> is negative. 
             /// </exception>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
-            /// <exception cref="T:System.NotSupportedException">The stream does not support reading. 
+            /// <exception cref="System.NotSupportedException">The stream does not support reading. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>1</filterpriority>
             public override int Read(byte[] buffer, int offset, int count)
@@ -430,13 +430,13 @@ namespace NodaTime.Test.TimeZones.IO
             /// </returns>
             /// <param name="offset">A byte offset relative to the <paramref name = "origin" /> parameter. 
             /// </param>
-            /// <param name="origin">A value of type <see cref="T:System.IO.SeekOrigin" /> indicating the reference point used to obtain the new position. 
+            /// <param name="origin">A value of type <see cref="System.IO.SeekOrigin" /> indicating the reference point used to obtain the new position. 
             /// </param>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
-            /// <exception cref="T:System.NotSupportedException">The stream does not support seeking, such as if the stream is constructed from a pipe or console output. 
+            /// <exception cref="System.NotSupportedException">The stream does not support seeking, such as if the stream is constructed from a pipe or console output. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>1</filterpriority>
             public override long Seek(long offset, SeekOrigin origin)
@@ -449,11 +449,11 @@ namespace NodaTime.Test.TimeZones.IO
             /// </summary>
             /// <param name="value">The desired length of the current stream in bytes. 
             /// </param>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
-            /// <exception cref="T:System.NotSupportedException">The stream does not support both writing and seeking, such as if the stream is constructed from a pipe or console output. 
+            /// <exception cref="System.NotSupportedException">The stream does not support both writing and seeking, such as if the stream is constructed from a pipe or console output. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>2</filterpriority>
             public override void SetLength(long value)
@@ -470,17 +470,17 @@ namespace NodaTime.Test.TimeZones.IO
             /// </param>
             /// <param name="count">The number of bytes to be written to the current stream. 
             /// </param>
-            /// <exception cref="T:System.ArgumentException">The sum of <paramref name = "offset" /> and <paramref name = "count" /> is greater than the buffer length. 
+            /// <exception cref="System.ArgumentException">The sum of <paramref name = "offset" /> and <paramref name = "count" /> is greater than the buffer length. 
             /// </exception>
-            /// <exception cref="T:System.ArgumentNullException"><paramref name = "buffer" /> is null. 
+            /// <exception cref="System.ArgumentNullException"><paramref name = "buffer" /> is null. 
             /// </exception>
-            /// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name = "offset" /> or <paramref name = "count" /> is negative. 
+            /// <exception cref="System.ArgumentOutOfRangeException"><paramref name = "offset" /> or <paramref name = "count" /> is negative. 
             /// </exception>
-            /// <exception cref="T:System.IO.IOException">An I/O error occurs. 
+            /// <exception cref="System.IO.IOException">An I/O error occurs. 
             /// </exception>
-            /// <exception cref="T:System.NotSupportedException">The stream does not support writing. 
+            /// <exception cref="System.NotSupportedException">The stream does not support writing. 
             /// </exception>
-            /// <exception cref="T:System.ObjectDisposedException">Methods were called after the stream was closed. 
+            /// <exception cref="System.ObjectDisposedException">Methods were called after the stream was closed. 
             /// </exception>
             /// <filterpriority>1</filterpriority>
             public override void Write(byte[] buffer, int offset, int count)

--- a/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
+++ b/src/NodaTime.Test/TimeZones/TzdbDateTimeZoneSourceTest.cs
@@ -225,8 +225,7 @@ namespace NodaTime.Test.TimeZones
                 return;
             }
 
-            string? id = TzdbDateTimeZoneSource.Default.GuessZoneIdByTransitionsUncached(bclZone,
-                TzdbDefaultZonesForIdGuessZoneIdByTransitionsUncached);
+            string? id = TzdbDateTimeZoneSource.GuessZoneIdByTransitionsUncached(bclZone, TzdbDefaultZonesForIdGuessZoneIdByTransitionsUncached);
 
             // Unmappable zones may not be mapped, or may be mapped to something reasonably accurate.
             // We don't mind either way.

--- a/src/NodaTime.Testing/NodaTime.Testing.csproj
+++ b/src/NodaTime.Testing/NodaTime.Testing.csproj
@@ -10,5 +10,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
+++ b/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
@@ -70,11 +70,16 @@ namespace NodaTime.Testing.TimeZones
             throw new InvalidOperationException($"Instant {instant} did not exist in time zone {Id}");
         }
 
+// This isn't really a collection type; it only implements IEnumerable to enable collection initializers.
+#pragma warning disable CA1010 // Implement IEnumerable<T>
+#pragma warning disable CA1710 // Rename to class end in "Collection"
         /// <summary>
         /// Builder to create instances of <see cref="MultiTransitionDateTimeZone"/>. Each builder
         /// can only be built once.
         /// </summary>
         public sealed class Builder : IEnumerable
+#pragma warning restore CA1710
+#pragma warning restore CA1010
         {
             private readonly List<ZoneInterval> intervals = new List<ZoneInterval>();
             private Offset currentStandardOffset;

--- a/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
+++ b/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
@@ -42,8 +42,8 @@ namespace NodaTime.Testing.TimeZones
         /// <remarks>
         /// This will always return a valid zone interval, as time zones cover the whole of time.
         /// </remarks>
-        /// <param name="instant">The <see cref="T:NodaTime.Instant" /> to query.</param>
-        /// <returns>The defined <see cref="T:NodaTime.TimeZones.ZoneInterval" />.</returns>
+        /// <param name="instant">The <see cref="NodaTime.Instant" /> to query.</param>
+        /// <returns>The defined <see cref="NodaTime.TimeZones.ZoneInterval" />.</returns>
         public override ZoneInterval GetZoneInterval(Instant instant)
         {
             int lower = 0; // Inclusive

--- a/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
+++ b/src/NodaTime.Testing/TimeZones/MultiTransitionDateTimeZone.cs
@@ -80,7 +80,7 @@ namespace NodaTime.Testing.TimeZones
             private Offset currentStandardOffset;
             private Offset currentSavings;
             private string currentName;
-            private bool built = false;
+            private bool built;
 
             /// <summary>
             /// Gets the ID of the time zone which will be built.

--- a/src/NodaTime.Testing/TimeZones/SingleTransitionDateTimeZone.cs
+++ b/src/NodaTime.Testing/TimeZones/SingleTransitionDateTimeZone.cs
@@ -75,8 +75,8 @@ namespace NodaTime.Testing.TimeZones
         /// This will always return a valid zone interval, as time zones cover the whole of time.
         /// This returns either the zone interval before or after the transition, based on the instant provided.
         /// </remarks>
-        /// <param name="instant">The <see cref="T:NodaTime.Instant" /> to query.</param>
-        /// <returns>The defined <see cref="T:NodaTime.TimeZones.ZoneInterval" />.</returns>
+        /// <param name="instant">The <see cref="NodaTime.Instant" /> to query.</param>
+        /// <returns>The defined <see cref="NodaTime.TimeZones.ZoneInterval" />.</returns>
         public override ZoneInterval GetZoneInterval(Instant instant) => EarlyInterval.Contains(instant) ? EarlyInterval : LateInterval;
     }
 }

--- a/src/NodaTime/AmbiguousTimeException.cs
+++ b/src/NodaTime/AmbiguousTimeException.cs
@@ -6,6 +6,13 @@ using NodaTime.Annotations;
 using NodaTime.Utility;
 using System;
 
+// Standard exception constructors: we don't *want* those constructors.
+// The single constructor provided in this class populates the message and
+// accepts the required parameters for populating other properties.
+// There are never any other causes to the exception, at least that I can
+// envisage for the moment.
+#pragma warning disable CA1032
+
 namespace NodaTime
 {
     /// <summary>

--- a/src/NodaTime/Annotations/FxCopAttributes.cs
+++ b/src/NodaTime/Annotations/FxCopAttributes.cs
@@ -1,0 +1,14 @@
+﻿// Copyright 2020 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using System;
+
+// This file just contains attributes that FxCop understands.
+// This is partly to work around https://github.com/dotnet/roslyn-analyzers/issues/3451
+
+namespace NodaTime.Annotations
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class ValidatedNotNullAttribute : Attribute { }
+}

--- a/src/NodaTime/Annotations/TestExemptionAttribute.cs
+++ b/src/NodaTime/Annotations/TestExemptionAttribute.cs
@@ -15,7 +15,7 @@ namespace NodaTime.Annotations
     {
         internal TestExemptionCategory Category { get; }
 
-        internal TestExemptionAttribute(TestExemptionCategory category, string? message = null)
+        internal TestExemptionAttribute(TestExemptionCategory category)
         {
             Category = category;
         }

--- a/src/NodaTime/AnnualDate.cs
+++ b/src/NodaTime/AnnualDate.cs
@@ -131,12 +131,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("G").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -777,11 +777,13 @@ namespace NodaTime
         /// </summary>
         private static class IslamicCalendars
         {
+#pragma warning disable CA1814 // Prefer jagged arrays; in this case it would take *more* space.
             internal static readonly CalendarSystem[,] ByLeapYearPatterAndEpoch;
 
             static IslamicCalendars()
             {
                 ByLeapYearPatterAndEpoch = new CalendarSystem[4, 2];
+#pragma warning restore CA1814
                 for (int i = 1; i <= 4; i++)
                 {
                     for (int j = 1; j <= 2; j++)

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -11,6 +11,11 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using static System.FormattableString;
 
+// Remove static constructors.
+// The calendar system initialization here can be slow or increase memory usage,
+// so the static constructors are very deliberately present to make them truly lazy.
+#pragma warning disable CA1810
+
 namespace NodaTime
 {
     /// <summary>

--- a/src/NodaTime/CalendarSystem.cs
+++ b/src/NodaTime/CalendarSystem.cs
@@ -583,6 +583,7 @@ namespace NodaTime
             return eraCalculator.GetEra(absoluteYear);
         }
 
+#pragma warning disable CA1822 // Make a member static because it doesn't use instance members - which is only true in a release build...
         /// <summary>
         /// In debug configurations only, this method calls <see cref="ValidateYearMonthDay"/>
         /// with the components of the given YearMonthDay, ensuring that it's valid in the
@@ -598,6 +599,7 @@ namespace NodaTime
             ValidateYearMonthDay(yearMonthDay.Year, yearMonthDay.Month, yearMonthDay.Day);
 #endif
         }
+#pragma warning restore CA1822
 
         #endregion
 

--- a/src/NodaTime/Calendars/BadiYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/BadiYearMonthDayCalculator.cs
@@ -217,7 +217,7 @@ namespace NodaTime.Calendars
             return new YearMonthDay(year, month, day);
         }
 
-        internal bool IsInAyyamiHa(YearMonthDay ymd) => ymd.Month == Month18 && ymd.Day > DaysInMonth;
+        internal static bool IsInAyyamiHa(YearMonthDay ymd) => ymd.Month == Month18 && ymd.Day > DaysInMonth;
 
         internal override bool IsLeapYear(int year) => GetDaysInAyyamiHa(year) != DaysInAyyamiHaInNormalYear;
 

--- a/src/NodaTime/Calendars/GJEraCalculator.cs
+++ b/src/NodaTime/Calendars/GJEraCalculator.cs
@@ -20,7 +20,7 @@ namespace NodaTime.Calendars
             maxYearOfAd = ymdCalculator.MaxYear;
         }
 
-        private void ValidateEra(Era era)
+        private static void ValidateEra(Era era)
         {
             if (era != Era.Common && era != Era.BeforeCommon)
             {

--- a/src/NodaTime/Calendars/GJYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/GJYearMonthDayCalculator.cs
@@ -15,22 +15,20 @@ namespace NodaTime.Calendars
         protected static readonly int[] MinDaysPerMonth = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
         protected static readonly int[] MaxDaysPerMonth = { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
-        private static readonly int[] MinTotalDaysByMonth;
-        private static readonly int[] MaxTotalDaysByMonth;
+        // Note: these fields must be declared after MinDaysPerMonth and MaxDaysPerMonth so that the initialization
+        // is correct. This behavior (textual order for initialization) is guaranteed by the spec. We'd normally
+        // try to avoid relying on it, but that's quite hard here.
+        private static readonly int[] MinTotalDaysByMonth = GenerateTotalDaysByMonth(MinDaysPerMonth);
+        private static readonly int[] MaxTotalDaysByMonth = GenerateTotalDaysByMonth(MaxDaysPerMonth);
 
-        static GJYearMonthDayCalculator()
+        private static int[] GenerateTotalDaysByMonth(int[] monthLengths)
         {
-            MinTotalDaysByMonth = new int[12];
-            MaxTotalDaysByMonth = new int[12];
-            int minSum = 0;
-            int maxSum = 0;
-            for (int i = 0; i < 11; i++)
+            int[] ret = new int[monthLengths.Length];
+            for (int i = 0; i < ret.Length - 1; i++)
             {
-                minSum += MinDaysPerMonth[i];
-                maxSum += MaxDaysPerMonth[i];
-                MinTotalDaysByMonth[i + 1] = minSum;
-                MaxTotalDaysByMonth[i + 1] = maxSum;
+                ret[i + 1] = ret[i] + monthLengths[i];
             }
+            return ret;
         }
 
         protected GJYearMonthDayCalculator(int minYear, int maxYear, int averageDaysPer10Years, int daysAtStartOfYear1)

--- a/src/NodaTime/Calendars/GJYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/GJYearMonthDayCalculator.cs
@@ -21,6 +21,10 @@ namespace NodaTime.Calendars
         private static readonly int[] MinTotalDaysByMonth = GenerateTotalDaysByMonth(MinDaysPerMonth);
         private static readonly int[] MaxTotalDaysByMonth = GenerateTotalDaysByMonth(MaxDaysPerMonth);
 
+        /// <summary>
+        /// Produces an array with "the sum of the elements of <paramref name="monthLengths"/> before the corresponding index".
+        /// So for an input of [1, 2, 3, 4, 5] this would produce [0, 1, 3, 6, 10].
+        /// </summary>
         private static int[] GenerateTotalDaysByMonth(int[] monthLengths)
         {
             int[] ret = new int[monthLengths.Length];

--- a/src/NodaTime/Calendars/IWeekYearRule.cs
+++ b/src/NodaTime/Calendars/IWeekYearRule.cs
@@ -86,14 +86,18 @@ namespace NodaTime.Calendars
         /// </summary>
         /// <param name="date">The date to compute the week-year of.</param>
         /// <returns>The week-year of <paramref name="date"/>, according to this rule.</returns>
+#pragma warning disable CA1716 // Parameter name conflicts with a framework name
         int GetWeekYear(LocalDate date);
+#pragma warning restore CA1716
 
         /// <summary>
         /// Calculates the week of the week-year in which the given date occurs, according to this rule.
         /// </summary>
         /// <param name="date">The date to compute the week of.</param>
         /// <returns>The week of the week-year of <paramref name="date"/>, according to this rule.</returns>
+#pragma warning disable CA1716 // Parameter name conflicts with a framework name
         int GetWeekOfWeekYear(LocalDate date);
+#pragma warning restore CA1716
 
         /// <summary>
         /// Returns the number of weeks in the given week-year, within the specified calendar system.

--- a/src/NodaTime/Calendars/IslamicYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/IslamicYearMonthDayCalculator.cs
@@ -41,6 +41,7 @@ namespace NodaTime.Calendars
         /// <summary>The pattern of leap years within a cycle, one bit per year, for this calendar.</summary>
         private readonly int leapYearPatternBits;
 
+        /// <summary>The number of days preceding the 0-indexed month - so [0, 30, 59, ...]</summary>
         private static readonly int[] TotalDaysByMonth = GenerateTotalDaysByMonth();
 
         private static int[] GenerateTotalDaysByMonth()

--- a/src/NodaTime/Calendars/IslamicYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/IslamicYearMonthDayCalculator.cs
@@ -41,15 +41,15 @@ namespace NodaTime.Calendars
         /// <summary>The pattern of leap years within a cycle, one bit per year, for this calendar.</summary>
         private readonly int leapYearPatternBits;
 
-        private static readonly int[] TotalDaysByMonth;
+        private static readonly int[] TotalDaysByMonth = GenerateTotalDaysByMonth();
 
-        static IslamicYearMonthDayCalculator()
+        private static int[] GenerateTotalDaysByMonth()
         {
             int days = 0;
-            TotalDaysByMonth = new int[12];
+            int[] ret = new int[12];
             for (int i = 0; i < 12; i++)
             {
-                TotalDaysByMonth[i] = days;
+                ret[i] = days;
                 // Here, the month number is 0-based, so even months are long
                 int daysInMonth = (i & 1) == 0 ? LongMonthLength : ShortMonthLength;
                 // This doesn't take account of leap years, but that doesn't matter - because
@@ -57,6 +57,7 @@ namespace NodaTime.Calendars
                 // in the Islamic calendar.
                 days += daysInMonth;
             }
+            return ret;
         }
 
         internal IslamicYearMonthDayCalculator(IslamicLeapYearPattern leapYearPattern, IslamicEpoch epoch)

--- a/src/NodaTime/Calendars/PersianYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/PersianYearMonthDayCalculator.cs
@@ -116,7 +116,6 @@ namespace NodaTime.Calendars
             private const long LeapYearPatternBits = (1L << 1) | (1L << 5) | (1L << 9) | (1L << 13)
                 | (1L << 17) | (1L << 22) | (1L << 26) | (1L << 30);
             private const int LeapYearCycleLength = 33;
-            private const int DaysPerLeapCycle = DaysPerNonLeapYear * 25 + DaysPerLeapYear * 8;
 
             /// <summary>The ticks for the epoch of March 21st 622CE.</summary>
             private const int DaysAtStartOfYear1Constant = -492268;

--- a/src/NodaTime/Calendars/PersianYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/PersianYearMonthDayCalculator.cs
@@ -24,23 +24,24 @@ namespace NodaTime.Calendars
         private const int AverageDaysPer10Years = (DaysPerNonLeapYear * 25 + DaysPerLeapYear * 8) * 10 / 33;
         internal const int MaxPersianYear = 9377;
 
-        private static readonly int[] TotalDaysByMonth;
+        private static readonly int[] TotalDaysByMonth = GenerateTotalDaysByMonth();
 
         private readonly int[] startOfYearInDaysCache;
 
-        static PersianYearMonthDayCalculator()
+        private static int[] GenerateTotalDaysByMonth()
         {
             int days = 0;
-            TotalDaysByMonth = new int[13];
+            int[] ret = new int[13];
             for (int i = 1; i <= 12; i++)
             {
-                TotalDaysByMonth[i] = days;
+                ret[i] = days;
                 int daysInMonth = i <= 6 ? 31 : 30;
                 // This doesn't take account of leap years, but that doesn't matter - because
                 // it's not used on the last iteration, and leap years only affect the final month
                 // in the Persian calendar.
                 days += daysInMonth;
             }
+            return ret;
         }
 
         private PersianYearMonthDayCalculator(int daysAtStartOfYear1)

--- a/src/NodaTime/Calendars/PersianYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/PersianYearMonthDayCalculator.cs
@@ -24,6 +24,7 @@ namespace NodaTime.Calendars
         private const int AverageDaysPer10Years = (DaysPerNonLeapYear * 25 + DaysPerLeapYear * 8) * 10 / 33;
         internal const int MaxPersianYear = 9377;
 
+        /// <summary>The number of days preceding the 1-indexed month - so [0, 0, 31, 62, 93, ...]</summary>
         private static readonly int[] TotalDaysByMonth = GenerateTotalDaysByMonth();
 
         private readonly int[] startOfYearInDaysCache;

--- a/src/NodaTime/Calendars/UmAlQuraYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/UmAlQuraYearMonthDayCalculator.cs
@@ -7,6 +7,12 @@ using NodaTime.Utility;
 using System;
 using System.Diagnostics.CodeAnalysis;
 
+// Remove static constructors.
+// The static constructor here does enough work across multiple fields that
+// it would be awkward to initialize the fields inline. It's an internal
+// class and referenced pretty rarely, so it really shouldn't be a problem.
+#pragma warning disable CA1810
+
 namespace NodaTime.Calendars
 {
     /// <summary>

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -146,7 +146,7 @@ namespace NodaTime
         /// <exception cref="ArgumentException"><paramref name="interval" /> uses a different
         /// calendar to this date interval.</exception>
         /// <returns><c>true</c> if <paramref name="interval"/> is within this interval; <c>false</c> otherwise.</returns>
-        public bool Contains(DateInterval interval)
+        public bool Contains([ValidatedNotNull] DateInterval interval)
         {
             ValidateInterval(interval);
             return Start <= interval.Start && interval.End <= End;
@@ -204,7 +204,7 @@ namespace NodaTime
         /// </returns>
         /// <exception cref="ArgumentException"><paramref name="interval" /> uses a different
         /// calendar to this date interval.</exception>
-        public DateInterval? Intersection(DateInterval interval) =>
+        public DateInterval? Intersection([ValidatedNotNull] DateInterval interval) =>
             Contains(interval) ? interval
                 : interval.Contains(this) ? this
                 : interval.Contains(Start) ? new DateInterval(Start, interval.End)
@@ -220,7 +220,7 @@ namespace NodaTime
         /// instance, in the case the intervals overlap or are contiguous; a null reference otherwise.
         /// </returns>
         /// <exception cref="ArgumentException"><paramref name="interval" /> uses a different calendar to this date interval.</exception>
-        public DateInterval? Union(DateInterval interval)
+        public DateInterval? Union([ValidatedNotNull] DateInterval interval)
         {
             ValidateInterval(interval);
 

--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -103,7 +103,7 @@ namespace NodaTime
         /// compare equal to an instance returned by calling <see cref="ForOffset"/> with an offset of zero, but it may
         /// or may not compare equal to an instance returned by e.g. <c>DateTimeZoneProviders.Tzdb["UTC"]</c>.
         /// </remarks>
-        /// <value>A UTC <see cref="T:NodaTime.DateTimeZone" />.</value>
+        /// <value>A UTC <see cref="NodaTime.DateTimeZone" />.</value>
         public static DateTimeZone Utc { get; } = new FixedDateTimeZone(Offset.Zero);
         private const int FixedZoneCacheGranularitySeconds = NodaConstants.SecondsPerMinute * 30;
         private const int FixedZoneCacheMinimumSeconds = -FixedZoneCacheGranularitySeconds * 12 * 2; // From UTC-12
@@ -142,7 +142,7 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:NodaTime.DateTimeZone" /> class.
+        /// Initializes a new instance of the <see cref="NodaTime.DateTimeZone" /> class.
         /// </summary>
         /// <param name="id">The unique id of this time zone.</param>
         /// <param name="isFixed">Set to <c>true</c> if this time zone has no transitions.</param>
@@ -214,8 +214,8 @@ namespace NodaTime
         /// <remarks>
         /// This will always return a valid zone interval, as time zones cover the whole of time.
         /// </remarks>
-        /// <param name="instant">The <see cref="T:NodaTime.Instant" /> to query.</param>
-        /// <returns>The defined <see cref="T:NodaTime.TimeZones.ZoneInterval" />.</returns>
+        /// <param name="instant">The <see cref="NodaTime.Instant" /> to query.</param>
+        /// <returns>The defined <see cref="NodaTime.TimeZones.ZoneInterval" />.</returns>
         /// <seealso cref="GetZoneIntervals(Interval)"/>
         public abstract ZoneInterval GetZoneInterval(Instant instant);
 

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -454,12 +454,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("o").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -127,6 +127,7 @@ namespace NodaTime
         // NanosecondsPerDay - 1, for example.)
         private readonly long nanoOfDay;
 
+#pragma warning disable CA1801 // Remove/use unused parameter
         // Trusted constructor with no validation. The value of the noValidation parameter is
         // ignored completely; its name is just to be suggestive.
         private Duration([Trusted] int days, [Trusted] long nanoOfDay, bool noValidation)
@@ -134,6 +135,7 @@ namespace NodaTime
             this.days = days;
             this.nanoOfDay = nanoOfDay;
         }
+#pragma warning restore CA1801
 
         // Implementation note: I've tried making this internal and calling it directly from Instant.FromUnixTimeSeconds etc?
         // That reduces the number of range checks, but doesn't seem to affect the performance in a significant way.

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -174,7 +174,7 @@ namespace NodaTime.Globalization
         /// See https://xamarin.github.io/bugzilla-archives/11/11361/bug.html for more details and progress.
         /// </para>
         /// </remarks>
-        private IReadOnlyList<string> ConvertGenitiveMonthArray(IReadOnlyList<string> nonGenitiveNames, string[] bclNames, string[] invariantNames)
+        private static IReadOnlyList<string> ConvertGenitiveMonthArray(IReadOnlyList<string> nonGenitiveNames, string[] bclNames, string[] invariantNames)
         {
             if (int.TryParse(bclNames[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var _))
             {

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -453,6 +453,9 @@ namespace NodaTime.Globalization
                 }
                 else
                 {
+                    // If the BCL has provided an era name other than the one we'd consider to be the primary one, make *that*
+                    // the primary one for formatting.
+                    // TODO: Achieve the same result without the string allocations.
                     string? eraNameFromCulture = GetEraNameFromBcl(era, cultureInfo);
                     if (eraNameFromCulture != null && !pipeDelimited.StartsWith(eraNameFromCulture + "|", StringComparison.Ordinal))
                     {

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -454,7 +454,7 @@ namespace NodaTime.Globalization
                 else
                 {
                     string? eraNameFromCulture = GetEraNameFromBcl(era, cultureInfo);
-                    if (eraNameFromCulture != null && !pipeDelimited.StartsWith(eraNameFromCulture + "|"))
+                    if (eraNameFromCulture != null && !pipeDelimited.StartsWith(eraNameFromCulture + "|", StringComparison.Ordinal))
                     {
                         pipeDelimited = $"{eraNameFromCulture}|{pipeDelimited}";
                     }

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -448,7 +448,7 @@ namespace NodaTime.Globalization
                 string[] allNames;
                 if (pipeDelimited is null)
                 {
-                    allNames = new string[0];
+                    allNames = Array.Empty<string>();
                     primaryName = "";
                 }
                 else

--- a/src/NodaTime/IClock.cs
+++ b/src/NodaTime/IClock.cs
@@ -18,7 +18,6 @@ namespace NodaTime
     /// assembly (or your own implementation).
     /// </remarks>
     /// <seealso cref="SystemClock"/>
-    /// <seealso cref="NodaTime.Testing.FakeClock"/>
     /// <threadsafety>All implementations in Noda Time are thread-safe; custom implementations
     /// should be thread-safe too. See the thread safety section of the user guide for more information.
     /// </threadsafety>

--- a/src/NodaTime/IClock.cs
+++ b/src/NodaTime/IClock.cs
@@ -18,7 +18,7 @@ namespace NodaTime
     /// assembly (or your own implementation).
     /// </remarks>
     /// <seealso cref="SystemClock"/>
-    /// <seealso cref="T:NodaTime.Testing.FakeClock"/>
+    /// <seealso cref="NodaTime.Testing.FakeClock"/>
     /// <threadsafety>All implementations in Noda Time are thread-safe; custom implementations
     /// should be thread-safe too. See the thread safety section of the user guide for more information.
     /// </threadsafety>

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -491,12 +491,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("g").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -73,6 +73,7 @@ namespace NodaTime
         /// </summary>
         private readonly Duration duration;
 
+#pragma warning disable CA1801 // Remove/use unused parameter
         /// <summary>
         /// Constructor which should *only* be used to construct the invalid instances.
         /// </summary>
@@ -80,6 +81,7 @@ namespace NodaTime
         {
             this.duration = new Duration(days, 0);
         }
+#pragma warning restore CA1801
 
         /// <summary>
         /// Constructor which constructs a new instance with the given duration, which

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -235,6 +235,7 @@ namespace NodaTime
         /// <returns>A new <see cref="LocalDate"/> with the same values as the specified <c>DateTime</c>.</returns>
         public static LocalDate FromDateTime(DateTime dateTime, CalendarSystem calendar)
         {
+            Preconditions.CheckNotNull(calendar, nameof(calendar));
             int days = NonNegativeTicksToDays(dateTime.Ticks) - NodaConstants.BclDaysAtUnixEpoch;
             return new LocalDate(days, calendar);
         }

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -809,12 +809,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("D").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -338,6 +338,7 @@ namespace NodaTime
         /// <returns>A new <see cref="LocalDateTime"/> with the same values as the specified <c>DateTime</c>.</returns>
         public static LocalDateTime FromDateTime(DateTime dateTime, CalendarSystem calendar)
         {
+            Preconditions.CheckNotNull(calendar, nameof(calendar));
             int days = TickArithmetic.NonNegativeTicksToDaysAndTickOfDay(dateTime.Ticks, out long tickOfDay) - NodaConstants.BclDaysAtUnixEpoch;
             return new LocalDateTime(new LocalDate(days, calendar), new LocalTime(unchecked(tickOfDay * NodaConstants.NanosecondsPerTick)));
         }

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -933,12 +933,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("G").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/LocalInstant.cs
+++ b/src/NodaTime/LocalInstant.cs
@@ -24,6 +24,7 @@ namespace NodaTime
         /// </summary>
         private readonly Duration duration;
 
+#pragma warning disable CA1801 // Remove/use unused parameter
         /// <summary>
         /// Constructor which should *only* be used to construct the invalid instances.
         /// </summary>
@@ -31,6 +32,7 @@ namespace NodaTime
         {
             this.duration = new Duration(days, 0);
         }
+#pragma warning restore CA1801
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LocalInstant"/> struct.

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -789,12 +789,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("T").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/NodaConstants.cs
+++ b/src/NodaTime/NodaConstants.cs
@@ -176,11 +176,11 @@ namespace NodaTime
         /// <summary>
         /// The number of ticks in a BCL DateTime at the Unix epoch.
         /// </summary>
-        internal static readonly long BclTicksAtUnixEpoch = 621355968000000000;
+        internal const long BclTicksAtUnixEpoch = 621355968000000000;
 
         /// <summary>
         /// The number of days in a BCL DateTime at the Unix epoch.
         /// </summary>
-        internal static readonly int BclDaysAtUnixEpoch = 719162;
+        internal const int BclDaysAtUnixEpoch = 719162;
     }
 }

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -23,5 +23,9 @@
   
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/NodaTime/Offset.cs
+++ b/src/NodaTime/Offset.cs
@@ -375,12 +375,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("g").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/OffsetDate.cs
+++ b/src/NodaTime/OffsetDate.cs
@@ -190,12 +190,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("G").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -17,6 +17,11 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using static NodaTime.NodaConstants;
 
+// Do not nest type X.
+// The rule is somewhat subjective, but more importantly these have been available
+// publicly for a while, so we can't change them now anyway.
+#pragma warning disable CA1034
+
 namespace NodaTime
 {
     /// <summary>

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -493,12 +493,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("G").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/OffsetTime.cs
+++ b/src/NodaTime/OffsetTime.cs
@@ -264,12 +264,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("G").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -316,6 +316,15 @@ namespace NodaTime
         }
 
         /// <summary>
+        /// Adds two periods together, by simply adding the values for each property.
+        /// </summary>
+        /// <param name="left">The first period to add</param>
+        /// <param name="right">The second period to add</param>
+        /// <returns>The sum of the two periods. The units of the result will be the union of those in both
+        /// periods.</returns>
+        public static Period Add(Period left, Period right) => left + right;
+
+        /// <summary>
         /// Creates an <see cref="IComparer{T}"/> for periods, using the given "base" local date/time.
         /// </summary>
         /// <remarks>
@@ -353,6 +362,16 @@ namespace NodaTime
                 minuend.Ticks - subtrahend.Ticks,
                 minuend.Nanoseconds - subtrahend.Nanoseconds);
         }
+
+        /// <summary>
+        /// Subtracts one period from another, by simply subtracting each property value.
+        /// </summary>
+        /// <param name="minuend">The period to subtract the second operand from</param>
+        /// <param name="subtrahend">The period to subtract the first operand from</param>
+        /// <returns>The result of subtracting all the values in the second operand from the values in the first. The
+        /// units of the result will be the union of both periods, even if the subtraction caused some properties to
+        /// become zero (so "2 weeks, 1 days" minus "2 weeks" is "zero weeks, 1 days", not "1 days").</returns>
+        public static Period Subtract(Period minuend, Period subtrahend) => minuend - subtrahend;
 
         /// <summary>
         /// Returns the number of days between two <see cref="LocalDate"/> objects.

--- a/src/NodaTime/SkippedTimeException.cs
+++ b/src/NodaTime/SkippedTimeException.cs
@@ -6,6 +6,13 @@ using NodaTime.Annotations;
 using NodaTime.Utility;
 using System;
 
+// Standard exception constructors: we don't *want* those constructors.
+// The single constructor provided in this class populates the message and
+// accepts the required parameters for populating other properties.
+// There are never any other causes to the exception, at least that I can
+// envisage for the moment.
+#pragma warning disable CA1032
+
 namespace NodaTime
 {
     /// <summary>

--- a/src/NodaTime/Text/AnnualDatePattern.cs
+++ b/src/NodaTime/Text/AnnualDatePattern.cs
@@ -139,7 +139,7 @@ namespace NodaTime.Text
         /// <param name="templateValue">Template value to use for unspecified fields</param>
         /// <returns>A pattern for parsing and formatting annual dates.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static AnnualDatePattern Create(string patternText, CultureInfo cultureInfo, AnnualDate templateValue) =>
+        public static AnnualDatePattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo, AnnualDate templateValue) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), templateValue);
 
         /// <summary>
@@ -198,7 +198,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public AnnualDatePattern WithCulture(CultureInfo cultureInfo) =>
+        public AnnualDatePattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             WithFormatInfo(NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>

--- a/src/NodaTime/Text/DurationPattern.cs
+++ b/src/NodaTime/Text/DurationPattern.cs
@@ -112,7 +112,7 @@ namespace NodaTime.Text
         /// <param name="cultureInfo">The culture to use in the pattern</param>
         /// <returns>A pattern for parsing and formatting offsets.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static DurationPattern Create(string patternText, CultureInfo cultureInfo) =>
+        public static DurationPattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public DurationPattern WithCulture(CultureInfo cultureInfo) =>
+        public DurationPattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             Create(PatternText, NodaFormatInfo.GetFormatInfo(cultureInfo));
     }
 }

--- a/src/NodaTime/Text/InstantPattern.cs
+++ b/src/NodaTime/Text/InstantPattern.cs
@@ -137,7 +137,7 @@ namespace NodaTime.Text
         /// <param name="cultureInfo">The culture to use in the pattern</param>
         /// <returns>A pattern for parsing and formatting instants.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static InstantPattern Create(string patternText, CultureInfo cultureInfo) =>
+        public static InstantPattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), DefaultTemplateValue);
 
         /// <summary>
@@ -180,7 +180,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public InstantPattern WithCulture(CultureInfo cultureInfo) =>
+        public InstantPattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             WithFormatInfo(NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>

--- a/src/NodaTime/Text/InvalidPatternException.cs
+++ b/src/NodaTime/Text/InvalidPatternException.cs
@@ -6,6 +6,11 @@ using NodaTime.Annotations;
 using System;
 using System.Globalization;
 
+// Standard exception constructors.
+// This exception is expected to be constructed within the library, and there are never any
+// inner exceptions.
+#pragma warning disable CA1032
+
 namespace NodaTime.Text
 {
     /// <summary>

--- a/src/NodaTime/Text/LocalDatePattern.cs
+++ b/src/NodaTime/Text/LocalDatePattern.cs
@@ -153,7 +153,7 @@ namespace NodaTime.Text
         /// <param name="templateValue">Template value to use for unspecified fields</param>
         /// <returns>A pattern for parsing and formatting local dates.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static LocalDatePattern Create(string patternText, CultureInfo cultureInfo, LocalDate templateValue) =>
+        public static LocalDatePattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo, LocalDate templateValue) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), templateValue);
 
         /// <summary>
@@ -212,7 +212,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public LocalDatePattern WithCulture(CultureInfo cultureInfo) =>
+        public LocalDatePattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             WithFormatInfo(NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>

--- a/src/NodaTime/Text/LocalDateTimePattern.cs
+++ b/src/NodaTime/Text/LocalDateTimePattern.cs
@@ -199,7 +199,7 @@ namespace NodaTime.Text
         /// <param name="templateValue">Template value to use for unspecified fields</param>
         /// <returns>A pattern for parsing and formatting local date/times.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static LocalDateTimePattern Create(string patternText, CultureInfo cultureInfo,
+        public static LocalDateTimePattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo,
             LocalDateTime templateValue) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), templateValue);
 
@@ -257,7 +257,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public LocalDateTimePattern WithCulture(CultureInfo cultureInfo) =>
+        public LocalDateTimePattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             WithFormatInfo(NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>

--- a/src/NodaTime/Text/LocalTimePattern.cs
+++ b/src/NodaTime/Text/LocalTimePattern.cs
@@ -160,7 +160,7 @@ namespace NodaTime.Text
         /// <param name="templateValue">Template value to use for unspecified fields</param>
         /// <returns>A pattern for parsing and formatting local times.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static LocalTimePattern Create(string patternText, CultureInfo cultureInfo, LocalTime templateValue) =>
+        public static LocalTimePattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo, LocalTime templateValue) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), templateValue);
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public LocalTimePattern WithCulture(CultureInfo cultureInfo) =>
+        public LocalTimePattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             WithFormatInfo(NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>

--- a/src/NodaTime/Text/OffsetDatePattern.cs
+++ b/src/NodaTime/Text/OffsetDatePattern.cs
@@ -143,7 +143,7 @@ namespace NodaTime.Text
         /// <param name="templateValue">Template value to use for unspecified fields</param>
         /// <returns>A pattern for parsing and formatting local dates.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static OffsetDatePattern Create(string patternText, CultureInfo cultureInfo, OffsetDate templateValue) =>
+        public static OffsetDatePattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo, OffsetDate templateValue) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), templateValue);
 
         /// <summary>
@@ -198,7 +198,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public OffsetDatePattern WithCulture(CultureInfo cultureInfo) =>
+        public OffsetDatePattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             WithFormatInfo(NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>

--- a/src/NodaTime/Text/OffsetDateTimePattern.cs
+++ b/src/NodaTime/Text/OffsetDateTimePattern.cs
@@ -173,7 +173,7 @@ namespace NodaTime.Text
         /// <param name="templateValue">Template value to use for unspecified fields</param>
         /// <returns>A pattern for parsing and formatting local date/times.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static OffsetDateTimePattern Create(string patternText, CultureInfo cultureInfo, OffsetDateTime templateValue) =>
+        public static OffsetDateTimePattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo, OffsetDateTime templateValue) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), templateValue);
 
         /// <summary>
@@ -228,7 +228,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public OffsetDateTimePattern WithCulture(CultureInfo cultureInfo) =>
+        public OffsetDateTimePattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             WithFormatInfo(NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>

--- a/src/NodaTime/Text/OffsetPattern.cs
+++ b/src/NodaTime/Text/OffsetPattern.cs
@@ -109,7 +109,7 @@ namespace NodaTime.Text
         /// <param name="cultureInfo">The culture to use in the pattern</param>
         /// <returns>A pattern for parsing and formatting offsets.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static OffsetPattern Create(string patternText, CultureInfo cultureInfo) =>
+        public static OffsetPattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>
@@ -146,7 +146,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public OffsetPattern WithCulture(CultureInfo cultureInfo) =>
+        public OffsetPattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             Create(PatternText, NodaFormatInfo.GetFormatInfo(cultureInfo));
     }
 }

--- a/src/NodaTime/Text/OffsetPatternParser.cs
+++ b/src/NodaTime/Text/OffsetPatternParser.cs
@@ -107,6 +107,8 @@ namespace NodaTime.Text
 
             // Handle Z-prefix by stripping it, parsing the rest as a normal pattern, then building a special pattern
             // which decides whether or not to delegate.
+            // Note that patternText is guaranteed not to be empty due to the check at the start.
+            // (And assuming we don't add any standard => custom pattern expansions that result in an empty pattern.)
             bool zPrefix = patternText[0] == 'Z';
 
             var patternBuilder = new SteppedPatternBuilder<Offset, OffsetParseBucket>(formatInfo, () => new OffsetParseBucket());

--- a/src/NodaTime/Text/OffsetPatternParser.cs
+++ b/src/NodaTime/Text/OffsetPatternParser.cs
@@ -107,7 +107,7 @@ namespace NodaTime.Text
 
             // Handle Z-prefix by stripping it, parsing the rest as a normal pattern, then building a special pattern
             // which decides whether or not to delegate.
-            bool zPrefix = patternText.StartsWith("Z");
+            bool zPrefix = patternText[0] == 'Z';
 
             var patternBuilder = new SteppedPatternBuilder<Offset, OffsetParseBucket>(formatInfo, () => new OffsetParseBucket());
             patternBuilder.ParseCustomPattern(zPrefix ? patternText.Substring(1) : patternText, PatternCharacterHandlers);
@@ -155,7 +155,7 @@ namespace NodaTime.Text
             public StringBuilder AppendFormat(Offset value, StringBuilder builder)
             {
                 Preconditions.CheckNotNull(builder, nameof(builder));
-                return value == Offset.Zero ? builder.Append("Z") : fullPattern.AppendFormat(value, builder);
+                return value == Offset.Zero ? builder.Append('Z') : fullPattern.AppendFormat(value, builder);
             }
         }
 

--- a/src/NodaTime/Text/OffsetTimePattern.cs
+++ b/src/NodaTime/Text/OffsetTimePattern.cs
@@ -157,7 +157,7 @@ namespace NodaTime.Text
         /// <param name="templateValue">Template value to use for unspecified fields</param>
         /// <returns>A pattern for parsing and formatting local times.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static OffsetTimePattern Create(string patternText, CultureInfo cultureInfo, OffsetTime templateValue) =>
+        public static OffsetTimePattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo, OffsetTime templateValue) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), templateValue);
 
         /// <summary>
@@ -212,7 +212,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public OffsetTimePattern WithCulture(CultureInfo cultureInfo) =>
+        public OffsetTimePattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             WithFormatInfo(NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>

--- a/src/NodaTime/Text/ParseResult.cs
+++ b/src/NodaTime/Text/ParseResult.cs
@@ -139,6 +139,8 @@ namespace NodaTime.Text
 
         #region Factory methods and readonly static fields
 
+// Changing this would be a breaking change, and I'm comfortable with it anyway.
+#pragma warning disable CA1000 // Do not declare static members on generic types
         /// <summary>
         /// Produces a ParseResult which represents a successful parse operation.
         /// </summary>
@@ -159,6 +161,7 @@ namespace NodaTime.Text
         /// <returns>A ParseResult representing a failed parsing operation.</returns>
         public static ParseResult<T> ForException(Func<Exception> exceptionProvider) =>
            new ParseResult<T>(Preconditions.CheckNotNull(exceptionProvider, nameof(exceptionProvider)), false);
+#pragma warning restore CA1000
 
         internal static ParseResult<T> ForInvalidValue(ValueCursor cursor, string formatString, params object[] parameters) =>
             ForInvalidValue(() =>

--- a/src/NodaTime/Text/Patterns/DatePatternHelper.cs
+++ b/src/NodaTime/Text/Patterns/DatePatternHelper.cs
@@ -114,13 +114,18 @@ namespace NodaTime.Text.Patterns
                 this.getter = getter;
             }
 
+#pragma warning disable CA1822 // Make this static
+#pragma warning disable CA1801 // Use/remove unused parameters
             [ExcludeFromCodeCoverage]
             internal void DummyMethod(TResult value, StringBuilder builder)
             {
                 // This method is never called. We use it to create a delegate with a target that implements
                 // IPostPatternParseFormatAction. There's no test for this throwing.
+                // This method must be an instance method, so that we can get the target of the method in SteppedPatternBuilder.Build.
                 throw new InvalidOperationException("This method should never be called");
             }
+#pragma warning restore CA1801
+#pragma warning restore CA1822
 
             public Action<TResult, StringBuilder> BuildFormatAction(PatternFields finalFields)
             {

--- a/src/NodaTime/Text/Patterns/PatternCursor.cs
+++ b/src/NodaTime/Text/Patterns/PatternCursor.cs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using System.Globalization;
 using System.Text;
 
 namespace NodaTime.Text.Patterns
@@ -104,7 +105,7 @@ namespace NodaTime.Text.Patterns
         {
             if (!MoveNext() || Current != EmbeddedPatternStart)
             {
-                throw new InvalidPatternException(string.Format(TextErrorMessages.MissingEmbeddedPatternStart, EmbeddedPatternStart));
+                throw new InvalidPatternException(string.Format(CultureInfo.CurrentCulture, TextErrorMessages.MissingEmbeddedPatternStart, EmbeddedPatternStart));
             }
             int startIndex = Index + 1;
             int depth = 1; // For nesting
@@ -138,7 +139,7 @@ namespace NodaTime.Text.Patterns
                 }
             }
             // We've reached the end of the enclosing pattern without reaching the end of the embedded pattern. Oops.
-            throw new InvalidPatternException(string.Format(TextErrorMessages.MissingEmbeddedPatternEnd, EmbeddedPatternEnd));
+            throw new InvalidPatternException(string.Format(CultureInfo.CurrentCulture, TextErrorMessages.MissingEmbeddedPatternEnd, EmbeddedPatternEnd));
         }
     }
 }

--- a/src/NodaTime/Text/Patterns/SteppedPatternBuilder.cs
+++ b/src/NodaTime/Text/Patterns/SteppedPatternBuilder.cs
@@ -416,7 +416,7 @@ namespace NodaTime.Text.Patterns
             {
                 if (!nonNegativePredicate(value))
                 {
-                    builder.Append("-");
+                    builder.Append('-');
                 }
             });
         }

--- a/src/NodaTime/Text/Patterns/SteppedPatternBuilder.cs
+++ b/src/NodaTime/Text/Patterns/SteppedPatternBuilder.cs
@@ -247,6 +247,7 @@ namespace NodaTime.Text.Patterns
         }
 
 #pragma warning disable IDE0060
+#pragma warning disable CA1801 // Remove/use unused parameter
         // Note: the builder parameter is unused, but required so that the method fits the delegate signature.
 
         /// <summary>
@@ -254,6 +255,7 @@ namespace NodaTime.Text.Patterns
         /// "use a custom format string consisting of H instead of a standard pattern H".
         /// </summary>
         internal static void HandlePercent(PatternCursor pattern, SteppedPatternBuilder<TResult, TBucket> builder)
+#pragma warning restore CA1801
 #pragma warning restore IDE0060
         {
             if (pattern.HasMoreCharacters)

--- a/src/NodaTime/Text/Patterns/SteppedPatternBuilder.cs
+++ b/src/NodaTime/Text/Patterns/SteppedPatternBuilder.cs
@@ -23,7 +23,7 @@ namespace NodaTime.Text.Patterns
         private readonly List<ParseAction> parseActions;
         private readonly Func<TBucket> bucketProvider;
         private PatternFields usedFields;
-        private bool formatOnly = false;
+        private bool formatOnly;
 
         internal NodaFormatInfo FormatInfo { get; }
 

--- a/src/NodaTime/Text/Patterns/TimePatternHelper.cs
+++ b/src/NodaTime/Text/Patterns/TimePatternHelper.cs
@@ -167,7 +167,7 @@ namespace NodaTime.Text.Patterns
 
                 // If we don't have an AM or PM designator, we're nearly done. Set the AM/PM designator
                 // to the special value of 2, meaning "take it from the template".
-                if (amDesignator == "" && pmDesignator == "")
+                if (amDesignator.Length == 0 && pmDesignator.Length == 0)
                 {
                     builder.AddParseAction((str, bucket) =>
                     {
@@ -178,9 +178,9 @@ namespace NodaTime.Text.Patterns
                 }
                 // Odd scenario (but present in af-ZA for .NET 2) - exactly one of the AM/PM designator is valid.
                 // Delegate to a separate method to keep this clearer...
-                if (amDesignator == "" || pmDesignator == "")
+                if (amDesignator.Length == 0 || pmDesignator.Length == 0)
                 {
-                    int specifiedDesignatorValue = amDesignator == "" ? 1 : 0;
+                    int specifiedDesignatorValue = amDesignator.Length == 0 ? 1 : 0;
                     string specifiedDesignator = specifiedDesignatorValue == 1 ? pmDesignator : amDesignator;
                     HandleHalfAmPmDesignator(count, specifiedDesignator, specifiedDesignatorValue, hourOfDayGetter, amPmSetter, builder);
                     return;

--- a/src/NodaTime/Text/PeriodPattern.cs
+++ b/src/NodaTime/Text/PeriodPattern.cs
@@ -78,7 +78,7 @@ namespace NodaTime.Text
         /// <returns>The builder passed in as <paramref name="builder"/>.</returns>
         public StringBuilder AppendFormat(Period value, StringBuilder builder) => pattern.AppendFormat(value, builder);
 
-        private static void AppendValue(StringBuilder builder, long value, string suffix)
+        private static void AppendValue(StringBuilder builder, long value, char suffix)
         {
             // Avoid having a load of conditions in the calling code by checking here
             if (value == 0)
@@ -184,20 +184,20 @@ namespace NodaTime.Text
             {
                 Preconditions.CheckNotNull(value, nameof(value));
                 Preconditions.CheckNotNull(builder, nameof(builder));
-                builder.Append("P");
-                AppendValue(builder, value.Years, "Y");
-                AppendValue(builder, value.Months, "M");
-                AppendValue(builder, value.Weeks, "W");
-                AppendValue(builder, value.Days, "D");
+                builder.Append('P');
+                AppendValue(builder, value.Years, 'Y');
+                AppendValue(builder, value.Months, 'M');
+                AppendValue(builder, value.Weeks, 'W');
+                AppendValue(builder, value.Days, 'D');
                 if (value.HasTimeComponent)
                 {
-                    builder.Append("T");
-                    AppendValue(builder, value.Hours, "H");
-                    AppendValue(builder, value.Minutes, "M");
-                    AppendValue(builder, value.Seconds, "S");
-                    AppendValue(builder, value.Milliseconds, "s");
-                    AppendValue(builder, value.Ticks, "t");
-                    AppendValue(builder, value.Nanoseconds, "n");
+                    builder.Append('T');
+                    AppendValue(builder, value.Hours, 'H');
+                    AppendValue(builder, value.Minutes, 'M');
+                    AppendValue(builder, value.Seconds, 'S');
+                    AppendValue(builder, value.Milliseconds, 's');
+                    AppendValue(builder, value.Ticks, 't');
+                    AppendValue(builder, value.Nanoseconds, 'n');
                 }
                 return builder;
             }
@@ -346,33 +346,33 @@ namespace NodaTime.Text
                     builder.Append("P0D");
                     return builder;
                 }
-                builder.Append("P");
-                AppendValue(builder, value.Years, "Y");
-                AppendValue(builder, value.Months, "M");
-                AppendValue(builder, value.Weeks, "W");
-                AppendValue(builder, value.Days, "D");
+                builder.Append('P');
+                AppendValue(builder, value.Years, 'Y');
+                AppendValue(builder, value.Months, 'M');
+                AppendValue(builder, value.Weeks, 'W');
+                AppendValue(builder, value.Days, 'D');
                 if (value.HasTimeComponent)
                 {
-                    builder.Append("T");
-                    AppendValue(builder, value.Hours, "H");
-                    AppendValue(builder, value.Minutes, "M");
+                    builder.Append('T');
+                    AppendValue(builder, value.Hours, 'H');
+                    AppendValue(builder, value.Minutes, 'M');
                     long nanoseconds = value.Milliseconds * NanosecondsPerMillisecond + value.Ticks * NanosecondsPerTick + value.Nanoseconds;
                     long seconds = value.Seconds;
                     if (nanoseconds != 0 || seconds != 0)
                     {
                         if (nanoseconds < 0 || seconds < 0)
                         {
-                            builder.Append("-");
+                            builder.Append('-');
                             nanoseconds = -nanoseconds;
                             seconds = -seconds;
                         }
                         FormatHelper.FormatInvariant(seconds, builder);
                         if (nanoseconds != 0)
                         {
-                            builder.Append(".");
+                            builder.Append('.');
                             FormatHelper.AppendFractionTruncate((int) nanoseconds, 9, 9, builder);
                         }
-                        builder.Append("S");
+                        builder.Append('S');
                     }
                 }
                 return builder;

--- a/src/NodaTime/Text/UnparsableValueException.cs
+++ b/src/NodaTime/Text/UnparsableValueException.cs
@@ -31,5 +31,14 @@ namespace NodaTime.Text
             : base(message)
         {
         }
+
+        /// <summary>
+        /// Creates a new UnparsableValueException with the given message and inner exception
+        /// </summary>
+        /// <param name="message">The failure message</param>
+        /// <param name="innerException">The inner exception</param>
+        public UnparsableValueException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
     }
 }

--- a/src/NodaTime/Text/YearMonthPattern.cs
+++ b/src/NodaTime/Text/YearMonthPattern.cs
@@ -142,7 +142,7 @@ namespace NodaTime.Text
         /// <param name="templateValue">Template value to use for unspecified fields</param>
         /// <returns>A pattern for parsing and formatting year/months.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static YearMonthPattern Create(string patternText, CultureInfo cultureInfo, YearMonth templateValue) =>
+        public static YearMonthPattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo, YearMonth templateValue) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), templateValue);
 
         /// <summary>
@@ -201,7 +201,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public YearMonthPattern WithCulture(CultureInfo cultureInfo) =>
+        public YearMonthPattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             WithFormatInfo(NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>

--- a/src/NodaTime/Text/ZonedDateTimePattern.cs
+++ b/src/NodaTime/Text/ZonedDateTimePattern.cs
@@ -171,7 +171,7 @@ namespace NodaTime.Text
         /// <param name="templateValue">Template value to use for unspecified fields</param>
         /// <returns>A pattern for parsing and formatting zoned date/times.</returns>
         /// <exception cref="InvalidPatternException">The pattern text was invalid.</exception>
-        public static ZonedDateTimePattern Create(string patternText, CultureInfo cultureInfo,
+        public static ZonedDateTimePattern Create(string patternText, [ValidatedNotNull] CultureInfo cultureInfo,
             ZoneLocalMappingResolver? resolver, IDateTimeZoneProvider? zoneProvider, ZonedDateTime templateValue) =>
             Create(patternText, NodaFormatInfo.GetFormatInfo(cultureInfo), resolver, zoneProvider, templateValue);
 
@@ -230,7 +230,7 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="cultureInfo">The culture to use in the new pattern.</param>
         /// <returns>A new pattern with the given culture.</returns>
-        public ZonedDateTimePattern WithCulture(CultureInfo cultureInfo) =>
+        public ZonedDateTimePattern WithCulture([ValidatedNotNull] CultureInfo cultureInfo) =>
             WithFormatInfo(NodaFormatInfo.GetFormatInfo(cultureInfo));
 
         /// <summary>

--- a/src/NodaTime/Text/ZonedDateTimePatternParser.cs
+++ b/src/NodaTime/Text/ZonedDateTimePatternParser.cs
@@ -161,7 +161,7 @@ namespace NodaTime.Text
             /// zone. Otherwise, it will return null and the cursor will remain where
             /// it was.
             /// </summary>
-            private DateTimeZone? TryParseFixedZone(ValueCursor value)
+            private static DateTimeZone? TryParseFixedZone(ValueCursor value)
             {
                 if (value.CompareOrdinal(DateTimeZone.UtcId) != 0)
                 {

--- a/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
@@ -97,6 +97,8 @@ namespace NodaTime.TimeZones
         /// </remarks>        
         DateTimeZone IDateTimeZoneSource.ForId(string id) => ForId(id);
 
+// Even though this member could be static, it would be inconsistent with the interface member.
+#pragma warning disable CA1822 // Make this member static
         /// <summary>
         /// Creates a new instance of <see cref="BclDateTimeZone" /> from the <see cref="TimeZoneInfo"/> with the given
         /// ID. The ID must be a known system time zone ID.
@@ -116,6 +118,7 @@ namespace NodaTime.TimeZones
                 throw new ArgumentException(id + " is not a system time zone ID", nameof(id));
             }
         }
+#pragma warning restore CA1822
 
         // Note: if TimeZoneInfo.Local returns a null reference, we'll return a null reference here as well.
         // However, we *don't* attempt to validate that a non-null reference has a valid ID that can be looked up.

--- a/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/BclDateTimeZoneSource.cs
@@ -98,6 +98,7 @@ namespace NodaTime.TimeZones
         DateTimeZone IDateTimeZoneSource.ForId(string id) => ForId(id);
 
 // Even though this member could be static, it would be inconsistent with the interface member.
+// It would also be a breaking change.
 #pragma warning disable CA1822 // Make this member static
         /// <summary>
         /// Creates a new instance of <see cref="BclDateTimeZone" /> from the <see cref="TimeZoneInfo"/> with the given

--- a/src/NodaTime/TimeZones/DateTimeZoneCache.cs
+++ b/src/NodaTime/TimeZones/DateTimeZoneCache.cs
@@ -125,7 +125,9 @@ namespace NodaTime.TimeZones
                 var zone = GetZoneOrNull(id);
                 if (zone is null)
                 {
+#pragma warning disable CA1065 // Don't throw an exception from an indexer
                     throw new DateTimeZoneNotFoundException($"Time zone {id} is unknown to source {VersionId}");
+#pragma warning restore CA1065
                 }
                 return zone;
             }

--- a/src/NodaTime/TimeZones/DateTimeZoneNotFoundException.cs
+++ b/src/NodaTime/TimeZones/DateTimeZoneNotFoundException.cs
@@ -5,6 +5,11 @@
 using NodaTime.Annotations;
 using System;
 
+// Standard exception constructors.
+// This exception is expected to be constructed within the library.
+// There are never any inner exceptions, and we always *do* have a message.
+#pragma warning disable CA1032
+
 namespace NodaTime.TimeZones
 {
     /// <summary>

--- a/src/NodaTime/TimeZones/FixedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/FixedDateTimeZone.cs
@@ -74,7 +74,7 @@ namespace NodaTime.TimeZones
         /// <returns>The parsed time zone, or null if the ID doesn't match.</returns>
         internal static DateTimeZone? GetFixedZoneOrNull(string id)
         {
-            if (!id.StartsWith(UtcId))
+            if (!id.StartsWith(UtcId, StringComparison.Ordinal))
             {
                 return null;
             }

--- a/src/NodaTime/TimeZones/IO/TzdbStreamData.cs
+++ b/src/NodaTime/TimeZones/IO/TzdbStreamData.cs
@@ -146,8 +146,8 @@ namespace NodaTime.TimeZones.IO
             // Note: deliberately mutable, as this is useful later when we map the canonical IDs to themselves.
             // This is a mapping of the aliases from TZDB, at this point.
             internal IDictionary<string, string>? tzdbIdMap;
-            internal ReadOnlyCollection<TzdbZoneLocation>? zoneLocations = null;
-            internal ReadOnlyCollection<TzdbZone1970Location>? zone1970Locations = null;
+            internal ReadOnlyCollection<TzdbZoneLocation>? zoneLocations;
+            internal ReadOnlyCollection<TzdbZone1970Location>? zone1970Locations;
             internal WindowsZones? windowsMapping;
             internal readonly IDictionary<string, TzdbStreamField> zoneFields = new Dictionary<string, TzdbStreamField>();
 

--- a/src/NodaTime/TimeZones/IO/TzdbStreamData.cs
+++ b/src/NodaTime/TimeZones/IO/TzdbStreamData.cs
@@ -120,7 +120,7 @@ namespace NodaTime.TimeZones.IO
         {
             Preconditions.CheckNotNull(stream, nameof(stream));
 
-            // Using statement to satisfy FxCop, but disposable won't do anything anyway, because
+            // Using statement to satisfy FxCop, but dispose won't do anything anyway, because
             // we deliberately leave the stream open.
             using (var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true))
             {

--- a/src/NodaTime/TimeZones/IO/TzdbStreamData.cs
+++ b/src/NodaTime/TimeZones/IO/TzdbStreamData.cs
@@ -236,7 +236,7 @@ namespace NodaTime.TimeZones.IO
                 }
             }
 
-            private void CheckSingleField(TzdbStreamField field, object? expectedNullField)
+            private static void CheckSingleField(TzdbStreamField field, object? expectedNullField)
             {
                 if (expectedNullField != null)
                 {

--- a/src/NodaTime/TimeZones/InvalidDateTimeZoneSourceException.cs
+++ b/src/NodaTime/TimeZones/InvalidDateTimeZoneSourceException.cs
@@ -5,6 +5,11 @@
 using NodaTime.Annotations;
 using System;
 
+// Standard exception constructors.
+// This exception is expected to be constructed within the library.
+// There are never any inner exceptions, and we always *do* have a message.
+#pragma warning disable CA1032
+
 namespace NodaTime.TimeZones
 {
     /// <summary>

--- a/src/NodaTime/TimeZones/Resolvers.cs
+++ b/src/NodaTime/TimeZones/Resolvers.cs
@@ -20,7 +20,9 @@ namespace NodaTime.TimeZones
     /// </para>
     /// </remarks>
     /// <threadsafety>All members of this class are thread-safe, as are the values returned by them.</threadsafety>
+#pragma warning disable CA1724 // Name conflicts with a framework name
     public static class Resolvers
+#pragma warning restore CA1724
     {
         /// <summary>
         /// An <see cref="AmbiguousTimeResolver"/> which returns the earlier of the two matching times.

--- a/src/NodaTime/TimeZones/TzdbDateTimeZoneSource.cs
+++ b/src/NodaTime/TimeZones/TzdbDateTimeZoneSource.cs
@@ -304,7 +304,7 @@ namespace NodaTime.TimeZones
         /// <param name="zone">Zone to resolve in a best-effort fashion.</param>
         /// <param name="candidates">All the Noda Time zones to consider - normally a list 
         /// obtained from this source.</param>
-        internal string? GuessZoneIdByTransitionsUncached(TimeZoneInfo zone, List<DateTimeZone> candidates)
+        internal static string? GuessZoneIdByTransitionsUncached(TimeZoneInfo zone, List<DateTimeZone> candidates)
         {
             // See https://github.com/nodatime/nodatime/issues/686 for performance observations.
             // Very rare use of the system clock! Windows time zone updates sometimes sacrifice past

--- a/src/NodaTime/TimeZones/TzdbZone1970Location.cs
+++ b/src/NodaTime/TimeZones/TzdbZone1970Location.cs
@@ -10,6 +10,11 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 
+// Do not nest type X.
+// The rule is somewhat subjective, but more importantly these have been available
+// publicly for a while, so we can't change them now anyway.
+#pragma warning disable CA1034
+
 namespace NodaTime.TimeZones
 {
     /// <summary>

--- a/src/NodaTime/TimeZones/ZoneInterval.cs
+++ b/src/NodaTime/TimeZones/ZoneInterval.cs
@@ -306,13 +306,13 @@ namespace NodaTime.TimeZones
 
         #region object Overrides
         /// <summary>
-        /// Determines whether the specified <see cref="T:System.Object" /> is equal to the current <see cref="T:System.Object" />.
+        /// Determines whether the specified <see cref="System.Object" /> is equal to the current <see cref="System.Object" />.
         /// See the type documentation for a description of equality semantics.
         /// </summary>
         /// <returns>
-        /// <c>true</c> if the specified <see cref="T:System.Object" /> is equal to the current <see cref="T:System.Object" />; otherwise, <c>false</c>.
+        /// <c>true</c> if the specified <see cref="System.Object" /> is equal to the current <see cref="System.Object" />; otherwise, <c>false</c>.
         /// </returns>
-        /// <param name="obj">The <see cref="T:System.Object" /> to compare with the current <see cref="T:System.Object" />.</param>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with the current <see cref="System.Object" />.</param>
         /// <filterpriority>2</filterpriority>
         [DebuggerStepThrough]
         public override bool Equals(object? obj) => Equals(obj as ZoneInterval);

--- a/src/NodaTime/TimeZones/ZoneLocalMapping.cs
+++ b/src/NodaTime/TimeZones/ZoneLocalMapping.cs
@@ -115,7 +115,9 @@ namespace NodaTime.TimeZones
         /// <exception cref="SkippedTimeException">The local date/time was skipped in the time zone.</exception>
         /// <exception cref="AmbiguousTimeException">The local date/time was ambiguous in the time zone.</exception>
         /// <returns>The unambiguous result of mapping the local date/time in the time zone.</returns>
+#pragma warning disable CA1720 // Identifier contains type name
         public ZonedDateTime Single()
+#pragma warning restore CA1720
         {
             switch (Count)
             {

--- a/src/NodaTime/TimeZones/ZoneLocalMapping.cs
+++ b/src/NodaTime/TimeZones/ZoneLocalMapping.cs
@@ -12,7 +12,7 @@ namespace NodaTime.TimeZones
     // reference to avoid being resolved to the LocalDateTime property instead.
 
     /// <summary>
-    /// The result of mapping a <see cref="T:NodaTime.LocalDateTime" /> within a time zone, i.e. finding out
+    /// The result of mapping a <see cref="NodaTime.LocalDateTime" /> within a time zone, i.e. finding out
     /// at what "global" time the "local" time occurred.
     /// </summary>
     /// <remarks>
@@ -58,7 +58,7 @@ namespace NodaTime.TimeZones
         public DateTimeZone Zone { get; }
 
         /// <summary>
-        /// Gets the <see cref="T:NodaTime.LocalDateTime" /> which was mapped within the time zone.
+        /// Gets the <see cref="NodaTime.LocalDateTime" /> which was mapped within the time zone.
         /// </summary>
         /// <value>The local date and time which was mapped within the time zone.</value>
         public LocalDateTime LocalDateTime { get; }
@@ -88,7 +88,7 @@ namespace NodaTime.TimeZones
 
         /// <summary>
         /// Gets the number of results within this mapping: the number of distinct
-        /// <see cref="ZonedDateTime" /> values which map to the original <see cref="T:NodaTime.LocalDateTime" />.
+        /// <see cref="ZonedDateTime" /> values which map to the original <see cref="NodaTime.LocalDateTime" />.
         /// </summary>
         /// <value>The number of results within this mapping: the number of distinct values which map to the
         /// original local date and time.</value>
@@ -110,7 +110,7 @@ namespace NodaTime.TimeZones
 
         /// <summary>
         /// Returns the single <see cref="ZonedDateTime"/> which maps to the original
-        /// <see cref="T:NodaTime.LocalDateTime" /> in the mapped <see cref="DateTimeZone" />.
+        /// <see cref="NodaTime.LocalDateTime" /> in the mapped <see cref="DateTimeZone" />.
         /// </summary>
         /// <exception cref="SkippedTimeException">The local date/time was skipped in the time zone.</exception>
         /// <exception cref="AmbiguousTimeException">The local date/time was ambiguous in the time zone.</exception>
@@ -132,7 +132,7 @@ namespace NodaTime.TimeZones
         // TODO: Reimplement as switch expressions after fixing https://github.com/nodatime/nodatime/issues/1269
 
         /// <summary>
-        /// Returns a <see cref="ZonedDateTime"/> which maps to the original <see cref="T:NodaTime.LocalDateTime" />
+        /// Returns a <see cref="ZonedDateTime"/> which maps to the original <see cref="NodaTime.LocalDateTime" />
         /// in the mapped <see cref="DateTimeZone" />: either the single result if the mapping is unambiguous,
         /// or the earlier result if the local date/time occurs twice in the time zone due to a time zone
         /// offset change such as an autumnal daylight saving transition.
@@ -151,7 +151,7 @@ namespace NodaTime.TimeZones
         }
 
         /// <summary>
-        /// Returns a <see cref="ZonedDateTime"/> which maps to the original <see cref="T:NodaTime.LocalDateTime" />
+        /// Returns a <see cref="ZonedDateTime"/> which maps to the original <see cref="NodaTime.LocalDateTime" />
         /// in the mapped <see cref="DateTimeZone" />: either the single result if the mapping is unambiguous,
         /// or the later result if the local date/time occurs twice in the time zone due to a time zone
         /// offset change such as an autumnal daylight saving transition.

--- a/src/NodaTime/Utility/InvalidNodaDataException.cs
+++ b/src/NodaTime/Utility/InvalidNodaDataException.cs
@@ -5,6 +5,12 @@
 using NodaTime.Annotations;
 using System;
 
+// Standard exception constructors.
+// This exception is expected to be constructed within the library.
+// We always have a message, and we don't want to accidentally be able
+// to construct an instance of this exception without a message.
+#pragma warning disable CA1032
+
 namespace NodaTime.Utility
 {
     /// <summary>

--- a/src/NodaTime/Utility/Preconditions.cs
+++ b/src/NodaTime/Utility/Preconditions.cs
@@ -5,6 +5,7 @@
 using JetBrains.Annotations;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace NodaTime.Utility
 {
@@ -122,7 +123,7 @@ namespace NodaTime.Utility
 #if DEBUG
             if (!expression)
             {
-                string message = string.Format(messageFormat, messageArgs);
+                string message = string.Format(CultureInfo.CurrentCulture, messageFormat, messageArgs);
                 throw new DebugPreconditionException($"{message} (parameter name: {parameter})");
             }
 #endif
@@ -143,7 +144,7 @@ namespace NodaTime.Utility
         {
             if (!expression)
             {
-                string message = string.Format(messageFormat, messageArg);
+                string message = string.Format(CultureInfo.CurrentCulture, messageFormat, messageArg);
                 throw new ArgumentException(message, parameter);
             }
         }
@@ -154,7 +155,7 @@ namespace NodaTime.Utility
         {
             if (!expression)
             {
-                string message = string.Format(messageFormat, messageArg1, messageArg2);
+                string message = string.Format(CultureInfo.CurrentCulture, messageFormat, messageArg1, messageArg2);
                 throw new ArgumentException(message, parameter);
             }
         }

--- a/src/NodaTime/Utility/Preconditions.cs
+++ b/src/NodaTime/Utility/Preconditions.cs
@@ -181,6 +181,9 @@ namespace NodaTime.Utility
     }
 
 #if DEBUG
+// This is an internal exception very deliberately, and we don't need other constructor forms.
+#pragma warning disable CA1032 // Standard exception constructors
+#pragma warning disable CA1064 // Exceptions should be public
     /// <summary>
     /// Exception which occurs only for preconditions violated in debug mode. This is
     /// thrown from the Preconditions.Debug* methods to avoid them throwing exceptions
@@ -195,5 +198,7 @@ namespace NodaTime.Utility
         {
         }
     }
+#pragma warning restore CA1064
+#pragma warning restore CA1032
 #endif
 }

--- a/src/NodaTime/Xml/XmlSchemaDefinition.cs
+++ b/src/NodaTime/Xml/XmlSchemaDefinition.cs
@@ -10,6 +10,14 @@ using System.Xml.Schema;
 using System.Xml.Serialization;
 using NodaTime.Extensions;
 
+// Remove static constructors.
+// The static constructor here does a fair amount of work and includes
+// local variables that would either need to be initialized multiple times,
+// or stored in another static field. Although this is a public type,
+// it's not a commonly-used one; I don't expect the performance difference
+// to be significant enough to merit extraordinary measures.
+#pragma warning disable CA1810
+
 namespace NodaTime.Xml
 {
     /// <summary>

--- a/src/NodaTime/YearMonth.cs
+++ b/src/NodaTime/YearMonth.cs
@@ -320,12 +320,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("D").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>

--- a/src/NodaTime/YearMonthDay.cs
+++ b/src/NodaTime/YearMonthDay.cs
@@ -56,7 +56,7 @@ namespace NodaTime
         internal static YearMonthDay Parse(string text)
         {
             // Handle a leading - to negate the year
-            if (text.StartsWith("-"))
+            if (text.StartsWith("-", StringComparison.Ordinal))
             {
                 var ymd = Parse(text.Substring(1));
                 return new YearMonthDay(-ymd.Year, ymd.Month, ymd.Day);

--- a/src/NodaTime/YearMonthDay.cs
+++ b/src/NodaTime/YearMonthDay.cs
@@ -52,11 +52,11 @@ namespace NodaTime
         internal int Month => unchecked(((value & MonthMask) >> YearMonthDayCalendar.DayBits) + 1);
         internal int Day => unchecked((value & DayMask) + 1);
 
-        // Just for testing purposes...
+        // Just for testing purposes... note that this does not perform clean validation.
         internal static YearMonthDay Parse(string text)
         {
             // Handle a leading - to negate the year
-            if (text.StartsWith("-", StringComparison.Ordinal))
+            if (text[0] == '-')
             {
                 var ymd = Parse(text.Substring(1));
                 return new YearMonthDay(-ymd.Year, ymd.Month, ymd.Day);

--- a/src/NodaTime/YearMonthDayCalendar.cs
+++ b/src/NodaTime/YearMonthDayCalendar.cs
@@ -73,12 +73,12 @@ namespace NodaTime
         internal int Month => unchecked(((value & MonthMask) >> CalendarDayBits) + 1);
         internal int Day => unchecked(((value & DayMask) >> CalendarBits) + 1);
 
-        // Just for testing purposes...
+        // Just for testing purposes... note that this does not perform clean validation.
         [VisibleForTesting]
         internal static YearMonthDayCalendar Parse(string text)
         {
             // Handle a leading - to negate the year
-            if (text.StartsWith("-", StringComparison.Ordinal))
+            if (text[0] == '-')
             {
                 var ymdc = Parse(text.Substring(1));
                 return new YearMonthDayCalendar(-ymdc.Year, ymdc.Month, ymdc.Day, ymdc.CalendarOrdinal);

--- a/src/NodaTime/YearMonthDayCalendar.cs
+++ b/src/NodaTime/YearMonthDayCalendar.cs
@@ -78,7 +78,7 @@ namespace NodaTime
         internal static YearMonthDayCalendar Parse(string text)
         {
             // Handle a leading - to negate the year
-            if (text.StartsWith("-"))
+            if (text.StartsWith("-", StringComparison.Ordinal))
             {
                 var ymdc = Parse(text.Substring(1));
                 return new YearMonthDayCalendar(-ymdc.Year, ymdc.Month, ymdc.Day, ymdc.CalendarOrdinal);

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -17,6 +17,11 @@ using System.Xml;
 using System.Xml.Schema;
 using System.Xml.Serialization;
 
+// Do not nest type X.
+// The rule is somewhat subjective, but more importantly these have been available
+// publicly for a while, so we can't change them now anyway.
+#pragma warning disable CA1034
+
 namespace NodaTime
 {
     // Note: documentation that refers to the LocalDateTime type within this class must use the fully-qualified

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -23,7 +23,7 @@ namespace NodaTime
     // reference to avoid being resolved to the LocalDateTime property instead.
 
     /// <summary>
-    /// A <see cref="T:NodaTime.LocalDateTime" /> in a specific time zone and with a particular offset to distinguish
+    /// A <see cref="NodaTime.LocalDateTime" /> in a specific time zone and with a particular offset to distinguish
     /// between otherwise-ambiguous instants. A <see cref="ZonedDateTime"/> is global, in that it maps to a single
     /// <see cref="Instant"/>.
     /// </summary>
@@ -119,7 +119,7 @@ namespace NodaTime
         /// </summary>
         /// <remarks>
         /// The returned
-        /// <see cref="T:NodaTime.LocalDateTime"/> will have the same calendar system and return the same values for
+        /// <see cref="NodaTime.LocalDateTime"/> will have the same calendar system and return the same values for
         /// each of the calendar properties (Year, MonthOfYear and so on), but will not be associated with any
         /// particular time zone.
         /// </remarks>
@@ -254,7 +254,7 @@ namespace NodaTime
         /// <remarks>
         /// This is always an unambiguous conversion. Any difficulties due to daylight saving
         /// transitions or other changes in time zone are handled when converting from a
-        /// <see cref="T:NodaTime.LocalDateTime" /> to a <see cref="ZonedDateTime"/>; the <c>ZonedDateTime</c> remembers
+        /// <see cref="NodaTime.LocalDateTime" /> to a <see cref="ZonedDateTime"/>; the <c>ZonedDateTime</c> remembers
         /// the actual offset from UTC to local time, so it always knows the exact instant represented.
         /// </remarks>
         /// <returns>The instant corresponding to this value.</returns>
@@ -539,12 +539,12 @@ namespace NodaTime
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
         /// <returns>
-        /// A <see cref="T:System.String" /> containing the value of the current instance in the specified format.
+        /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
-        /// <param name="patternText">The <see cref="T:System.String" /> specifying the pattern to use,
+        /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
         /// or null to use the default format pattern ("G").
         /// </param>
-        /// <param name="formatProvider">The <see cref="T:System.IFormatProvider" /> to use when formatting the value,
+        /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
         /// </param>
         /// <filterpriority>2</filterpriority>


### PR DESCRIPTION
This PR looks huge, but each commit is relatively small. Definitely review one commit at a time!

I've deliberately *not* suppressed anything at a project level. Each suppression should be very explicit, so we don't get into bad habits. (There are some things that we might have done differently if we'd seen them from the start, but would now break things.)

This PR should be almost entirely invisible to users, with two exceptions:

- There are two static methods in LocalDate and LocalDateTime that will now (correctly) throw ArgumentNullException instead of NullReferenceException when null is passed to them
- There are two additional static methods in Period to match existing operators
