### PR TITLE
Upgrade targets to include .NET 6

### DIFF
--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -11,7 +11,7 @@
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
     <ProjectReference Include="..\NodaTime.Testing\NodaTime.Testing.csproj" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
@@ -46,6 +46,9 @@
     </Compile>
     <Compile Update="YearMonthTest.*.cs">
       <DependentUpon>YearMonthTest.cs</DependentUpon>
+    </Compile>
+    <Compile Update="TimeZones/BclDateTimeZoneTest.*.cs">
+  	  <DependentUpon>TimeZones/BclDateTimeZoneTest.cs</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>

--- a/src/NodaTime.Test/NodaTime.Test.csproj
+++ b/src/NodaTime.Test/NodaTime.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
 
     <!-- ApprovalTests appears to not be able to cope with DeterministicSourcePaths -->
     <DeterministicSourcePaths>false</DeterministicSourcePaths>
@@ -10,9 +10,9 @@
     <PackageReference Include="ApprovalTests" Version="5.0.0" />
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
     <ProjectReference Include="..\NodaTime.Testing\NodaTime.Testing.csproj" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Test/TestData/LinuxAdjustmentRuleTestData.txt
+++ b/src/NodaTime.Test/TestData/LinuxAdjustmentRuleTestData.txt
@@ -1,0 +1,208 @@
+﻿// See BclDateTimeZoneTest.LinuxAdjustmentRules.cs for the format of this file.
+// Every test must start with a zone interval that is daylight or "from the start of time".
+// Every test must end with a zone interval that is daylight or "to the end of time".
+
+Europe/Paris in 2020:
+Base offset = 1
+---
+2019-03-31 - 2019-10-27: Daylight delta: +01; DST starts March 31 at 02:00:00 and ends October 27 at 02:59:59
+2019-10-27 - 2020-03-29: Daylight delta: +00; DST starts October 27 at 02:00:00 and ends March 29 at 01:59:59
+2020-03-29 - 2020-10-25: Daylight delta: +01; DST starts March 29 at 02:00:00 and ends October 25 at 02:59:59
+2020-10-25 - 2021-03-28: Daylight delta: +00; DST starts October 25 at 02:00:00 and ends March 28 at 01:59:59
+2021-03-28 - 2021-10-31: Daylight delta: +01; DST starts March 28 at 02:00:00 and ends October 31 at 02:59:59
+---
+2019-03-31 - 2019-10-27: Daylight delta: +01; DST starts March 31 at 02:00:00 and ends October 27 at 02:59:59.999
+2020-03-29 - 2020-10-25: Daylight delta: +01; DST starts March 29 at 02:00:00 and ends October 25 at 02:59:59.999
+2021-03-28 - 2021-10-31: Daylight delta: +01; DST starts March 28 at 02:00:00 and ends October 31 at 02:59:59.999
+---
+2019-03-31T01:00:00Z - 2019-10-27T01:00:00Z, +01, +01
+2019-10-27T01:00:00Z - 2020-03-29T01:00:00Z, +01, +00
+2020-03-29T01:00:00Z - 2020-10-25T01:00:00Z, +01, +01
+2020-10-25T01:00:00Z - 2021-03-28T01:00:00Z, +01, +00
+2021-03-28T01:00:00Z - 2021-10-31T01:00:00Z, +01, +01
+
+
+America/Los_Angeles in 2020:
+Base offset = -8
+---
+2019-03-10 - 2019-11-03: Daylight delta: +01; DST starts March 10 at 02:00:00 and ends November 03 at 01:59:59
+2019-11-03 - 2020-03-08: Daylight delta: +00; DST starts November 03 at 01:00:00 and ends March 08 at 01:59:59
+2020-03-08 - 2020-11-01: Daylight delta: +01; DST starts March 08 at 02:00:00 and ends November 01 at 01:59:59
+2020-11-01 - 2021-03-14: Daylight delta: +00; DST starts November 01 at 01:00:00 and ends March 14 at 01:59:59
+2021-03-14 - 2021-11-07: Daylight delta: +01; DST starts March 14 at 02:00:00 and ends November 07 at 01:59:59
+---
+2019-03-10 - 2019-11-03: Daylight delta: +01; DST starts March 10 at 02:00:00 and ends November 03 at 01:59:59.999
+2020-03-08 - 2020-11-01: Daylight delta: +01; DST starts March 08 at 02:00:00 and ends November 01 at 01:59:59.999
+2021-03-14 - 2021-11-07: Daylight delta: +01; DST starts March 14 at 02:00:00 and ends November 07 at 01:59:59.999
+---
+2019-03-10T10:00:00Z - 2019-11-03T09:00:00Z, -08, +01
+2019-11-03T09:00:00Z - 2020-03-08T10:00:00Z, -08, +00
+2020-03-08T10:00:00Z - 2020-11-01T09:00:00Z, -08, +01
+2020-11-01T09:00:00Z - 2021-03-14T10:00:00Z, -08, +00
+2021-03-14T10:00:00Z - 2021-11-07T09:00:00Z, -08, +01
+
+
+Europe/Prague in 1946/1947:
+Base offset = 1
+---
+1945-04-02 - 1945-05-08: Daylight delta: +01; DST starts April 02 at 02:00:00 and ends May 08 at 23:59:59
+1945-05-08 - 1945-10-01: Daylight delta: +01; DST starts May 08 at 23:00:00 and ends October 01 at 02:59:59
+1945-10-01 - 1946-05-06: Daylight delta: +00; DST starts October 01 at 02:00:00 and ends May 06 at 01:59:59
+1946-05-06 - 1946-10-06: Daylight delta: +01; DST starts May 06 at 02:00:00 and ends October 06 at 02:59:59
+1946-10-06 - 1946-12-01: Daylight delta: +00; DST starts October 06 at 02:00:00 and ends December 01 at 02:59:59
+1946-12-01 - 1947-02-23: Daylight delta: -01; DST starts December 01 at 03:00:00 and ends February 23 at 01:59:59
+1947-02-23 - 1947-04-20: Daylight delta: +00; DST starts February 23 at 03:00:00 and ends April 20 at 01:59:59
+1947-04-20 - 1947-10-05: Daylight delta: +01; DST starts April 20 at 02:00:00 and ends October 05 at 02:59:59
+1947-10-05 - 1948-04-18: Daylight delta: +00; DST starts October 05 at 02:00:00 and ends April 18 at 01:59:59
+1948-04-18 - 1948-10-03: Daylight delta: +01; DST starts April 18 at 02:00:00 and ends October 03 at 02:59:59
+---
+1945-04-02 - 1945-05-08: Daylight delta: +01; DST starts April 02 at 02:00:00 and ends May 08 at 23:59:59.999
+1945-05-08 - 1945-10-01: Daylight delta: +01; DST starts May 08 at 23:00:00 and ends October 01 at 02:59:59.999
+1946-05-06 - 1946-10-06: Daylight delta: +01; DST starts May 06 at 02:00:00 and ends October 06 at 02:59:59.999
+1946-12-01 - 1946-12-31: Daylight delta: -01; DST starts December 01 at 03:00:00 and ends December 31 at 23:59:59.999
+1947-01-01 - 1947-02-23: Daylight delta: -01; DST starts January 01 at 00:00:00 and ends February 23 at 01:59:59.999
+1947-04-20 - 1947-10-05: Daylight delta: +01; DST starts April 20 at 02:00:00 and ends October 05 at 02:59:59.999
+1948-04-18 - 1948-10-03: Daylight delta: +01; DST starts April 18 at 02:00:00 and ends October 03 at 02:59:59.999
+---
+1945-04-02T01:00:00Z - 1945-10-01T01:00:00Z, +01, +01
+1945-10-01T01:00:00Z - 1946-05-06T01:00:00Z, +01, +00
+1946-05-06T01:00:00Z - 1946-10-06T01:00:00Z, +01, +01
+1946-10-06T01:00:00Z - 1946-12-01T02:00:00Z, +01, +00
+1946-12-01T02:00:00Z - 1947-02-23T02:00:00Z, +01, -01
+1947-02-23T02:00:00Z - 1947-04-20T01:00:00Z, +01, +00
+1947-04-20T01:00:00Z - 1947-10-05T01:00:00Z, +01, +01
+1947-10-05T01:00:00Z - 1948-04-18T01:00:00Z, +01, +00
+1948-04-18T01:00:00Z - 1948-10-03T01:00:00Z, +01, +01
+
+
+Europe/Dublin in 2020:
+Base offset = 1
+---
+2019-10-27 - 2020-03-29: Daylight delta: -01; DST starts October 27 at 02:00:00 and ends March 29 at 00:59:59
+2020-03-29 - 2020-10-25: Daylight delta: +00; DST starts March 29 at 02:00:00 and ends October 25 at 01:59:59
+2020-10-25 - 2021-03-28: Daylight delta: -01; DST starts October 25 at 02:00:00 and ends March 28 at 00:59:59
+---
+2019-10-27 - 2019-12-31: Daylight delta: -01; DST starts October 27 at 02:00:00 and ends December 31 at 23:59:59.999
+2020-01-01 - 2020-03-29: Daylight delta: -01; DST starts January 01 at 00:00:00 and ends March 29 at 00:59:59.999
+2020-10-25 - 2020-12-31: Daylight delta: -01; DST starts October 25 at 02:00:00 and ends December 31 at 23:59:59.999
+2021-01-01 - 2021-03-28: Daylight delta: -01; DST starts January 01 at 00:00:00 and ends March 28 at 00:59:59.999
+---
+2019-10-27T01:00:00Z - 2020-03-29T01:00:00Z, +01, -01
+2020-03-29T01:00:00Z - 2020-10-25T01:00:00Z, +01, +00
+2020-10-25T01:00:00Z - 2021-03-28T01:00:00Z, +01, -01
+
+
+Europe/Dublin in 1960:
+Base offset = 1
+---
+1959-10-04 - 1960-04-10: Base UTC offset delta: -01; Daylight delta: +00; DST starts October 04 at 03:00:00 and ends April 10 at 02:59:59
+1960-04-10 - 1960-10-02: Daylight delta: +00; DST starts April 10 at 03:00:00 and ends October 02 at 02:59:59 (force daylight)
+1960-10-02 - 1961-03-26: Base UTC offset delta: -01; Daylight delta: +00; DST starts October 02 at 03:00:00 and ends March 26 at 02:59:59
+---
+1959-10-04 - 1959-12-31: Base UTC offset delta: -01; Daylight delta: +00; DST starts October 04 at 03:00:00 and ends December 31 at 23:59:59.999
+1960-01-01 - 1960-04-10: Base UTC offset delta: -01; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends April 10 at 02:59:59.999
+1960-04-10 - 1960-10-02: Daylight delta: +00; DST starts April 10 at 03:00:00 and ends October 02 at 02:59:59.999 (force daylight)
+1960-10-02 - 1960-12-31: Base UTC offset delta: -01; Daylight delta: +00; DST starts October 02 at 03:00:00 and ends December 31 at 23:59:59.999
+1961-01-01 - 1961-03-26: Base UTC offset delta: -01; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends March 26 at 02:59:59.999
+---
+1959-10-04T02:00:00Z - 1960-04-10T02:00:00Z, +00, +00
+1960-04-10T02:00:00Z - 1960-10-02T02:00:00Z, +00, +01
+1960-10-02T02:00:00Z - 1961-03-26T02:00:00Z, +00, +00
+
+
+America/Sao_Paulo in 2018:
+Base offset = -3
+---
+2017-10-15 - 2018-02-17: Daylight delta: +01; DST starts October 15 at 00:00:00 and ends February 17 at 23:59:59
+2018-02-17 - 2018-11-03: Daylight delta: +00; DST starts February 17 at 23:00:00 and ends November 03 at 23:59:59
+2018-11-04 - 2019-02-16: Daylight delta: +01; DST starts November 04 at 00:00:00 and ends February 16 at 23:59:59
+---
+2017-10-15 - 2017-12-31: Daylight delta: +01; DST starts October 15 at 00:00:00 and ends December 31 at 23:59:59.999
+2018-01-01 - 2018-02-17: Daylight delta: +01; DST starts January 01 at 00:00:00 and ends February 17 at 23:59:59.999
+2018-11-04 - 2018-12-31: Daylight delta: +01; DST starts November 04 at 00:00:00 and ends December 31 at 23:59:59.999
+2019-01-01 - 2019-02-16: Daylight delta: +01; DST starts January 01 at 00:00:00 and ends February 16 at 23:59:59.999
+---
+2017-10-15T03:00:00Z - 2018-02-18T02:00:00Z, -03, +01
+2018-02-18T02:00:00Z - 2018-11-04T03:00:00Z, -03, +00
+2018-11-04T03:00:00Z - 2019-02-17T02:00:00Z, -03, +01
+
+
+Europe/London in 1968-1971
+Base offset = 0
+---
+1968-10-26 - 1971-10-31: Base UTC offset delta: +01; Daylight delta: +00; DST starts October 26 at 23:00:00 and ends October 31 at 01:59:59
+---
+1968-10-26 - 1968-12-31: Base UTC offset delta: +01; Daylight delta: +00; DST starts October 26 at 23:00:00 and ends December 31 at 23:59:59.999
+1969-01-01 - 1970-12-31: Base UTC offset delta: +01; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends December 31 at 23:59:59.999
+1971-01-01 - 1971-10-31: Base UTC offset delta: +01; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends October 31 at 01:59:59.999
+---
+1968-10-26T23:00:00Z - 1971-10-31T02:00:00Z, +01, +00
+
+
+Europe/Moscow in 2011-2014
+Base offset = 3
+---
+2011-03-27 - 2014-10-26: Base UTC offset delta: +01; Daylight delta: +00; DST starts March 27 at 02:00:00 and ends October 26 at 00:59:59
+---
+2011-03-27 - 2011-12-31: Base UTC offset delta: +01; Daylight delta: +00; DST starts March 27 at 02:00:00 and ends December 31 at 23:59:59.999
+2012-01-01 - 2013-12-31: Base UTC offset delta: +01; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends December 31 at 23:59:59.999
+2014-01-01 - 2014-10-26: Base UTC offset delta: +01; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends October 26 at 00:59:59.999
+---
+2011-03-26T23:00:00Z - 2014-10-25T22:00:00Z, +04, +00
+
+
+Pacific/Wallis
+Base offset = 12
+---
+0001-01-01 - 1900-12-31: Base UTC offset delta: +00:15; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends December 31 at 23:44:39
+1900-12-31 - 2038-01-19: Daylight delta: +00; DST starts December 31 at 23:44:40 and ends January 19 at 15:14:06
+2038-01-19 - 9999-12-31: Daylight delta: +00; DST starts January 19 at 15:14:07 and ends December 31 at 23:59:59
+---
+0001-01-01 - 0001-12-31: Base UTC offset delta: +00:15; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends December 31 at 23:59:59.999
+0002-01-01 - 1899-12-31: Base UTC offset delta: +00:15; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends December 31 at 23:59:59.999
+1900-01-01 - 1900-12-31: Base UTC offset delta: +00:15; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends December 31 at 23:44:39.999
+---
+0001-01-01T00:00:00Z - 1900-12-31T11:44:40Z, +12:15, +00
+1900-12-31T11:44:40Z - 9999-12-31T23:59:59Z, +12, +00
+
+
+America/Creston
+Base offset = -7
+---
+1942-02-09 - 1944-01-01: Daylight delta: +01; DST starts February 09 at 02:00:00 and ends January 01 at 00:00:59
+1943-12-31 - 1944-04-01: Daylight delta: +00; DST starts December 31 at 23:01:00 and ends April 01 at 00:00:59
+1944-04-01 - 1944-10-01: Daylight delta: +01; DST starts April 01 at 00:01:00 and ends October 01 at 00:00:59
+1944-09-30 - 1967-04-30: Daylight delta: +00; DST starts September 30 at 23:01:00 and ends April 30 at 01:59:59
+1967-04-30 - 1967-10-29: Daylight delta: +01; DST starts April 30 at 02:00:00 and ends October 29 at 01:59:59
+---
+1942-02-09 - 1942-12-31: Daylight delta: +01; DST starts February 09 at 02:00:00 and ends December 31 at 23:59:59.999
+1943-01-01 - 1943-12-31: Daylight delta: +01; DST starts January 01 at 00:00:00 and ends December 31 at 23:59:59.999
+1944-01-01 - 1944-01-01: Daylight delta: +01; DST starts January 01 at 00:00:00 and ends January 01 at 00:00:59.999
+1944-04-01 - 1944-10-01: Daylight delta: +01; DST starts April 01 at 00:01:00 and ends October 01 at 00:00:59.999
+1967-04-30 - 1967-10-29: Daylight delta: +01; DST starts April 30 at 02:00:00 and ends October 29 at 01:59:59.999
+---
+1942-02-09T09:00:00Z - 1944-01-01T06:01:00Z, -07, +01
+1944-01-01T06:01:00Z - 1944-04-01T07:01:00Z, -07, +00
+1944-04-01T07:01:00Z - 1944-10-01T06:01:00Z, -07, +01
+1944-10-01T06:01:00Z - 1967-04-30T09:00:00Z, -07, +00
+1967-04-30T09:00:00Z - 1967-10-29T08:00:00Z, -07, +01
+
+
+Antarctica/Macquarie
+Base offset = 10
+---
+2008-10-05 - 2009-04-05: Daylight delta: +01; DST starts October 05 at 02:00:00 and ends April 05 at 02:59:59
+2009-04-05 - 2009-10-04: Daylight delta: +00; DST starts April 05 at 02:00:00 and ends October 04 at 01:59:59
+2009-10-04 - 2009-12-31: Daylight delta: +01; DST starts October 04 at 02:00:00 and ends December 31 at 23:59:59
+2009-12-31 - 2011-04-03: Daylight delta: +01; DST starts December 31 at 23:00:00 and ends April 03 at 02:59:59
+---
+2008-10-05 - 2008-12-31: Daylight delta: +01; DST starts October 05 at 02:00:00 and ends December 31 at 23:59:59.999
+2009-01-01 - 2009-04-05: Daylight delta: +01; DST starts January 01 at 00:00:00 and ends April 05 at 02:59:59.999
+2009-10-04 - 2009-12-31: Daylight delta: +01; DST starts October 04 at 02:00:00 and ends December 31 at 23:59:59.999
+2009-12-31 - 2009-12-31: Daylight delta: +01; DST starts December 31 at 23:00:00 and ends December 31 at 23:59:59.999
+2010-01-01 - 2010-12-31: Daylight delta: +01; DST starts January 01 at 00:00:00 and ends December 31 at 23:59:59.999
+2011-01-01 - 2011-04-03: Daylight delta: +01; DST starts January 01 at 00:00:00 and ends April 03 at 02:59:59.999
+---
+2008-10-04T16:00:00Z - 2009-04-04T16:00:00Z, +10, +01
+2009-04-04T16:00:00Z - 2009-10-03T16:00:00Z, +10, +00
+2009-10-03T16:00:00Z - 2011-04-02T16:00:00Z, +10, +01

