### PR TITLE
Add rfc3339 pattern for ZonedDateTime

### DIFF
--- a/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
@@ -145,13 +145,13 @@ namespace NodaTime.Test.Text
             // Standard patterns without a DateTimeZoneProvider
             new Data(MsdnStandardExampleNoMillis) { StandardPattern = ZonedDateTimePattern.GeneralFormatOnlyIso, Pattern = "G", Text = "2009-06-15T13:45:30 UTC (+00)", Culture = Cultures.FrFr, ZoneProvider = null},
             new Data(MsdnStandardExample) { StandardPattern = ZonedDateTimePattern.ExtendedFormatOnlyIso, Pattern = "F", Text = "2009-06-15T13:45:30.09 UTC (+00)", Culture = Cultures.FrFr, ZoneProvider = null },
-            new Data(MsdnStandardExampleNoMillis) { StandardPattern = ZonedDateTimePattern.GeneralFormatRfc3339SuffixOnly, Pattern = "e", Text = "2009-06-15T13:45:30+00[UTC]", Culture = Cultures.FrFr, ZoneProvider = null},
-            new Data(MsdnStandardExample) { StandardPattern = ZonedDateTimePattern.ExtendedFormatRfc3339SuffixOnly, Pattern = "E", Text = "2009-06-15T13:45:30.09+00[UTC]", Culture = Cultures.FrFr, ZoneProvider = null },
+            new Data(MsdnStandardExampleNoMillis) { StandardPattern = ZonedDateTimePattern.GeneralRfc3339TimeZoneSuffix, Pattern = "e", Text = "2009-06-15T13:45:30+00[UTC]", Culture = Cultures.FrFr, ZoneProvider = null},
+            new Data(MsdnStandardExample) { StandardPattern = ZonedDateTimePattern.ExtendedRfc3339TimeZoneSuffix, Pattern = "E", Text = "2009-06-15T13:45:30.09+00[UTC]", Culture = Cultures.FrFr, ZoneProvider = null },
             // Standard patterns without a resolver
             new Data(MsdnStandardExampleNoMillis) { StandardPattern = ZonedDateTimePattern.GeneralFormatOnlyIso, Pattern = "G", Text = "2009-06-15T13:45:30 UTC (+00)", Culture = Cultures.FrFr, Resolver = null},
             new Data(MsdnStandardExample) { StandardPattern = ZonedDateTimePattern.ExtendedFormatOnlyIso, Pattern = "F", Text = "2009-06-15T13:45:30.09 UTC (+00)", Culture = Cultures.FrFr, Resolver = null },
