### PR TITLE
Make slow tests opt-in instead of opt-out 

### DIFF
--- a/build/appveyor.sh
+++ b/build/appveyor.sh
@@ -14,7 +14,7 @@ dotnet --info
 
 dotnet build -c Release src/NodaTime.sln
 
-dotnet test -c Release src/NodaTime.Test -s src/NodaTime.Test/NoSlowTests.runsettings
+dotnet test -c Release src/NodaTime.Test
 dotnet test -c Release src/NodaTime.Demo
 
 dotnet build -c Release src/NodaTime.TzdbCompiler

--- a/build/buildrelease.sh
+++ b/build/buildrelease.sh
@@ -37,8 +37,9 @@ export Configuration=Release
 
 dotnet build src/NodaTime.sln
 
-# Even run the slow tests before a release...
 dotnet test src/NodaTime.Test
+# Even run the slow tests before a release...
+dotnet test src/NodaTime.Test --filter TestCategory=Slow
 
 mkdir $OUTPUT
 

--- a/build/ci.sh
+++ b/build/ci.sh
@@ -7,7 +7,7 @@ cd $ROOT
 
 export ContinuousIntegrationBuild=true
 dotnet build -c Release src/NodaTime.sln
-dotnet test -c Release src/NodaTime.Test -s src/NodaTime.Test/NoSlowTests.runsettings
+dotnet test -c Release src/NodaTime.Test
 dotnet test -c Release src/NodaTime.Demo
 
 dotnet build -c Release src/NodaTime.TzdbCompiler

--- a/build/tzdbupdate/update-master.sh
+++ b/build/tzdbupdate/update-master.sh
@@ -34,7 +34,7 @@ dotnet run -p $SRCDIR/NodaTime.TzdbCompiler -f netcoreapp3.1 -- \
 echo ""
 echo "Testing"
 dotnet build -nologo -clp:NoSummary -v quiet -c Release $SRCDIR/NodaTime.Test
-dotnet test -nologo --no-build -c Release ../../src/NodaTime.Test --filter=TestCategory!=Slow
+dotnet test -nologo --no-build -c Release ../../src/NodaTime.Test
 
 echo "Checking hashes"
 rm -rf tmp-hashes

--- a/src/NodaTime.Demo/NodaTime.Demo.csproj
+++ b/src/NodaTime.Demo/NodaTime.Demo.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="XmlSchemaClassGenerator-beta" Version="2.0.349" />
   </ItemGroup>
 

--- a/src/NodaTime.Test/Calendars/HebrewCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/HebrewCalendarSystemTest.cs
@@ -36,6 +36,7 @@ namespace NodaTime.Test.Calendars
         /// using the civil month numbering.
         /// </summary>
         [Test]
+        [Explicit]
         [Category("Slow")]
         public void BclThroughHistory_Civil()
         {

--- a/src/NodaTime.Test/Calendars/IslamicCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/IslamicCalendarSystemTest.cs
@@ -295,6 +295,7 @@ namespace NodaTime.Test.Calendars
         /// This tests every day for 9000 (ISO) years, to check that it always matches the year, month and day.
         /// </summary>
         [Test]
+        [Explicit]
         [Category("Slow")]
         public void BclThroughHistory()
         {

--- a/src/NodaTime.Test/Calendars/PersianCalendarSystemTest.cs
+++ b/src/NodaTime.Test/Calendars/PersianCalendarSystemTest.cs
@@ -15,6 +15,7 @@ namespace NodaTime.Test.Calendars
     public class PersianCalendarSystemTest
     {
         [Test]
+        [Explicit]
         [Category("Slow")]
         public void BclThroughHistory()
         {

--- a/src/NodaTime.Test/NoSlowTests.runsettings
+++ b/src/NodaTime.Test/NoSlowTests.runsettings
@@ -1,5 +1,0 @@
-<RunSettings>
-  <NUnit>
-    <Where>cat != Slow</Where>
-  </NUnit>
-</RunSettings>

--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
     <ProjectReference Include="..\NodaTime.Testing\NodaTime.Testing.csproj" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
 

--- a/src/NodaTime.Test/coverageparams.xml
+++ b/src/NodaTime.Test/coverageparams.xml
@@ -5,7 +5,7 @@
  -->
 <CoverageParams>
   <TargetExecutable>c:/Program Files/dotnet/dotnet.exe</TargetExecutable>
-  <TargetArguments>test --no-build -c Release -s NoSlowTests.runsettings</TargetArguments>
+  <TargetArguments>test --no-build -c Release</TargetArguments>
   <TargetWorkingDir>.</TargetWorkingDir>
   <Filters>
     <IncludeFilters>

--- a/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
+++ b/src/NodaTime.TzdbCompiler.Test/NodaTime.TzdbCompiler.Test.csproj
@@ -7,7 +7,7 @@
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
     <ProjectReference Include="..\NodaTime.TzdbCompiler\NodaTime.TzdbCompiler.csproj" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #1625

The NUnit test adapter update is required for the `--filter` switch to work as desired for this use case in `dotnet test`. See https://github.com/nunit/nunit3-vs-adapter/issues/473.