--- a/src/NodaTime.Test/TestData/README
+++ b/src/NodaTime.Test/TestData/README
@@ -1,19 +1,10 @@
-This directory contains the following files, used by
-TzdbDateTimeZoneSourceTest.
-
-Tzdb.resx
-  The current version of TZDB compiled using the current version of
-  TzdbCompiler with the ResX output format. A test verifies that this is
-  equivalent to the stream format shipped with the main Noda Time assembly,
-  in src/NodaTime/TimeZones/Tzdb.nzd.
-
-Tzdb2012iFromNodaTime1.0.resx
-  TZDB 2012i, as distributed with Noda Time 1.0 (in ResX format, which was
-  all that version of Noda Time supported). A test verifies that we can
-  read and use the file's contents using the current version of the resource
-  parser.
+This directory contains the following files, used by various test cases.
 
 Tzdb2013bFromNodaTime1.1.nzd
   TZDB 2013b, as distributed with Noda Time 1.1 (in NodaZoneData format).
   A test verifies that we can read and use the file's contents using the
   current version of the stream parser.
+
+LinuxAdjustmentRuleTestData.txt
+  Data for TimeZoneInfo.AdjustmentRule on Linux (.NET Core 3.1 and .NET 6)
+  for use in BclDateTimeZoneTest.LinuxAdjustmentRules.

