### PR TITLE
Format Period.Zero as "P0D" in the roundtrip pattern

### DIFF
--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -617,7 +617,7 @@ namespace NodaTime.Test
         [Test]
         public void ToString_Zero()
         {
-            Assert.AreEqual("P", Period.Zero.ToString());
+            Assert.AreEqual("P0D", Period.Zero.ToString());
         }
 
         [Test]

--- a/src/NodaTime.Test/Text/PeriodPatternTest.Roundtrip.cs
+++ b/src/NodaTime.Test/Text/PeriodPatternTest.Roundtrip.cs
@@ -40,13 +40,17 @@ namespace NodaTime.Test.Text
             internal static Data[] ParseOnlyData = {
                 new Data(new PeriodBuilder { Hours = 5 }) { Text = "PT005H" },
                 new Data(new PeriodBuilder { Hours = 5 }) { Text = "PT00000000000000000000005H" },
+                // This is invalid for ISO, but *used* to be the formatted result, so we want
+                // to be able to parse it in case people are parsing previous formatting results.
+                // See https://github.com/nodatime/nodatime/issues/1629
+                new Data(Period.Zero) { Text = "P" },
             };
 
             // This pattern round-trips, so we can always parse what we format.
             internal static Data[] FormatOnlyData = { };
 
             internal static readonly Data[] FormatAndParseData = {
-                new Data(Period.Zero) { Text = "P" },
+                new Data(Period.Zero) { Text = "P0D" },
 
                 // All single values                                                                
                 new Data(new PeriodBuilder { Years = 5 }) { Text = "P5Y" },

--- a/src/NodaTime.Test/Text/TypeConvertersTest.cs
+++ b/src/NodaTime.Test/Text/TypeConvertersTest.cs
@@ -113,7 +113,7 @@ namespace NodaTime.Test.Text
             AssertRoundtrip(text, new OffsetTime(new LocalTime(hour, minute, second, millisecond), new Offset(seconds)));
 
         [Test]
-        [TestCase(00, 00, 00, 00, 00, 00, 00, 00, 00, 00, "P")]
+        [TestCase(00, 00, 00, 00, 00, 00, 00, 00, 00, 00, "P0D")]
         [TestCase(01, 01, 01, 01, 01, 01, 01, 01, 01, 01, "P1Y1M1W1DT1H1M1S1s1t1n")]
         public void Period_Roundtrip(int years, int months, int weeks, int days, long hours, long minutes, long seconds, long milliseconds, long ticks, long nanoseconds, string text) =>
             AssertRoundtrip(text, new Period(years, months, weeks, days, hours, minutes, seconds, milliseconds, ticks, nanoseconds));

--- a/src/NodaTime/Text/PeriodPattern.cs
+++ b/src/NodaTime/Text/PeriodPattern.cs
@@ -184,6 +184,15 @@ namespace NodaTime.Text
             {
                 Preconditions.CheckNotNull(value, nameof(value));
                 Preconditions.CheckNotNull(builder, nameof(builder));
+                // Always ensure we've got *some* unit to ensure the result is valid in ISO-8601; arbitrarily pick days.
+                // Note: "P0S" might be nicer here, but NormalizingIsoPatternImpl picked "P0D" a
+                // long time ago and we want to be consistent between the two.
+                // We might want to make both pattern implementations configurable at some point.
+                if (value.Equals(Period.Zero))
+                {
+                    builder.Append("P0D");
+                    return builder;
+                }
                 builder.Append('P');
                 AppendValue(builder, value.Years, 'Y');
                 AppendValue(builder, value.Months, 'M');


### PR DESCRIPTION
Fixes #1629

Note that we still allow "P" on its own to be parsed, for backward compatibility. (This came for free, as it happens.)