### PR TITLE
Run test coverage on .NET 5 and on Mac

### DIFF
--- a/build/Coverage.proj
+++ b/build/Coverage.proj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="$(DOTCOVER_VERSION)">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="ReportGenerator" Version="$(REPORTGENERATOR_VERSION)" />
+  </ItemGroup>
+</Project>

--- a/build/Coverage.proj
+++ b/build/Coverage.proj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JetBrains.dotCover.CommandLineTools" Version="$(DOTCOVER_VERSION)">
+    <PackageReference Include="JetBrains.dotCover.CommandLineTools$(DOTCOVER_PACKAGE_SUFFIX)" Version="$(DOTCOVER_VERSION)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/build/coverage-mac.sh
+++ b/build/coverage-mac.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+declare -r BUILD_DIR=$(realpath $(dirname $0))
+
+DOTCOVER_PACKAGE_SUFFIX=.macos-x64 DOTCOVER_EXECUTABLE=./dotCover.sh $BUILD_DIR/coverage.sh "$@"

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -11,16 +11,17 @@ declare -r REPORTGENERATOR_VERSION=4.8.11
 
 export REPORTGENERATOR_VERSION
 export DOTCOVER_VERSION
+export DOTCOVER_PACKAGE_SUFFIX
 dotnet restore $ROOT/build/Coverage.proj --packages $ROOT/packages
 
-declare -r DOTCOVER_DIR=$ROOT/packages/jetbrains.dotcover.commandlinetools/$DOTCOVER_VERSION/tools
+declare -r DOTCOVER_DIR=$ROOT/packages/jetbrains.dotcover.commandlinetools${DOTCOVER_PACKAGE_SUFFIX}/$DOTCOVER_VERSION/tools
 
 rm -rf $ROOT/coverage
 mkdir $ROOT/coverage
 
 # Run the tests under dotCover
 (cd $DOTCOVER_DIR; 
- ./dotCover.exe dotnet $TEST/coverageparams.xml --Output=$ROOT/coverage/coverage.xml --ReportType=DetailedXML --ReturnTargetExitCode -- test $TEST)
+ ${DOTCOVER_EXECUTABLE:-"./dotcover.exe"} dotnet $TEST/coverageparams.xml --Output=$ROOT/coverage/coverage.xml --ReportType=DetailedXML --ReturnTargetExitCode -- test $TEST)
 
 if [[ $1 == "--report" ]]
 then

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -13,22 +13,20 @@ export REPORTGENERATOR_VERSION
 export DOTCOVER_VERSION
 dotnet restore $ROOT/build/Coverage.proj --packages $ROOT/packages
 
-declare -r DOTCOVER=$ROOT/packages/jetbrains.dotcover.commandlinetools/$DOTCOVER_VERSION/tools/dotCover.exe
+declare -r DOTCOVER_DIR=$ROOT/packages/jetbrains.dotcover.commandlinetools/$DOTCOVER_VERSION/tools
 
 rm -rf $ROOT/coverage
 mkdir $ROOT/coverage
 
 # Run the tests under dotCover
-(cd $TEST; 
- $DOTCOVER cover coverageparams.xml -ReturnTargetExitCode)
-
-$DOTCOVER report --Source=$ROOT/coverage/NodaTime.dvcr --Output=$ROOT/coverage/coverage.xml --ReportType=DetailedXML ""
+(cd $DOTCOVER_DIR; 
+ ./dotCover.exe dotnet $TEST/coverageparams.xml --Output=$ROOT/coverage/coverage.xml --ReportType=DetailedXML --ReturnTargetExitCode -- test $TEST)
 
 if [[ $1 == "--report" ]]
 then
-  declare -r REPORTGENERATOR=$ROOT/packages/reportgenerator/$REPORTGENERATOR_VERSION/tools/net47/ReportGenerator.exe
+  declare -r REPORTGENERATOR=$ROOT/packages/reportgenerator/$REPORTGENERATOR_VERSION/tools/net5.0/ReportGenerator.dll
   
