### PR TITLE
Correct documentation on constructor

### DIFF
--- a/src/NodaTime/YearMonth.cs
+++ b/src/NodaTime/YearMonth.cs
@@ -97,7 +97,7 @@ namespace NodaTime
         }
 
         /// <summary>
-        /// Constructs an instance for the given year, month and day in the specified calendar.
+        /// Constructs an instance for the given year and month in the specified calendar.
         /// </summary>
         /// <param name="year">The year. This is the "absolute year", so, for
         /// the ISO calendar, a value of 0 means 1 BC, for example.</param>


### PR DESCRIPTION
The summary of one of the YearMonth constructors contained an erroneous reference to "Day", presumably because the documentation was copied from [here](https://github.com/nodatime/nodatime/blob/aa49ace02d8a46668033e75e2fec0fbbf935e068/src/NodaTime/LocalDate.cs#L96) and edited when first created.

The change is simply to correct this.