-            new Data(MsdnStandardExampleNoMillis) { StandardPattern = ZonedDateTimePattern.GeneralFormatRfc3339SuffixOnly, Pattern = "e", Text = "2009-06-15T13:45:30+00[UTC]", Culture = Cultures.FrFr, Resolver = null},
-            new Data(MsdnStandardExample) { StandardPattern = ZonedDateTimePattern.ExtendedFormatRfc3339SuffixOnly, Pattern = "E", Text = "2009-06-15T13:45:30.09+00[UTC]", Culture = Cultures.FrFr, Resolver = null },
+            new Data(MsdnStandardExampleNoMillis) { StandardPattern = ZonedDateTimePattern.GeneralRfc3339TimeZoneSuffix, Pattern = "e", Text = "2009-06-15T13:45:30+00[UTC]", Culture = Cultures.FrFr, Resolver = null},
+            new Data(MsdnStandardExample) { StandardPattern = ZonedDateTimePattern.ExtendedRfc3339TimeZoneSuffix, Pattern = "E", Text = "2009-06-15T13:45:30.09+00[UTC]", Culture = Cultures.FrFr, Resolver = null },
         };
 
         internal static Data[] FormatAndParseData = {
@@ -212,8 +212,8 @@ namespace NodaTime.Test.Text
             // Standard patterns with a time zone provider
             new Data(2013, 01, 13, 15, 44, 30, 0, TestZone1) { StandardPattern = ZonedDateTimePattern.GeneralFormatOnlyIso.WithZoneProvider(TestProvider) , Pattern = "G", Text = "2013-01-13T15:44:30 ab (+02)", Culture = Cultures.FrFr },
             new Data(2013, 01, 13, 15, 44, 30, 90, TestZone1) { StandardPattern = ZonedDateTimePattern.ExtendedFormatOnlyIso.WithZoneProvider(TestProvider), Pattern = "F", Text = "2013-01-13T15:44:30.09 ab (+02)", Culture = Cultures.FrFr },
-            new Data(2013, 01, 13, 15, 44, 30, 0, TestZone1) { StandardPattern = ZonedDateTimePattern.GeneralFormatRfc3339SuffixOnly.WithZoneProvider(TestProvider) , Pattern = "e", Text = "2013-01-13T15:44:30+02[ab]", Culture = Cultures.FrFr },
-            new Data(2013, 01, 13, 15, 44, 30, 90, TestZone1) { StandardPattern = ZonedDateTimePattern.ExtendedFormatRfc3339SuffixOnly.WithZoneProvider(TestProvider), Pattern = "E", Text = "2013-01-13T15:44:30.09+02[ab]", Culture = Cultures.FrFr },
+            new Data(2013, 01, 13, 15, 44, 30, 0, TestZone1) { StandardPattern = ZonedDateTimePattern.GeneralRfc3339TimeZoneSuffix.WithZoneProvider(TestProvider) , Pattern = "e", Text = "2013-01-13T15:44:30+02[ab]", Culture = Cultures.FrFr },
+            new Data(2013, 01, 13, 15, 44, 30, 90, TestZone1) { StandardPattern = ZonedDateTimePattern.ExtendedRfc3339TimeZoneSuffix.WithZoneProvider(TestProvider), Pattern = "E", Text = "2013-01-13T15:44:30.09+02[ab]", Culture = Cultures.FrFr },
 
             // Custom embedded patterns (or mixture of custom and standard)
             new Data(2015, 10, 24, 11, 55, 30, 0, Athens) { Pattern = "ld<uuuu*MM*dd>'X'lt<HH_mm_ss> z o<g>", Text = "2015*10*24X11_55_30 Europe/Athens +03", ZoneProvider = DateTimeZoneProviders.Tzdb },

--- a/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
@@ -145,9 +145,13 @@ namespace NodaTime.Test.Text
             // Standard patterns without a DateTimeZoneProvider
             new Data(MsdnStandardExampleNoMillis) { StandardPattern = ZonedDateTimePattern.GeneralFormatOnlyIso, Pattern = "G", Text = "2009-06-15T13:45:30 UTC (+00)", Culture = Cultures.FrFr, ZoneProvider = null},
             new Data(MsdnStandardExample) { StandardPattern = ZonedDateTimePattern.ExtendedFormatOnlyIso, Pattern = "F", Text = "2009-06-15T13:45:30.09 UTC (+00)", Culture = Cultures.FrFr, ZoneProvider = null },
+            new Data(MsdnStandardExampleNoMillis) { StandardPattern = ZonedDateTimePattern.GeneralFormatRfc3339SuffixOnly, Pattern = "e", Text = "2009-06-15T13:45:30+00[UTC]", Culture = Cultures.FrFr, ZoneProvider = null},
+            new Data(MsdnStandardExample) { StandardPattern = ZonedDateTimePattern.ExtendedFormatRfc3339SuffixOnly, Pattern = "E", Text = "2009-06-15T13:45:30.09+00[UTC]", Culture = Cultures.FrFr, ZoneProvider = null },
             // Standard patterns without a resolver
             new Data(MsdnStandardExampleNoMillis) { StandardPattern = ZonedDateTimePattern.GeneralFormatOnlyIso, Pattern = "G", Text = "2009-06-15T13:45:30 UTC (+00)", Culture = Cultures.FrFr, Resolver = null},
             new Data(MsdnStandardExample) { StandardPattern = ZonedDateTimePattern.ExtendedFormatOnlyIso, Pattern = "F", Text = "2009-06-15T13:45:30.09 UTC (+00)", Culture = Cultures.FrFr, Resolver = null },
+            new Data(MsdnStandardExampleNoMillis) { StandardPattern = ZonedDateTimePattern.GeneralFormatRfc3339SuffixOnly, Pattern = "e", Text = "2009-06-15T13:45:30+00[UTC]", Culture = Cultures.FrFr, Resolver = null},
+            new Data(MsdnStandardExample) { StandardPattern = ZonedDateTimePattern.ExtendedFormatRfc3339SuffixOnly, Pattern = "E", Text = "2009-06-15T13:45:30.09+00[UTC]", Culture = Cultures.FrFr, Resolver = null },
         };
 
         internal static Data[] FormatAndParseData = {
@@ -208,6 +212,8 @@ namespace NodaTime.Test.Text
             // Standard patterns with a time zone provider
             new Data(2013, 01, 13, 15, 44, 30, 0, TestZone1) { StandardPattern = ZonedDateTimePattern.GeneralFormatOnlyIso.WithZoneProvider(TestProvider) , Pattern = "G", Text = "2013-01-13T15:44:30 ab (+02)", Culture = Cultures.FrFr },
             new Data(2013, 01, 13, 15, 44, 30, 90, TestZone1) { StandardPattern = ZonedDateTimePattern.ExtendedFormatOnlyIso.WithZoneProvider(TestProvider), Pattern = "F", Text = "2013-01-13T15:44:30.09 ab (+02)", Culture = Cultures.FrFr },
+            new Data(2013, 01, 13, 15, 44, 30, 0, TestZone1) { StandardPattern = ZonedDateTimePattern.GeneralFormatRfc3339SuffixOnly.WithZoneProvider(TestProvider) , Pattern = "e", Text = "2013-01-13T15:44:30+02[ab]", Culture = Cultures.FrFr },
+            new Data(2013, 01, 13, 15, 44, 30, 90, TestZone1) { StandardPattern = ZonedDateTimePattern.ExtendedFormatRfc3339SuffixOnly.WithZoneProvider(TestProvider), Pattern = "E", Text = "2013-01-13T15:44:30.09+02[ab]", Culture = Cultures.FrFr },
 
             // Custom embedded patterns (or mixture of custom and standard)
             new Data(2015, 10, 24, 11, 55, 30, 0, Athens) { Pattern = "ld<uuuu*MM*dd>'X'lt<HH_mm_ss> z o<g>", Text = "2015*10*24X11_55_30 Europe/Athens +03", ZoneProvider = DateTimeZoneProviders.Tzdb },

--- a/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/ZonedDateTimePatternTest.cs
@@ -215,6 +215,10 @@ namespace NodaTime.Test.Text
             new Data(2013, 01, 13, 15, 44, 30, 0, TestZone1) { StandardPattern = ZonedDateTimePattern.GeneralRfc3339TimeZoneSuffix.WithZoneProvider(TestProvider) , Pattern = "e", Text = "2013-01-13T15:44:30+02[ab]", Culture = Cultures.FrFr },
             new Data(2013, 01, 13, 15, 44, 30, 90, TestZone1) { StandardPattern = ZonedDateTimePattern.ExtendedRfc3339TimeZoneSuffix.WithZoneProvider(TestProvider), Pattern = "E", Text = "2013-01-13T15:44:30.09+02[ab]", Culture = Cultures.FrFr },
 
+            // RFC 3339 standard patterns with default time zone provider
+            new Data(2013, 09, 13, 15, 44, 30, 0, Athens, true) { StandardPattern = ZonedDateTimePattern.GeneralRfc3339TimeZoneSuffix , Pattern = "e", Text = "2013-09-13T15:44:30+03[Europe/Athens]", Culture = Cultures.EnUs },
+            new Data(2013, 09, 13, 15, 44, 30, 90, Athens, true) { StandardPattern = ZonedDateTimePattern.ExtendedRfc3339TimeZoneSuffix, Pattern = "E", Text = "2013-09-13T15:44:30.09+03[Europe/Athens]", Culture = Cultures.EnUs },
+
             // Custom embedded patterns (or mixture of custom and standard)
             new Data(2015, 10, 24, 11, 55, 30, 0, Athens) { Pattern = "ld<uuuu*MM*dd>'X'lt<HH_mm_ss> z o<g>", Text = "2015*10*24X11_55_30 Europe/Athens +03", ZoneProvider = DateTimeZoneProviders.Tzdb },
             new Data(2015, 10, 24, 11, 55, 30, 0, Athens) { Pattern = "lt<HH_mm_ss>'Y'ld<uuuu*MM*dd> z o<g>", Text = "11_55_30Y2015*10*24 Europe/Athens +03", ZoneProvider = DateTimeZoneProviders.Tzdb },
@@ -339,11 +343,11 @@ namespace NodaTime.Test.Text
             /// Initializes a new instance of the <see cref="Data" /> class.
             /// </summary>
             /// <param name="value">The value.</param>
-            public Data(ZonedDateTime value)
+            public Data(ZonedDateTime value, bool usePatternDefaultZoneProvider = false)
                 : base(value)
             {
                 Resolver = Resolvers.StrictResolver;
-                ZoneProvider = TestProvider;
+                ZoneProvider = usePatternDefaultZoneProvider ? null : TestProvider;
             }
 
             public Data(int year, int month, int day)
@@ -370,6 +374,11 @@ namespace NodaTime.Test.Text
 
             public Data(int year, int month, int day, int hour, int minute, int second, int millis, DateTimeZone zone)
                 : this(new LocalDateTime(year, month, day, hour, minute, second, millis).InZoneStrictly(zone))
+            {
+            }
+
+            public Data(int year, int month, int day, int hour, int minute, int second, int millis, DateTimeZone zone, bool usePatternDefaultZoneProvider)
+                : this(new LocalDateTime(year, month, day, hour, minute, second, millis).InZoneStrictly(zone), usePatternDefaultZoneProvider)
             {
             }
 

--- a/src/NodaTime/Text/ZonedDateTimePattern.cs
+++ b/src/NodaTime/Text/ZonedDateTimePattern.cs
@@ -26,7 +26,7 @@ namespace NodaTime.Text
         internal static ZonedDateTime DefaultTemplateValue { get; } = new LocalDateTime(2000, 1, 1, 0, 0).InUtc();
 
         /// <summary>
-        /// Gets an zoned local date/time pattern based on ISO-8601 (down to the second) including offset from UTC and zone ID.
+        /// Returns an invariant zoned local date/time pattern based on ISO-8601 (down to the second) including offset from UTC and zone ID.
         /// It corresponds to a custom pattern of "uuuu'-'MM'-'dd'T'HH':'mm':'ss z '('o&lt;g&gt;')'" and is available
         /// as the 'G' standard pattern.
         /// </summary>
@@ -35,7 +35,7 @@ namespace NodaTime.Text
         /// provider is included. Call <see cref="WithZoneProvider"/> on the value of this property to obtain a
         /// pattern which can be used for parsing.
         /// </remarks>
-        /// <value>An zoned local date/time pattern based on ISO-8601 (down to the second) including offset from UTC and zone ID.</value>
+        /// <value>An invariant zoned local date/time pattern based on ISO-8601 (down to the second) including offset from UTC and zone ID.</value>
         public static ZonedDateTimePattern GeneralFormatOnlyIso => Patterns.GeneralFormatOnlyPatternImpl;
 
         /// <summary>
@@ -51,6 +51,34 @@ namespace NodaTime.Text
         /// <value>An invariant zoned date/time pattern based on ISO-8601 (down to the nanosecond) including offset from UTC and zone ID.</value>
         public static ZonedDateTimePattern ExtendedFormatOnlyIso => Patterns.ExtendedFormatOnlyPatternImpl;
 
+        /// <summary>
+        /// Returns an invariant zoned local date/time pattern based on the extended format [proposed to/approved in] RFC 3339 (down to the second) 
+        /// including offset from UTC and zone ID.
+        /// It corresponds to a custom pattern of "uuuu'-'MM'-'dd'T'HH':'mm':'sso&lt;g&gt;z']'" and is available
+        /// as the 'e' standard pattern.
+        /// </summary>
+        /// <remarks>
+        /// The calendar system is not formatted as part of this pattern, and it cannot be used for parsing as no time zone
+        /// provider is included. Call <see cref="WithZoneProvider"/> on the value of this property to obtain a
+        /// pattern which can be used for parsing.
+        /// </remarks>
+        /// <value>An zoned local date/time pattern based on the extend format [propsed to/approved in] RFC 3339 (down to the second) including offset from UTC and zone ID.</value>
+        public static ZonedDateTimePattern GeneralFormatRfc3339SuffixOnly => Patterns.Rfc3339SuffixGeneralFormatOnlyPatternImpl;
+
+        /// <summary>
+        /// Returns an invariant zoned local date/time pattern based on the extended format [proposed to/approved in] RFC 3339 (down to the nanosecond) 
+        /// including offset from UTC and zone ID.
+        /// It corresponds to a custom pattern of "uuuu'-'MM'-'dd'T'HH':'mm':'sso;FFFFFFFFF&lt;g&gt;z']'" and is available
+        /// as the 'E' standard pattern.
+        /// </summary>
+        /// <remarks>
+        /// The calendar system is not formatted as part of this pattern, and it cannot be used for parsing as no time zone
+        /// provider is included. Call <see cref="WithZoneProvider"/> on the value of this property to obtain a
+        /// pattern which can be used for parsing.
+        /// </remarks>
+        /// <value>An zoned local date/time pattern based on the extend format [propsed to/approved in] RFC 3339 (down to the second) including offset from UTC and zone ID.</value>
+        public static ZonedDateTimePattern ExtendedFormatRfc3339SuffixOnly => Patterns.Rfc3339SuffixExtendedFormatOnlyPatternImpl;
+
         private readonly IPattern<ZonedDateTime> pattern;
 
         /// <summary>
@@ -61,6 +89,8 @@ namespace NodaTime.Text
         {
             internal static readonly ZonedDateTimePattern GeneralFormatOnlyPatternImpl = CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss z '('o<g>')'", null);
             internal static readonly ZonedDateTimePattern ExtendedFormatOnlyPatternImpl = CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFFF z '('o<g>')'", null);
+            internal static readonly ZonedDateTimePattern Rfc3339SuffixGeneralFormatOnlyPatternImpl = CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'sso<g>'['z']'", null);
+            internal static readonly ZonedDateTimePattern Rfc3339SuffixExtendedFormatOnlyPatternImpl = CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFFFo<g>'['z']'", null);
             internal static readonly PatternBclSupport<ZonedDateTime> BclSupport = new PatternBclSupport<ZonedDateTime>("G", fi => fi.ZonedDateTimePatternParser);
         }
 

--- a/src/NodaTime/Text/ZonedDateTimePattern.cs
+++ b/src/NodaTime/Text/ZonedDateTimePattern.cs
@@ -44,9 +44,9 @@ namespace NodaTime.Text
         /// as the 'F' standard pattern.
         /// </summary>
         /// <remarks>
-        /// The calendar system is not formatted as part of this pattern, and it cannot be used for parsing as no time zone
-        /// provider is included. Call <see cref="WithZoneProvider"/> on the value of this property to obtain a
-        /// pattern which can be used for parsing.
+        /// The calendar system is not formatted as part of this pattern. By default, this pattern uses the Tzdb database for parsing,
+        /// as that is the time zone provider expected by RFC 3339. Call <see cref="WithZoneProvider"/> on the value of this property to 
+        /// use a different provider for parsing.
         /// </remarks>
         /// <value>An invariant zoned date/time pattern based on ISO-8601 (down to the nanosecond) including offset from UTC and zone ID.</value>
         public static ZonedDateTimePattern ExtendedFormatOnlyIso => Patterns.ExtendedFormatOnlyPatternImpl;
@@ -58,12 +58,12 @@ namespace NodaTime.Text
         /// as the 'e' standard pattern.
         /// </summary>
         /// <remarks>
-        /// The calendar system is not formatted as part of this pattern, and it cannot be used for parsing as no time zone
-        /// provider is included. Call <see cref="WithZoneProvider"/> on the value of this property to obtain a
-        /// pattern which can be used for parsing.
+        /// The calendar system is not formatted as part of this pattern. By default, this pattern uses the Tzdb database for parsing,
+        /// as that is the time zone provider expected by RFC 3339. Call <see cref="WithZoneProvider"/> on the value of this property to 
+        /// use a different provider for parsing.
         /// </remarks>
         /// <value>An zoned local date/time pattern based on the extend format [propsed to/approved in] RFC 3339 (down to the second) including offset from UTC and zone ID.</value>
-        public static ZonedDateTimePattern GeneralFormatRfc3339SuffixOnly => Patterns.Rfc3339SuffixGeneralFormatOnlyPatternImpl;
+        public static ZonedDateTimePattern GeneralRfc3339TimeZoneSuffix => Patterns.Rfc3339TimeZoneSuffixGeneralPatternImpl;
 
         /// <summary>
         /// Returns an invariant zoned local date/time pattern based on the extended format [proposed to/approved in] RFC 3339 (down to the nanosecond) 
@@ -77,7 +77,7 @@ namespace NodaTime.Text
         /// pattern which can be used for parsing.
         /// </remarks>
         /// <value>An zoned local date/time pattern based on the extend format [propsed to/approved in] RFC 3339 (down to the second) including offset from UTC and zone ID.</value>
-        public static ZonedDateTimePattern ExtendedFormatRfc3339SuffixOnly => Patterns.Rfc3339SuffixExtendedFormatOnlyPatternImpl;
+        public static ZonedDateTimePattern ExtendedRfc3339TimeZoneSuffix => Patterns.Rfc3339TimeZoneSuffixExtendedPatternImpl ;
 
         private readonly IPattern<ZonedDateTime> pattern;
 
@@ -89,8 +89,8 @@ namespace NodaTime.Text
         {
             internal static readonly ZonedDateTimePattern GeneralFormatOnlyPatternImpl = CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss z '('o<g>')'", null);
             internal static readonly ZonedDateTimePattern ExtendedFormatOnlyPatternImpl = CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFFF z '('o<g>')'", null);
-            internal static readonly ZonedDateTimePattern Rfc3339SuffixGeneralFormatOnlyPatternImpl = CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'sso<g>'['z']'", null);
-            internal static readonly ZonedDateTimePattern Rfc3339SuffixExtendedFormatOnlyPatternImpl = CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFFFo<g>'['z']'", null);
+            internal static readonly ZonedDateTimePattern Rfc3339TimeZoneSuffixGeneralPatternImpl = CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'sso<g>'['z']'", DateTimeZoneProviders.Tzdb);
+            internal static readonly ZonedDateTimePattern Rfc3339TimeZoneSuffixExtendedPatternImpl = CreateWithInvariantCulture("uuuu'-'MM'-'dd'T'HH':'mm':'ss;FFFFFFFFFo<g>'['z']'", DateTimeZoneProviders.Tzdb);
             internal static readonly PatternBclSupport<ZonedDateTime> BclSupport = new PatternBclSupport<ZonedDateTime>("G", fi => fi.ZonedDateTimePatternParser);
         }
 

--- a/src/NodaTime/Text/ZonedDateTimePatternParser.cs
+++ b/src/NodaTime/Text/ZonedDateTimePatternParser.cs
@@ -82,6 +82,12 @@ namespace NodaTime.Text
                     'F' => ZonedDateTimePattern.Patterns.ExtendedFormatOnlyPatternImpl
                             .WithZoneProvider(zoneProvider)
                             .WithResolver(resolver),
+                    'e' => ZonedDateTimePattern.Patterns.Rfc3339SuffixGeneralFormatOnlyPatternImpl
+                            .WithZoneProvider(zoneProvider)
+                            .WithResolver(resolver),
+                    'E' => ZonedDateTimePattern.Patterns.Rfc3339SuffixExtendedFormatOnlyPatternImpl
+                            .WithZoneProvider(zoneProvider)
+                            .WithResolver(resolver),
                     _ => throw new InvalidPatternException(TextErrorMessages.UnknownStandardFormat, patternText, typeof(ZonedDateTime))
                 };
             }

