### PR TITLE
Allow TzdbCompiler to run under .NET 5.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@
 # TODO: Test against Mono as well, using matrix.include
 language: csharp
 mono: none
-dotnet: 3.1
+dotnet:
+  - 3.1
+  - 5.0
 dist: xenial
 
 script:

--- a/build/tzdbupdate/update-master.sh
+++ b/build/tzdbupdate/update-master.sh
@@ -24,7 +24,7 @@ dotnet build -nologo -clp:NoSummary -v quiet $SRCDIR/NodaTime.sln
 
 echo ""
 echo "Generating NZD file"
-dotnet run -p $SRCDIR/NodaTime.TzdbCompiler -- \
+dotnet run -p $SRCDIR/NodaTime.TzdbCompiler -f netcoreapp3.1 -- \
   -o $OUTPUT \
   -s https://data.iana.org/time-zones/releases/tzdata$1.tar.gz \
   -w $DATADIR/cldr \

--- a/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
+++ b/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/NodaTime.TzdbCompiler/Tzdb/CldrWindowsZonesParser.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/CldrWindowsZonesParser.cs
@@ -21,8 +21,8 @@ namespace NodaTime.TzdbCompiler.Tzdb
         {
             var mapZones = MapZones(document);
             var windowsZonesVersion = FindVersion(document);
-            var tzdbVersion = document.Root.Element("windowsZones")?.Element("mapTimezones")?.Attribute("typeVersion")?.Value ?? "";
-            var windowsVersion = document.Root.Element("windowsZones")?.Element("mapTimezones")?.Attribute("otherVersion")?.Value ?? "";
+            var tzdbVersion = document.Root?.Element("windowsZones")?.Element("mapTimezones")?.Attribute("typeVersion")?.Value ?? "";
+            var windowsVersion = document.Root?.Element("windowsZones")?.Element("mapTimezones")?.Attribute("otherVersion")?.Value ?? "";
             return new WindowsZones(windowsZonesVersion, tzdbVersion, windowsVersion, mapZones);
         }
 
@@ -41,7 +41,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
 
         private static string FindVersion(XDocument document)
         {
-            string revision = (string)document.Root.Element("version")?.Attribute("number");
+            string? revision = (string?)document.Root?.Element("version")?.Attribute("number");
             if (revision is null)
             {
                 return "";
@@ -63,14 +63,22 @@ namespace NodaTime.TzdbCompiler.Tzdb
         /// Reads the input XML file for the windows mappings.
         /// </summary>
         /// <returns>A lookup of Windows time zone mappings</returns>
-        private static IList<MapZone> MapZones(XDocument document) =>
-            document.Root
-                .Element("windowsZones")
-                .Element("mapTimezones")
-                .Elements("mapZone")
-                .Select(x => new MapZone(x.Attribute("other").Value,
-                                         x.Attribute("territory").Value,
-                                         x.Attribute("type").Value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)))
+        private static IList<MapZone> MapZones(XDocument document) {
+            var mapZone = document.Root
+                ?.Element("windowsZones")
+                ?.Element("mapTimezones")
+                ?.Elements("mapZone");
+            if (mapZone is null)
+            {
+                return new List<MapZone>();
+            }
+
+            return mapZone
+                .Select(x => new MapZone(x?.Attribute("other")?.Value ?? "",
+                                         x?.Attribute("territory")?.Value ?? "",
+                                         x?.Attribute("type")?.Value.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries) ?? new string[0]))
+                .Where(x => !(x is null))
                 .ToList();
+        }
     }
 }


### PR DESCRIPTION
Also fix more stringent `net5.0` C# compiler errors from nullable expressions.
Running TzdbCompiler using `dotnet run` now requires a `-f <tfm>` flag, so use
`-f netcoreapp3.1` to preserve previous behavior.