### PR TITLE
Add LocalDateTime.{Min,Max}IsoValue

### DIFF
--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -480,5 +480,21 @@ namespace NodaTime.Test
                 new LocalDateTime(2017, 10, 15, 21, 30, 0, 1, CalendarSystem.Iso),
                 new LocalDateTime(2017, 10, 15, 21, 30, 0, 0, CalendarSystem.Gregorian),
             });
+
+        [Test]
+        public void MaxIsoValue()
+        {
+            var value = LocalDateTime.MaxIsoValue;
+            Assert.AreEqual(CalendarSystem.Iso, value.Calendar);
+            Assert.Throws<OverflowException>(() => value.PlusNanoseconds(1));
+        }
+
+        [Test]
+        public void MinIsoValue()
+        {
+            var value = LocalDateTime.MinIsoValue;
+            Assert.AreEqual(CalendarSystem.Iso, value.Calendar);
+            Assert.Throws<OverflowException>(() => value.PlusNanoseconds(-1));
+        }
     }
 }

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -43,6 +43,18 @@ namespace NodaTime
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct LocalDateTime : IEquatable<LocalDateTime>, IComparable<LocalDateTime>, IComparable, IFormattable, IXmlSerializable
     {
+        /// <summary>
+        /// The maximum (latest) date and time representable in the ISO calendar system.
+        /// This is a nanosecond before midnight at the end of <see cref="LocalDate.MaxIsoValue"/>.
+        /// </summary>
+        public static LocalDateTime MaxIsoValue => LocalDate.MaxIsoValue + LocalTime.MaxValue;
+
+        /// <summary>
+        /// The minimum (earliest) date and time representable in the ISO calendar system.
+        /// This is midnight at the start of <see cref="LocalDate.MinIsoValue"/>.
+        /// </summary>
+        public static LocalDateTime MinIsoValue => LocalDate.MinIsoValue + LocalTime.MinValue;
+
         private readonly LocalDate date;
         private readonly LocalTime time;
 


### PR DESCRIPTION
Fixes #58

We won't implement the same for Period, ZonedDateTime or
OffsetDateTime at the moment, as they're rather murkier domains to
use.