### PR TITLE
Use 1-based indexes for all month arrays in Islamic and Gregorian YearMonthDayCalculators

### DIFF
--- a/src/NodaTime/Calendars/GJYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/GJYearMonthDayCalculator.cs
@@ -9,21 +9,21 @@ namespace NodaTime.Calendars
     internal abstract class GJYearMonthDayCalculator : RegularYearMonthDayCalculator
     {
         // These arrays are NOT public. We trust ourselves not to alter the array.
-        // They use zero-based array indexes so the that valid range of months is
-        // automatically checked. They are protected so that GregorianYearMonthDayCalculator can
-        // read them.
-        protected static readonly int[] MinDaysPerMonth = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
-        protected static readonly int[] MaxDaysPerMonth = { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+        // They are protected so that GregorianYearMonthDayCalculator can read them.
+        // The arrays are 1-based (so "days in January" are accessed via array[1]); the index should be validated before
+        // use.
+        private protected static readonly int[] NonLeapDaysPerMonth = { 0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+        private protected static readonly int[] LeapDaysPerMonth = { 0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
 
-        // Note: these fields must be declared after MinDaysPerMonth and MaxDaysPerMonth so that the initialization
+        // Note: these fields must be declared after NonLeapDaysPerMonth and LeapDaysPerMonth so that the initialization
         // is correct. This behavior (textual order for initialization) is guaranteed by the spec. We'd normally
         // try to avoid relying on it, but that's quite hard here.
-        private static readonly int[] MinTotalDaysByMonth = GenerateTotalDaysByMonth(MinDaysPerMonth);
-        private static readonly int[] MaxTotalDaysByMonth = GenerateTotalDaysByMonth(MaxDaysPerMonth);
+        private static readonly int[] NonLeapTotalDaysByMonth = GenerateTotalDaysByMonth(NonLeapDaysPerMonth);
+        private static readonly int[] LeapTotalDaysByMonth = GenerateTotalDaysByMonth(LeapDaysPerMonth);
 
         /// <summary>
         /// Produces an array with "the sum of the elements of <paramref name="monthLengths"/> before the corresponding index".
-        /// So for an input of [1, 2, 3, 4, 5] this would produce [0, 1, 3, 6, 10].
+        /// So for an input of [0, 1, 2, 3, 4, 5] this would produce [0, 0, 1, 3, 6, 10].
         /// </summary>
         private static int[] GenerateTotalDaysByMonth(int[] monthLengths)
         {
@@ -80,6 +80,6 @@ namespace NodaTime.Calendars
             : 30 + ((month + (month >> 3)) & 1);
 
         protected override int GetDaysFromStartOfYearToStartOfMonth([Trusted] int year, [Trusted] int month) =>
-            IsLeapYear(year) ? MaxTotalDaysByMonth[month - 1] : MinTotalDaysByMonth[month - 1];
+            IsLeapYear(year) ? LeapTotalDaysByMonth[month] : NonLeapTotalDaysByMonth[month];
     }
 }

--- a/src/NodaTime/Calendars/GregorianYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/GregorianYearMonthDayCalculator.cs
@@ -151,7 +151,7 @@ namespace NodaTime.Calendars
             {
                 return;
             }
-            int daysInMonth = month == 2 && IsGregorianLeapYear(year) ? MaxDaysPerMonth[month - 1] : MinDaysPerMonth[month - 1];
+            int daysInMonth = month == 2 && IsGregorianLeapYear(year) ? LeapDaysPerMonth[month] : NonLeapDaysPerMonth[month];
             if (day < 1 || day > daysInMonth)
             {
                 Preconditions.CheckArgumentRange(nameof(day), day, 1, daysInMonth);

--- a/src/NodaTime/Calendars/IslamicYearMonthDayCalculator.cs
+++ b/src/NodaTime/Calendars/IslamicYearMonthDayCalculator.cs
@@ -41,18 +41,18 @@ namespace NodaTime.Calendars
         /// <summary>The pattern of leap years within a cycle, one bit per year, for this calendar.</summary>
         private readonly int leapYearPatternBits;
 
-        /// <summary>The number of days preceding the 0-indexed month - so [0, 30, 59, ...]</summary>
+        /// <summary>The number of days preceding the 1-indexed month - so [0, 0, 30, 59, ...]</summary>
         private static readonly int[] TotalDaysByMonth = GenerateTotalDaysByMonth();
 
         private static int[] GenerateTotalDaysByMonth()
         {
             int days = 0;
-            int[] ret = new int[12];
-            for (int i = 0; i < 12; i++)
+            int[] ret = new int[13];
+            for (int i = 1; i <= 12; i++)
             {
                 ret[i] = days;
-                // Here, the month number is 0-based, so even months are long
-                int daysInMonth = (i & 1) == 0 ? LongMonthLength : ShortMonthLength;
+                // Here, the month number is 1-based, so odd months are long
+                int daysInMonth = (i & 1) == 1 ? LongMonthLength : ShortMonthLength;
                 // This doesn't take account of leap years, but that doesn't matter - because
                 // it's not used on the last iteration, and leap years only affect the final month
                 // in the Islamic calendar.
@@ -67,12 +67,9 @@ namespace NodaTime.Calendars
             this.leapYearPatternBits = GetLeapYearPatternBits(leapYearPattern);
         }
 
-        protected override int GetDaysFromStartOfYearToStartOfMonth(int year, int month)
-        {
-            // The number of days at the *start* of a month isn't affected by
-            // the year as the only month length which varies by year is the last one.
-            return TotalDaysByMonth[month - 1];
-        }
+        // The number of days at the *start* of a month isn't affected by
+        // the year as the only month length which varies by year is the last one.
+        protected override int GetDaysFromStartOfYearToStartOfMonth(int year, int month) => TotalDaysByMonth[month];
 
         internal override YearMonthDay GetYearMonthDay(int year, int dayOfYear)
         {


### PR DESCRIPTION
The arrays in GJYearMOnthDayCalculator are only used in the places I've changed - so it's definitely safe. Despite the previous (now deleted) comment, the array index wasn't being used for validation anyway.

Fixes #1595.