### PR TITLE
Document conversions to BCL types for non-Gregorian calendars

### DIFF
--- a/src/NodaTime.Test/LocalDateTest.Conversion.cs
+++ b/src/NodaTime.Test/LocalDateTest.Conversion.cs
@@ -3,6 +3,7 @@
 // as found in the LICENSE.txt file.
 
 using System;
+using System.Globalization;
 using System.Linq;
 using NUnit.Framework;
 
@@ -42,6 +43,16 @@ namespace NodaTime.Test
         {
             LocalDate noda = new LocalDate(2015, 4, 2);
             DateTime bcl = new DateTime(2015, 4, 2, 0, 0, 0, DateTimeKind.Unspecified);
+            Assert.AreEqual(bcl, noda.ToDateTimeUnspecified());
+        }
+
+        [Test]
+        public void ToDateTimeUnspecified_JulianCalendar()
+        {
+            // Non-Gregorian calendar systems are handled by converting to the same
+            // date, just like the DateTime constructor does.
+            LocalDate noda = new LocalDate(2015, 4, 2, CalendarSystem.Julian);
+            DateTime bcl = new DateTime(2015, 4, 2, 0, 0, 0, 0, new JulianCalendar(), DateTimeKind.Unspecified);
             Assert.AreEqual(bcl, noda.ToDateTimeUnspecified());
         }
 

--- a/src/NodaTime.Test/LocalDateTimeTest.cs
+++ b/src/NodaTime.Test/LocalDateTimeTest.cs
@@ -11,6 +11,7 @@ using NodaTime.Utility;
 using NUnit.Framework;
 using NodaTime.Test.Calendars;
 using System.Linq;