--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.LinuxAdjustmentRules.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.LinuxAdjustmentRules.cs
@@ -1,0 +1,204 @@
+// Copyright 2022 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+using NodaTime.Text;
+using NodaTime.TimeZones;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using BclAdjustmentRule = NodaTime.TimeZones.BclDateTimeZone.BclAdjustmentRule;
+
+namespace NodaTime.Test.TimeZones
+{
+    public partial class BclDateTimeZoneTest
+    {
+        public class LinuxAdjustmentRules
+        {
+            private static List<LinuxAdjustmentMultiRuleData> TestData => LoadTestData().ToList();
+
+            [TestCaseSource(nameof(TestData))]
+            public void SimpleMultiRulesNetCore31(LinuxAdjustmentMultiRuleData data) => AssertRules(data, data.NetCore31Rules);
+
+            [TestCaseSource(nameof(TestData))]
+            public void SimpleMultiRulesNet6(LinuxAdjustmentMultiRuleData data) => AssertRules(data, data.Net6Rules);
+
+            private static void AssertRules(LinuxAdjustmentMultiRuleData data, IReadOnlyList<EnhancedAdjustmentRule> sourceRules)
+            {
+                var expectedIntervals = data.ExpectedIntervals;
+                var bclAdjustmentRules = sourceRules
+                    .Select(rule => BclAdjustmentRule.ConvertUnixRuleToBclAdjustmentRule(rule.Rule, "Standard", "Daylight", rule.ZoneStandardOffset, rule.RuleStandardOffset, rule.ForceDaylight))
+                    .ToArray();
+                BclDateTimeZone.FixUnixTransitions(bclAdjustmentRules);
+
+                // Convert our rules to a full map, as there's coalescing code in there that we want to take advantage of.
+                var map = BclDateTimeZone.BuildMap(bclAdjustmentRules, Offset.FromTimeSpan(data.ZoneStandardOffset), "Standard"); ;
+
+                // Get all of the zone intervals in the expected interval
+                var actualIntervals = new List<ZoneInterval>();
+                actualIntervals.Add(map.GetZoneInterval(expectedIntervals[0].RawStart));
+                while (actualIntervals.Last().RawEnd < expectedIntervals.Last().RawEnd)
+                {
+                    actualIntervals.Add(map.GetZoneInterval(actualIntervals.Last().RawEnd));
+                }
+                Assert.AreEqual(expectedIntervals, actualIntervals);
+            }
+
+            private static IEnumerable<LinuxAdjustmentMultiRuleData> LoadTestData()
+            {
+                using var stream = typeof(BclDateTimeZoneTest).Assembly.GetManifestResourceStream("NodaTime.Test.TestData.LinuxAdjustmentRuleTestData.txt")!;
+                using var reader = new StreamReader(stream);
+
+                while (true)
+                {
+                    var name = reader.ReadLine();
+                    if (name is null)
+                    {
+                        break;
+                    }
+                    if (name.StartsWith("//") || name == "")
+                    {
+                        continue;
+                    }
+                    name = name.TrimEnd(':');
+                    var baseOffset = reader.ReadLine()!;
+                    Assert.True(baseOffset.StartsWith("Base offset = "));
+                    var baseOffsetHours = int.Parse(baseOffset.Split(' ').Last());
+                    Assert.AreEqual("---", reader.ReadLine());
+                    var netCoreApp31Rules = new List<string>();
+                    while (reader.ReadLine() is string line && line != "---")
+                    {
+                        netCoreApp31Rules.Add(line);
+                    }
+                    var net6Rules = new List<string>();
+                    while (reader.ReadLine() is string line && line != "---")
+                    {
+                        net6Rules.Add(line);
+                    }
+                    var nodaTimeIntervals = new List<string>();
+                    while (reader.ReadLine() is string line && line != "")
+                    {
+                        nodaTimeIntervals.Add(line);
+                    }
+                    yield return new(name, baseOffsetHours, netCoreApp31Rules, net6Rules, nodaTimeIntervals);
+                }
+            }
+
+            public class LinuxAdjustmentMultiRuleData
+            {
+                internal string Name { get; }
+                internal TimeSpan ZoneStandardOffset;
+                internal IReadOnlyList<EnhancedAdjustmentRule> NetCore31Rules { get; }
+                internal IReadOnlyList<EnhancedAdjustmentRule> Net6Rules { get; }
+                internal IReadOnlyList<ZoneInterval> ExpectedIntervals { get; }
+
+                public LinuxAdjustmentMultiRuleData(string name, int baseUtcOffsetHours, IEnumerable<string> netCore31Rules, IEnumerable<string> net6Rules, IEnumerable<string> expectedIntervals)
+                {
+                    Name = name;
+                    var baseUtcOffset = TimeSpan.FromHours(baseUtcOffsetHours);
+                    ZoneStandardOffset = baseUtcOffset;
+                    NetCore31Rules = netCore31Rules.Select(text => EnhancedAdjustmentRule.Parse(text, baseUtcOffset)).ToList();
+                    Net6Rules = net6Rules.Select(text => EnhancedAdjustmentRule.Parse(text, baseUtcOffset)).ToList();
+                    ExpectedIntervals = expectedIntervals.Select(ParseZoneInterval).ToList();
+                }
+
+                public override string ToString() => Name;
+
+                private static readonly Regex ZoneIntervalRegex = new Regex(@"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z) - (\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z), ([-+][:\d]+), ([-+][:\d]+)$");
+                /// <summary>
+                /// Parses a zone interval of the form "from - to, standard offset, savings offset" into a ZoneInterval.
+                /// Sample line: "2017-10-15T03:00:00Z - 2018-02-18T02:00:00Z, -03, +01"
+                /// The name is "Standard" if the daylight offset is zero, and "Daylight" otherwise.
+                /// </summary>
+                private static ZoneInterval ParseZoneInterval(string text)
+                {
+                    var match = ZoneIntervalRegex.Match(text);
+                    Assert.True(match.Success);
+                    var start = InstantPattern.General.Parse(match.Groups[1].Value).Value;
+                    if (start == NodaConstants.BclEpoch)
+                    {
+                        start = Instant.BeforeMinValue;
+                    }
+                    var end = InstantPattern.General.Parse(match.Groups[2].Value).Value;
+                    if (end.InUtc().Year == 9999)
+                    {
+                        end = Instant.AfterMaxValue;
+                    }
+                    var standardOffset = OffsetPattern.GeneralInvariant.Parse(match.Groups[3].Value).Value;
+                    var savingsOffset = OffsetPattern.GeneralInvariant.Parse(match.Groups[4].Value).Value;
+                    return new ZoneInterval(savingsOffset == Offset.Zero ? "Standard" : "Daylight", start, end, standardOffset + savingsOffset, savingsOffset);
+                }
+            }
+
+            internal class EnhancedAdjustmentRule
+            {
+                internal TimeZoneInfo.AdjustmentRule Rule;
+
+                /// <summary>
+                /// Indicates that this rule really indicates daylight savings,
+                /// which are assumed (possibly incorrectly?) to be one hour.
+                /// This is set when zone.IsDaylightSavingTime(start) returns true,
+                /// but rule.DaylightDelta is zero. Unfortunately we can't determine
+                /// the meaning just from the rule.
+                /// </summary>
+                internal bool ForceDaylight { get; }
+
+                /// <summary>
+                /// The UTC offset for the overall zone; this is used to determine when a rule starts and finishes (apparently).
+                /// </summary>
+                internal TimeSpan ZoneStandardOffset { get; }
+                /// <summary>
+                /// The UTC offset for the standard intervals in force during this rule.
+                /// </summary>
+                internal TimeSpan RuleStandardOffset { get; }
+
+                private EnhancedAdjustmentRule(TimeZoneInfo.AdjustmentRule rule, TimeSpan baseUtcOffset, TimeSpan baseUtcOffsetDelta, bool forceDaylight)
+                {
+                    Rule = rule;
+                    ForceDaylight = forceDaylight;
+                    ZoneStandardOffset = baseUtcOffset;
+                    RuleStandardOffset = baseUtcOffset + baseUtcOffsetDelta;
+                }
+
+                private static readonly Regex RuleRegex = new Regex(
+                    @"^(?<from>\d{4}-\d{2}-\d{2}) - (?<to>\d{4}-\d{2}-\d{2}): " +
+                    @"(Base UTC offset delta: (?<base_offset_delta>[-+][\d:]+); )?" +
+                    @"Daylight delta: (?<savings>[-+][\d:]+); " +
+                    @"DST starts (?<dst_start>[A-Za-z]+ \d{2} at [\d:\.]+) " +
+                    @"and ends (?<dst_end>[A-Za-z]+ \d{2} at [\d:\.]+)(?<force_daylight> \(force daylight\))?$");
+                private static readonly LocalDateTimePattern DstPattern = LocalDateTimePattern.CreateWithInvariantCulture("MMMM dd 'at' HH:mm:ss.FFFFFF");
+
+                /// <summary>
+                /// Parses a rule of the form "from - to: Daylight delta: offset; DST starts {date} at {time} and ends {date} at {time}"
+                /// or "from - to: Base UTC offset delta: offset; Daylight delta: offset; DST starts {date} at {time} and ends {date} at {time}".
+                /// Sample lines:
+                /// "2019-10-27 - 2019-12-31: Daylight delta: -01; DST starts October 27 at 02:00:00 and ends December 31 at 23:59:59.999"
+                /// "1960-01-01 - 1960-04-10: Base UTC offset delta: -01; Daylight delta: +00; DST starts January 01 at 00:00:00 and ends April 10 at 02:59:59.999"
+                /// This is the format printed out by NodaTime.Tools.DumpTimeZoneInfo. It only handles fixed date transitions.
+                /// </summary>
+                internal static EnhancedAdjustmentRule Parse(string text, TimeSpan baseUtcOffset)
+                {
+                    var match = RuleRegex.Match(text);
+                    Assert.True(match.Success);
+                    LocalDate fromDate = LocalDatePattern.Iso.Parse(match.Groups["from"].Value).Value;
+                    LocalDate toDate = LocalDatePattern.Iso.Parse(match.Groups["to"].Value).Value;
+                    var baseUtcOffsetDelta = match.Groups["base_offset_delta"] is { Success: true, Value: string baseUtcOffsetDeltaText }
+                        ? OffsetPattern.GeneralInvariant.Parse(baseUtcOffsetDeltaText).Value
+                        : Offset.Zero;
+                    var savings = OffsetPattern.GeneralInvariant.Parse(match.Groups["savings"].Value).Value;
+                    var dstStart = DstPattern.Parse(match.Groups["dst_start"].Value).Value;
+                    var dstEnd = DstPattern.Parse(match.Groups["dst_end"].Value).Value;
+                    var rule = TimeZoneInfo.AdjustmentRule.CreateAdjustmentRule(fromDate.ToDateTimeUnspecified(), toDate.ToDateTimeUnspecified(), savings.ToTimeSpan(), CreateTransitionTime(dstStart), CreateTransitionTime(dstEnd));
+                    var forceDaylight = match.Groups["force_daylight"].Success;
+                    return new EnhancedAdjustmentRule(rule, baseUtcOffset, baseUtcOffsetDelta.ToTimeSpan(), forceDaylight);
+
+                    TimeZoneInfo.TransitionTime CreateTransitionTime(LocalDateTime dateTime) =>
+                        TimeZoneInfo.TransitionTime.CreateFixedDateRule(new LocalDate(1, 1, 1).At(dateTime.TimeOfDay).ToDateTimeUnspecified(), dateTime.Month, dateTime.Day);
+                }
+            }
+        }
+    }
+}

