### PR TITLE
Add XML schema validation tests for Interval without start and/or end

### DIFF
--- a/src/NodaTime.Test/Xml/XmlSchemaTest.cs
+++ b/src/NodaTime.Test/Xml/XmlSchemaTest.cs
@@ -117,6 +117,24 @@ namespace NodaTime.Test.Xml
         }
 
         [Test]
+        public void IntervalWithoutStart()
+        {
+            AssertValidSerializedNodaTimeObject(new NodaTimeObject { MyInterval = new Interval(null, Instant.MinValue) });
+        }
+
+        [Test]
+        public void IntervalWithoutEnd()
+        {
+            AssertValidSerializedNodaTimeObject(new NodaTimeObject { MyInterval = new Interval(Instant.MinValue, null) });
+        }
+
+        [Test]
+        public void IntervalWithoutStartNorEnd()
+        {
+            AssertValidSerializedNodaTimeObject(new NodaTimeObject { MyInterval = new Interval(null, null) });
+        }
+
+        [Test]
         public void LocalDateMinValue()
         {
             AssertValidSerializedNodaTimeObject(new NodaTimeObject { MyLocalDate = LocalDate.MinIsoValue });


### PR DESCRIPTION
The XML schema was correct but these new test formally ensure that when serialized as XML, an `Interval` may not have either a `start` or an `end` attribute.