--- a/src/NodaTime/Text/ZonedDateTimePatternParser.cs
+++ b/src/NodaTime/Text/ZonedDateTimePatternParser.cs
@@ -82,10 +82,10 @@ namespace NodaTime.Text
                     'F' => ZonedDateTimePattern.Patterns.ExtendedFormatOnlyPatternImpl
                             .WithZoneProvider(zoneProvider)
                             .WithResolver(resolver),
-                    'e' => ZonedDateTimePattern.Patterns.Rfc3339SuffixGeneralFormatOnlyPatternImpl
+                    'e' => ZonedDateTimePattern.Patterns.Rfc3339TimeZoneSuffixGeneralPatternImpl
                             .WithZoneProvider(zoneProvider)
                             .WithResolver(resolver),
-                    'E' => ZonedDateTimePattern.Patterns.Rfc3339SuffixExtendedFormatOnlyPatternImpl
+                    'E' => ZonedDateTimePattern.Patterns.Rfc3339TimeZoneSuffixExtendedPatternImpl
                             .WithZoneProvider(zoneProvider)
                             .WithResolver(resolver),
                     _ => throw new InvalidPatternException(TextErrorMessages.UnknownStandardFormat, patternText, typeof(ZonedDateTime))

--- a/src/NodaTime/Text/ZonedDateTimePatternParser.cs
+++ b/src/NodaTime/Text/ZonedDateTimePatternParser.cs
@@ -82,10 +82,16 @@ namespace NodaTime.Text
                     'F' => ZonedDateTimePattern.Patterns.ExtendedFormatOnlyPatternImpl
                             .WithZoneProvider(zoneProvider)
                             .WithResolver(resolver),