--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace NodaTime.Test.TimeZones
 {
-    public class BclDateTimeZoneTest
+    public partial class BclDateTimeZoneTest
     {        
         private static readonly ReadOnlyCollection<NamedWrapper<TimeZoneInfo>> BclZones =
             (TestHelper.IsRunningOnMono ? GetSafeSystemTimeZones() : TimeZoneInfo.GetSystemTimeZones())

--- a/src/NodaTime.Tools.DumpTimeZoneInfo/Program.cs
+++ b/src/NodaTime.Tools.DumpTimeZoneInfo/Program.cs
@@ -38,6 +38,8 @@ namespace NodaTime.Tools.DumpTimeZoneInfo
         private static void DumpZone(string id)
         {
             var zone = TimeZoneInfo.FindSystemTimeZoneById(id);
+            Console.WriteLine(zone.IsDaylightSavingTime(new DateTime(2009, 11, 1)));
+            Console.WriteLine(zone.GetUtcOffset(new DateTime(2009, 10, 4, 0, 0, 0, DateTimeKind.Utc)));
             Console.WriteLine($"Zone ID: {zone.Id}");
             Console.WriteLine($"Display name: {zone.DisplayName}");
             Console.WriteLine($"Standard name: {zone.StandardName}");
@@ -45,32 +47,53 @@ namespace NodaTime.Tools.DumpTimeZoneInfo
             Console.WriteLine($"Base offset: {zone.BaseUtcOffset}");
             Console.WriteLine($"Supports DST: {zone.SupportsDaylightSavingTime}");
             var rules = zone.GetAdjustmentRules();
+            bool windowsRules = AreWindowsStyleRules();
             if (rules != null && rules.Length > 0)
             {
                 Console.WriteLine("Rules:");
                 foreach (var rule in rules)
                 {
-                    DumpRule(zone, rule);
+                    DumpRule(zone, rule, windowsRules);
                 }
+            }
+
+            bool AreWindowsStyleRules()
+            {
+                int windowsRules = rules.Count(IsWindowsRule);
+                return windowsRules == rules.Length;
+
+                bool IsWindowsRule(TimeZoneInfo.AdjustmentRule rule) =>
+                    rule.DateStart.Month == 1 && rule.DateStart.Day == 1 && rule.DateStart.TimeOfDay.Ticks == 0 &&
+                    rule.DateEnd.Month == 12 && rule.DateEnd.Day == 31 && rule.DateEnd.TimeOfDay.Ticks == 0;
             }
         }
 
         // Most code taken from https://github.com/jskeet/DemoCode/blob/master/DateTimeDemos/TimeZoneInfoExplorer/MainForm.cs
-        private static void DumpRule(TimeZoneInfo zone, TimeZoneInfo.AdjustmentRule rule)
+        private static void DumpRule(TimeZoneInfo zone, TimeZoneInfo.AdjustmentRule rule, bool windowsRules)
         {
             var start = rule.DateStart.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var end = rule.DateEnd.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var delta = FormatOffset(rule.DaylightDelta);
             var startTransition = FormatTransition(rule.DaylightTransitionStart);
             var endTransition = FormatTransition(rule.DaylightTransitionEnd);
-            var baseUtcOffsetDeltaText = "";
+
+            // Work out the start of the transition. This depends on the type of rule.
+            DateTime ruleStartLocal = windowsRules ? rule.DateStart : rule.DateStart + rule.DaylightTransitionStart.TimeOfDay.TimeOfDay;
+            DateTime ruleStartUtc = DateTime.SpecifyKind(ruleStartLocal.Year == 1 ? DateTime.MinValue : ruleStartLocal - zone.BaseUtcOffset, DateTimeKind.Utc);
 #if NET6_0_OR_GREATER
-            if (rule.BaseUtcOffsetDelta != TimeSpan.Zero)
-            {
-                baseUtcOffsetDeltaText = $"Base UTC offset delta: {FormatOffset(rule.BaseUtcOffsetDelta)}; ";
-            }
+            var baseUtcOffsetDelta = rule.BaseUtcOffsetDelta;
+#else
+            // Effectively fake the BaseUtcOffsetDelta detection for older versions of .NET.
+            var ruleStandardOffset = zone.GetUtcOffset(ruleStartUtc) - (zone.IsDaylightSavingTime(ruleStartUtc) ? rule.DaylightDelta : TimeSpan.Zero);
+            var baseUtcOffsetDelta = ruleStandardOffset - zone.BaseUtcOffset;
 #endif
-            Console.WriteLine($"{start} - {end}: {baseUtcOffsetDeltaText}Daylight delta: {delta}; DST starts {startTransition} and ends {endTransition}");
+            var baseUtcOffsetDeltaText = baseUtcOffsetDelta == TimeSpan.Zero ? ""
+                : $"Base UTC offset delta: {FormatOffset(baseUtcOffsetDelta)}; ";
+
+            // Note: while this is "usually okay" there are some rules that don't actually start when we'd predict, which is unfortunate.
+            bool isDst = zone.IsDaylightSavingTime(ruleStartUtc);
+            var forceDaylightText = rule.DaylightDelta == TimeSpan.Zero && isDst ? " (force daylight)" : "";            
+            Console.WriteLine($"{start} - {end}: {baseUtcOffsetDeltaText}Daylight delta: {delta}; DST starts {startTransition} and ends {endTransition}{forceDaylightText}");
         }
 
         private static string FormatOffset(TimeSpan offset)

--- a/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
+++ b/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -3,7 +3,7 @@
     <Description>Noda Time is a date and time API acting as an alternative to the built-in DateTime/DateTimeOffset etc types in .NET.</Description>
     <AssemblyTitle>Noda Time</AssemblyTitle>
     <Authors>Jon Skeet</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>    
     <IsPackable>True</IsPackable>
     <PackageTags>date;time;timezone;calendar;nodatime</PackageTags>

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -4,7 +4,8 @@
     <AssemblyTitle>Noda Time</AssemblyTitle>
     <Authors>Jon Skeet</Authors>
     <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>    
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>CA1303</NoWarn>
     <IsPackable>True</IsPackable>
     <PackageTags>date;time;timezone;calendar;nodatime</PackageTags>
   </PropertyGroup>

--- a/src/NodaTime/TimeZones/IZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/IZoneIntervalMap.cs
@@ -18,6 +18,8 @@ namespace NodaTime.TimeZones
         ZoneInterval GetZoneInterval(Instant instant);
     }
 
+    // TODO: How hard would it be to add these on to IZoneIntervalMap and implement them everywhere?
+
     // This is slightly ugly, but it allows us to use any time zone as the tail
     // zone for PrecalculatedDateTimeZone, which is handy for testing.
     internal interface IZoneIntervalMapWithMinMax : IZoneIntervalMap

--- a/src/NodaTime/TimeZones/PartialZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/PartialZoneIntervalMap.cs
@@ -104,10 +104,12 @@ namespace NodaTime.TimeZones
                 if (current is null)
                 {
                     current = next;
-                    Preconditions.DebugCheckArgument(current.Start == Instant.BeforeMinValue, nameof(maps), "First partial map must start at the beginning of time");
+                    Preconditions.DebugCheckArgument(current.Start == Instant.BeforeMinValue, nameof(maps), "First partial map must start at the beginning of time. Actual start: {0:uuuu-MM-dd'T'HH:mm:ss.FFFFFFF}",
+                        current.Start);
                     continue;
                 }
-                Preconditions.DebugCheckArgument(current.End == next.Start, nameof(maps), "Maps must abut");
+                Preconditions.DebugCheckArgument(current.End == next.Start, nameof(maps),
+                    "Maps must abut: {0:uuuu-MM-dd'T'HH:mm:ss.FFFFFFF}Z != {1:uuuu-MM-dd'T'HH:mm:ss.FFFFFFF}Z", current.End, next.Start);
 
                 if (next.Start == next.End)
                 {

--- a/src/NodaTime/TimeZones/PartialZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/PartialZoneIntervalMap.cs
@@ -52,7 +52,7 @@ namespace NodaTime.TimeZones
         internal ZoneInterval GetZoneInterval(Instant instant)
         {
             Preconditions.DebugCheckArgument(instant >= Start && instant < End, nameof(instant),
-                "Value {0} was not in the range [{0}, {1})", instant, Start, End);
+                "Value {0} was not in the range [{1}, {2})", instant, Start, End);
             var interval = map.GetZoneInterval(instant);
             // Clamp the interval for the sake of sanity. Checking this every time isn't very efficient,
             // but we're not expecting this to be called too often, due to caching.

--- a/src/NodaTime/TimeZones/StandardDaylightAlternatingMap.cs
+++ b/src/NodaTime/TimeZones/StandardDaylightAlternatingMap.cs
@@ -128,7 +128,7 @@ namespace NodaTime.TimeZones
                 // Okay, the transitions happen at the same time. If they're not at infinity, we're stumped.
                 if (standardTransitionInstant.IsValid)
                 {
-                    throw new InvalidOperationException("Zone recurrence rules have identical transitions. This time zone is broken.");
+                    throw new InvalidOperationException($"Zone recurrence rules have identical transitions. This time zone is broken. Transition time: {standardTransitionInstant}");
                 }
                 // Okay, the two transitions must be to the end of time. Find which recurrence has the later *previous* transition...
                 var previousDstTransition = dstRecurrence.PreviousOrSameOrFail(instant, standardOffset, Offset.Zero);

--- a/src/NodaTime/TimeZones/ZoneInterval.cs
+++ b/src/NodaTime/TimeZones/ZoneInterval.cs
@@ -198,7 +198,8 @@ namespace NodaTime.TimeZones
         internal ZoneInterval(string name, Instant start, Instant end, Offset wallOffset, Offset savings)
         {
             Preconditions.CheckNotNull(name, nameof(name));
-            Preconditions.CheckArgument(start < end, nameof(start), "The start Instant must be less than the end Instant");
+            Preconditions.CheckArgument(start < end, nameof(start),
+                "The start Instant must be less than the end Instant. start: {0}; end: {1}", start, end);
             this.Name = name;
             this.RawStart = start;
             this.RawEnd = end;


### PR DESCRIPTION
This is along the way to #1635. It's a bit of a shame that we have to go back to multiple targets, but there may well be other things we want to be able to do with .NET 6 as well, over time.