### PR TITLE
Implement ToString() for YearMonth

### DIFF
--- a/src/NodaTime/Text/YearMonthPattern.cs
+++ b/src/NodaTime/Text/YearMonthPattern.cs
@@ -24,10 +24,12 @@ namespace NodaTime.Text
     {
         internal static readonly YearMonth DefaultTemplateValue = new YearMonth(2000, 1);
 
-        private const string DefaultFormatPattern = "g"; // General (ISO)
+        private const string IsoFormatPattern = "g"; // General (ISO)
+
+        internal const string CultureDefaultFormatPattern = "G"; // General (culture-specific)
 
         internal static readonly PatternBclSupport<YearMonth> BclSupport =
-            new PatternBclSupport<YearMonth>(DefaultFormatPattern, fi => fi.YearMonthPatternParser);
+            new PatternBclSupport<YearMonth>(IsoFormatPattern, fi => fi.YearMonthPatternParser);
 
         /// <summary>
         /// Gets an invariant year/month pattern which is ISO-8601 compatible.

--- a/src/NodaTime/Text/YearMonthPatternParser.cs
+++ b/src/NodaTime/Text/YearMonthPatternParser.cs
@@ -54,16 +54,23 @@ namespace NodaTime.Text
                 {
                     // Invariant standard patterns return cached implementations.
                     'g' => YearMonthPattern.Patterns.IsoPatternImpl,
+                    // Culture-specific default pattern
+                    'G' => ParseNoStandardExpansion(formatInfo.DateTimeFormat.YearMonthPattern),
                     // Unknown standard patterns fail.
                     _ => throw new InvalidPatternException(TextErrorMessages.UnknownStandardFormat, patternText, typeof(YearMonth))
                 };
             }
 
-            var patternBuilder = new SteppedPatternBuilder<YearMonth, YearMonthParseBucket>(formatInfo,
-                () => new YearMonthParseBucket(templateValue));
-            patternBuilder.ParseCustomPattern(patternText, PatternCharacterHandlers);
-            patternBuilder.ValidateUsedFields();
-            return patternBuilder.Build(templateValue);
+            return ParseNoStandardExpansion(patternText);
+
+            IPattern<YearMonth> ParseNoStandardExpansion(string patternTextLocal)
+            {
+                var patternBuilder = new SteppedPatternBuilder<YearMonth, YearMonthParseBucket>(formatInfo,
+                    () => new YearMonthParseBucket(templateValue));
+                patternBuilder.ParseCustomPattern(patternTextLocal, PatternCharacterHandlers);
+                patternBuilder.ValidateUsedFields();
+                return patternBuilder.Build(templateValue);
+            }
         }
 
         /// <summary>

--- a/src/NodaTime/YearMonth.cs
+++ b/src/NodaTime/YearMonth.cs
@@ -9,6 +9,7 @@ using NodaTime.Text;
 using NodaTime.Utility;
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -319,11 +320,16 @@ namespace NodaTime
         /// <summary>
         /// Formats the value of the current instance using the specified pattern.
         /// </summary>
+        /// <remarks>
+        /// Unlike most <see cref="IFormattable"/> implementations, a <paramref name="patternText"/> of null with
+        /// the current thread's culture does not yield the same result as the parameterless <see cref="ToString()"/>
+        /// overload, for backward-compatibility reasons. (It uses the ISO format, which is culture-insensitive.)
+        /// </remarks>
         /// <returns>
         /// A <see cref="System.String" /> containing the value of the current instance in the specified format.
         /// </returns>
         /// <param name="patternText">The <see cref="System.String" /> specifying the pattern to use,
-        /// or null to use the default format pattern ("D").
+        /// or null to use the ISO format pattern ("g").
         /// </param>
         /// <param name="formatProvider">The <see cref="System.IFormatProvider" /> to use when formatting the value,
         /// or null to use the current thread's culture to obtain a format provider.
@@ -331,6 +337,16 @@ namespace NodaTime
         /// <filterpriority>2</filterpriority>
         public string ToString(string? patternText, IFormatProvider? formatProvider) =>
             YearMonthPattern.BclSupport.Format(this, patternText, formatProvider);
+
+        /// <summary>
+        /// Returns a <see cref="System.String" /> that represents this instance.
+        /// </summary>
+        /// <returns>
+        /// The value of the current instance in the culture-specific default format pattern ("G"), using the current thread's
+        /// culture to obtain a format provider.
+        /// </returns>
+        public override string ToString() =>
+            YearMonthPattern.BclSupport.Format(this, YearMonthPattern.CultureDefaultFormatPattern, CultureInfo.CurrentCulture);
 
         #region XML serialization
         /// <summary>


### PR DESCRIPTION
Fixes #1670

Unfortunately it's too late to make `yearMonth.ToString(null, null)` yield the same results as `yearMonth.ToString()`, due to compatibility reasons. But the result isn't *too* bad, really.
This will need a documentation update to document the new "G" format once it's merged.