### PR TITLE
Fix global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "3.1",
+    "version": "3.1.410",
+    "allowPrerelease": false,
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/global",
   "sdk": {
-    "version": "3.1.410",
+    "version": "5.0.301",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }

--- a/global.json
+++ b/global.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/global",
   "sdk": {
     "version": "3.1.410",
     "allowPrerelease": false,

--- a/src/NodaTime.sln
+++ b/src/NodaTime.sln
@@ -32,6 +32,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MSBuild", "MSBuild", "{33DA
 	ProjectSection(SolutionItems) = preProject
 		..\Directory.Build.props = ..\Directory.Build.props
 		..\Directory.Build.targets = ..\Directory.Build.targets
+		..\global.json = ..\global.json
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
The SDK version must have major.minor.patch else it doesn't work as expected (i.e. always use the latest available SDK).

- With with following .NET SDKs installed:
  2.1.816 [/usr/local/share/dotnet/sdk]
  3.1.410 [/usr/local/share/dotnet/sdk]
  5.0.301 [/usr/local/share/dotnet/sdk]
  6.0.100-preview.4.21255.9 [/usr/local/share/dotnet/sdk]
  - With "rollForward": "latestMinor"
    - With "version": "3.1" in global.json
      ❌ `dotnet --version` returns 6.0.100-preview.4.21255.9
    - With "version": "3.1.410" in global.json
      ✅ `dotnet --version` returns 3.1.410

  - With "rollForward": "latestMajor" and "allowPrerelease": false,
    - With "version": "3.1" in global.json
      ❌ `dotnet --version` returns 6.0.100-preview.4.21255.9 (works by chance)
    - With "version": "3.1.410" in global.json
      ✅ `dotnet --version` returns 5.0.301

That's a lot of words to say that you can't use `3.1` but must use `3.1.410`.

Also, explicitly set `allowPrerelease` to `false`.