+using System.Globalization;
 
 namespace NodaTime.Test
 {
@@ -24,9 +25,22 @@ namespace NodaTime.Test
         [Test]
         public void ToDateTimeUnspecified()
         {
-            LocalDateTime zoned = new LocalDateTime(2011, 3, 5, 1, 0, 0);
+            LocalDateTime ldt = new LocalDateTime(2011, 3, 5, 1, 0, 0);
             DateTime expected = new DateTime(2011, 3, 5, 1, 0, 0, DateTimeKind.Unspecified);
-            DateTime actual = zoned.ToDateTimeUnspecified();
+            DateTime actual = ldt.ToDateTimeUnspecified();
+            Assert.AreEqual(expected, actual);
+            // Kind isn't checked by Equals...
+            Assert.AreEqual(DateTimeKind.Unspecified, actual.Kind);
+        }
+
+        [Test]
+        public void ToDateTimeUnspecified_JulianCalendar()
+        {
+            // Non-Gregorian calendar systems are handled by converting to the same
+            // date, just like the DateTime constructor does.
+            LocalDateTime ldt = new LocalDateTime(2011, 3, 5, 1, 0, 0, CalendarSystem.Julian);
+            DateTime expected = new DateTime(2011, 3, 5, 1, 0, 0, 0, new JulianCalendar(), DateTimeKind.Unspecified);
+            DateTime actual = ldt.ToDateTimeUnspecified();
             Assert.AreEqual(expected, actual);
             // Kind isn't checked by Equals...
             Assert.AreEqual(DateTimeKind.Unspecified, actual.Kind);

--- a/src/NodaTime.Test/OffsetDateTimeTest.cs
+++ b/src/NodaTime.Test/OffsetDateTimeTest.cs
@@ -103,6 +103,22 @@ namespace NodaTime.Test
         }
 
         [Test]
+        public void ToDateTimeOffset_JulianCalendar()
+        {
+            // Non-Gregorian calendar systems are handled by converting to the same
+            // date, just like the DateTime constructor does.
+            LocalDateTime local = new LocalDateTime(2012, 10, 6, 1, 2, 3, CalendarSystem.Julian);
+            Offset offset = Offset.FromHours(1);
+            OffsetDateTime odt = new OffsetDateTime(local, offset);
+
+            DateTimeOffset expected = new DateTimeOffset(
+                DateTime.SpecifyKind(new DateTime(2012, 10, 6, 1, 2, 3, new JulianCalendar()), DateTimeKind.Unspecified),
+                TimeSpan.FromHours(1));
+            DateTimeOffset actual = odt.ToDateTimeOffset();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         [TestCase(0, 30, 20)]
         [TestCase(-1, -30, -20)]
         [TestCase(0, 30, 55)]

--- a/src/NodaTime.Test/ZonedDateTimeTest.cs
+++ b/src/NodaTime.Test/ZonedDateTimeTest.cs
@@ -188,6 +188,17 @@ namespace NodaTime.Test
         }
 
         [Test]
+        public void ToDateTimeOffset_JulianCalendar()
+        {
+            // Non-Gregorian calendar systems are handled by converting to the same
+            // date, just like the DateTime constructor does.
+            ZonedDateTime zoned = SampleZone.AtStrictly(new LocalDateTime(2011, 3, 5, 1, 0, 0, CalendarSystem.Julian));
+            DateTimeOffset expected = new DateTimeOffset(2011, 3, 5, 1, 0, 0, 0, new JulianCalendar(), TimeSpan.FromHours(3));
+            DateTimeOffset actual = zoned.ToDateTimeOffset();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
         [TestCase(0, 30, 20)]
         [TestCase(-1, -30, -20)]
         [TestCase(0, 30, 55)]
@@ -290,6 +301,19 @@ namespace NodaTime.Test
         {
             ZonedDateTime zoned = SampleZone.AtStrictly(new LocalDateTime(2011, 3, 5, 1, 0, 0));
             DateTime expected = new DateTime(2011, 3, 5, 1, 0, 0, DateTimeKind.Unspecified);
+            DateTime actual = zoned.ToDateTimeUnspecified();
+            Assert.AreEqual(expected, actual);
+            // Kind isn't checked by Equals...
+            Assert.AreEqual(DateTimeKind.Unspecified, actual.Kind);
+        }
+
+        [Test]
+        public void ToDateTimeUnspecified_JulianCalendar()
+        {
+            // Non-Gregorian calendar systems are handled by converting to the same
+            // date, just like the DateTime constructor does.
+            ZonedDateTime zoned = SampleZone.AtStrictly(new LocalDateTime(2011, 3, 5, 1, 0, 0, CalendarSystem.Julian));
+            DateTime expected = new DateTime(2011, 3, 5, 1, 0, 0, 0, new JulianCalendar(), DateTimeKind.Unspecified);
             DateTime actual = zoned.ToDateTimeUnspecified();
             Assert.AreEqual(expected, actual);
             // Kind isn't checked by Equals...

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -198,10 +198,18 @@ namespace NodaTime
         /// by this value.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// <see cref="DateTimeKind.Unspecified"/> is slightly odd - it can be treated as UTC if you use <see cref="DateTime.ToLocalTime"/>
         /// or as system local time if you use <see cref="DateTime.ToUniversalTime"/>, but it's the only kind which allows
         /// you to construct a <see cref="DateTimeOffset"/> with an arbitrary offset, which makes it as close to
         /// the Noda Time non-system-specific "local" concept as exists in .NET.
+        /// </para>
+        /// <para>
+        /// <see cref="DateTime"/> uses the Gregorian calendar by definition, so the value is implicitly converted
+        /// to the Gregorian calendar first. The result will be on the same physical day,
+        /// but the values returned by the Year/Month/Day properties of the <see cref="DateTime"/> may not
+        /// match the Year/Month/Day properties of this value.
+        /// </para>
         /// </remarks>
         /// <returns>A <see cref="DateTime"/> value for the same date and time as this value.</returns>
         [Pure]

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -310,6 +310,12 @@ namespace NodaTime
         /// If the date and time is not on a tick boundary (the unit of granularity of DateTime) the value will be truncated
         /// towards the start of time.
         /// </para>
+        /// <para>
+        /// <see cref="DateTime"/> uses the Gregorian calendar by definition, so the value is implicitly converted
+        /// to the Gregorian calendar first. The result will be on the same physical day,
+        /// but the values returned by the Year/Month/Day properties of the <see cref="DateTime"/> may not
+        /// match the Year/Month/Day properties of this value.
+        /// </para>
         /// </remarks>
         /// <exception cref="InvalidOperationException">The date/time is outside the range of <c>DateTime</c>.</exception>
         /// <returns>A <see cref="DateTime"/> value for the same date and time as this value.</returns>

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -306,6 +306,12 @@ namespace NodaTime
         /// If the offset has a non-zero second component, this is truncated as <c>DateTimeOffset</c> has an offset
         /// granularity of minutes.
         /// </para>
+        /// <para>
+        /// <see cref="DateTimeOffset"/> uses the Gregorian calendar by definition, so the value is implicitly converted
+        /// to the Gregorian calendar first. The result will be the same instant in time (potentially truncated as described
+        /// above), but the values returned by the Year/Month/Day properties of the <see cref="DateTimeOffset"/> may not
+        /// match the Year/Month/Day properties of this value.
+        /// </para>
         /// </remarks>
         /// <exception cref="InvalidOperationException">The date/time is outside the range of <c>DateTimeOffset</c>,
         /// or the offset is outside the range of +/-14 hours (the range supported by <c>DateTimeOffset</c>).</exception>

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -575,6 +575,12 @@ namespace NodaTime
         /// If the offset has a non-zero second component, this is truncated as <c>DateTimeOffset</c> has an offset
         /// granularity of minutes.
         /// </para>
+        /// <para>
+        /// <see cref="DateTimeOffset"/> uses the Gregorian calendar by definition, so the value is implicitly converted
+        /// to the Gregorian calendar first. The result will be the same instant in time (potentially truncated as described
+        /// above), but the values returned by the Year/Month/Day properties of the <see cref="DateTimeOffset"/> may not
+        /// match the Year/Month/Day properties of this value.
+        /// </para>
         /// </remarks>
         /// <exception cref="InvalidOperationException">The date/time is outside the range of <c>DateTimeOffset</c>,
         /// or the offset is outside the range of +/-14 hours (the range supported by <c>DateTimeOffset</c>).</exception>
@@ -625,6 +631,12 @@ namespace NodaTime
         /// <para>
         /// If the date and time is not on a tick boundary (the unit of granularity of DateTime) the value will be truncated
         /// towards the start of time.
+        /// </para>
+        /// <para>
+        /// <see cref="DateTime"/> uses the Gregorian calendar by definition, so the value is implicitly converted
+        /// to the Gregorian calendar first. The result will be on the same physical date,
+        /// but the values returned by the Year/Month/Day properties of the <see cref="DateTime"/> may not
+        /// match the Year/Month/Day properties of this value.
         /// </para>
         /// </remarks>
         /// <exception cref="InvalidOperationException">The date/time is outside the range of <c>DateTime</c>.</exception>


### PR DESCRIPTION
This doesn't change the behavior at all; it just documents it.

This is the first step towards implementing #1635.