-  $REPORTGENERATOR \
+  dotnet $REPORTGENERATOR \
    -reports:$ROOT/coverage/coverage.xml \
    -targetdir:$ROOT/coverage/report \
    -verbosity:Error

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -7,7 +7,7 @@ set -e
 declare -r ROOT=$(realpath $(dirname $0)/..)
 declare -r TEST=$ROOT/src/NodaTime.Test
 declare -r DOTCOVER_VERSION=2021.1.3
-declare -r REPORTGENERATOR_VERSION=4.0.12
+declare -r REPORTGENERATOR_VERSION=4.8.11
 
 nuget.exe install -Verbosity quiet -OutputDirectory $ROOT/packages -Version $DOTCOVER_VERSION JetBrains.dotCover.CommandLineTools
 

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -9,9 +9,11 @@ declare -r TEST=$ROOT/src/NodaTime.Test
 declare -r DOTCOVER_VERSION=2021.1.3
 declare -r REPORTGENERATOR_VERSION=4.8.11
 
-nuget.exe install -Verbosity quiet -OutputDirectory $ROOT/packages -Version $DOTCOVER_VERSION JetBrains.dotCover.CommandLineTools
+export REPORTGENERATOR_VERSION
+export DOTCOVER_VERSION
+dotnet restore $ROOT/build/Coverage.proj --packages $ROOT/packages
 
-declare -r DOTCOVER=$ROOT/packages/JetBrains.dotCover.CommandLineTools.$DOTCOVER_VERSION/tools/dotCover.exe
+declare -r DOTCOVER=$ROOT/packages/jetbrains.dotcover.commandlinetools/$DOTCOVER_VERSION/tools/dotCover.exe
 
 rm -rf $ROOT/coverage
 mkdir $ROOT/coverage
@@ -24,8 +26,7 @@ $DOTCOVER report --Source=$ROOT/coverage/NodaTime.dvcr --Output=$ROOT/coverage/c
 
 if [[ $1 == "--report" ]]
 then
-  nuget.exe install -Verbosity quiet -OutputDirectory $ROOT/packages -Version $REPORTGENERATOR_VERSION ReportGenerator
-  declare -r REPORTGENERATOR=$ROOT/packages/ReportGenerator.$REPORTGENERATOR_VERSION/tools/net47/ReportGenerator.exe
+  declare -r REPORTGENERATOR=$ROOT/packages/reportgenerator/$REPORTGENERATOR_VERSION/tools/net47/ReportGenerator.exe
   
   $REPORTGENERATOR \
    -reports:$ROOT/coverage/coverage.xml \

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -6,7 +6,7 @@ set -e
 
 declare -r ROOT=$(realpath $(dirname $0)/..)
 declare -r TEST=$ROOT/src/NodaTime.Test
-declare -r DOTCOVER_VERSION=2019.3.4
+declare -r DOTCOVER_VERSION=2021.1.3
 declare -r REPORTGENERATOR_VERSION=4.0.12
 
 nuget.exe install -Verbosity quiet -OutputDirectory $ROOT/packages -Version $DOTCOVER_VERSION JetBrains.dotCover.CommandLineTools


### PR DESCRIPTION
While working on #1642 I needed to change the [coverageparams.xml](/nodatime/nodatime/blob/master/src/NodaTime.Test/coverageparams.xml) file, and I wanted to verify the change. However, I work mostly on a Mac, and the `coverage.sh` script is dependent on Windows: both because it runs against .NET Framework, and because it runs exe files.

This PR updates the versions of dotCover and ReportGenerator, changes them to run against .NET 5 instead of .NET Framework, removes the dependency on `nuget.exe` in favor of `dotnet restore`, and creates a `coverage-mac.sh` script which will run coverage on a Mac.

I did verify that the `coverage.xml` output file is the same after the change to running against .NET 5 (there are some changes compared to master, but those are caused by the version change), and that the report can be generated and _appears_ correct on both Mac and Windows.