-                    'e' => ZonedDateTimePattern.Patterns.Rfc3339TimeZoneSuffixGeneralPatternImpl
+                    'e' => (zoneProvider == null) ? 
+                        ZonedDateTimePattern.Patterns.Rfc3339TimeZoneSuffixGeneralPatternImpl
+                            .WithResolver(resolver)
+                        : ZonedDateTimePattern.Patterns.Rfc3339TimeZoneSuffixGeneralPatternImpl
                             .WithZoneProvider(zoneProvider)
                             .WithResolver(resolver),
-                    'E' => ZonedDateTimePattern.Patterns.Rfc3339TimeZoneSuffixExtendedPatternImpl
+                    'E' => (zoneProvider == null) ?
+                        ZonedDateTimePattern.Patterns.Rfc3339TimeZoneSuffixExtendedPatternImpl
+                            .WithResolver(resolver)
+                        : ZonedDateTimePattern.Patterns.Rfc3339TimeZoneSuffixExtendedPatternImpl
                             .WithZoneProvider(zoneProvider)
                             .WithResolver(resolver),
                     _ => throw new InvalidPatternException(TextErrorMessages.UnknownStandardFormat, patternText, typeof(ZonedDateTime))


### PR DESCRIPTION
Add a standard pattern for the zoned date time format proposed as an [extension to RFC 3339](https://ryzokuken.dev/draft-ryzokuken-datetime-extended/documents/rfc-3339.html),

This format appears likely to be approved next year (see [this issue](https://github.com/tc39/proposal-temporal/issues/1450)).  It is the format that the proposed [Temporal](https://tc39.es/proposal-temporal/docs/iso-string-ext.html) addition to ECMA wants to use, and that is currently used by [java.time](https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html#toString--).

The PR is being submitted in draft form because, even if otherwise acceptable, it should await final approval of the RFC 3339 proposal.  There will be an [accompanying PR for the serialization library](https://github.com/nodatime/nodatime.serialization/pull/77) as well, which I'm happy to keep working on when I have a little more time.

#jskeet a few thoughts/questions in putting this together:
- I went with "e" and "E" as the pattern characters; I didn't see any collisions with other patterns and they suggest "extension"
- It's not clear to me that technically RFC3339 will support time zone providers other than IANA, but I didn't see any reason to so restrict the pattern being exposed; this way it's consistent with G and F
