### PR TITLE
Add safeguard to prevent non webassembly friendly code

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/global",
   "sdk": {
-    "version": "5.0.301",
+    "version": "6.0.200",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/global",
   "sdk": {
-    "version": "6.0.200",
+    "version": "5.0.301",
     "allowPrerelease": false,
     "rollForward": "latestMinor"
   }

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -20,6 +20,10 @@
       <Pack>true</Pack>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <SupportedPlatform Include="browser" />
+  </ItemGroup>
   
   <ItemGroup>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />


### PR DESCRIPTION
Jon,

This addition to the CSPROJ is just to prevent anyone from accidentally adding any code that might make NodaTime incompatible with Blazor Web Assembly.

Feel free to disregard it if you'd like but I'm trying to get the libraries I intend to use in Blazor at least marked with the equivalent safeguard so I don't get stung by an unintended minor change.

Buvy