### PR TITLE
Support for DateOnly in .NET 6.0

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateBenchmarks.cs
@@ -12,6 +12,9 @@ namespace NodaTime.Benchmarks.NodaTimeTests
     public class LocalDateBenchmarks
     {
         private static readonly LocalDate Sample = new LocalDate(2009, 12, 26);
+#if NET6_0_OR_GREATER
+        private static readonly DateOnly SampleDateOnly = new DateOnly(2009, 12, 26);
+#endif
         private static readonly DateTime SampleDateTime = new DateTime(2009, 12, 26, 1, 2, 3, DateTimeKind.Utc);
         private static readonly LocalDate SampleBeforeEpoch = new LocalDate(1909, 12, 26);
 
@@ -135,5 +138,13 @@ namespace NodaTime.Benchmarks.NodaTimeTests
 
         [Benchmark]
         public bool LessThanOperator() => Sample < SampleBeforeEpoch;
+
+#if NET6_0_OR_GREATER
+        [Benchmark]
+        public DateOnly ToDateOnly() => Sample.ToDateOnly();
+
+        [Benchmark]
+        public LocalDate FromDateOnly() => LocalDate.FromDateOnly(SampleDateOnly);
+#endif
     }
 }

--- a/src/NodaTime.Test/Extensions/DateOnlyExtensionsTest.cs
+++ b/src/NodaTime.Test/Extensions/DateOnlyExtensionsTest.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2022 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+#if NET6_0_OR_GREATER
+using NodaTime.Extensions;
+using NUnit.Framework;
+using System;
+
+namespace NodaTime.Test.Extensions
+{
+    public class DateOnlyExtensionsTest
+    {
+        [Test]
+        public void ToLocalDate()
+        {
+            var dateOnly = new DateOnly(2011, 8, 18);
+            var expected = new LocalDate(2011, 8, 18);
+            var actual = dateOnly.ToLocalDate();
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}
+#endif

--- a/src/NodaTime.Test/LocalDateTest.Conversion.cs
+++ b/src/NodaTime.Test/LocalDateTest.Conversion.cs
@@ -87,5 +87,45 @@ namespace NodaTime.Test
             LocalDate start = new LocalDate(1, 1, 1);
             Assert.Throws<ArgumentOutOfRangeException>(() => start.WithCalendar(CalendarSystem.PersianSimple));
         }
+#if NET6_0_OR_GREATER
+        [Test]
+        public void ToDateOnly_Gregorian()
+        {
+            var date = new LocalDate(2011, 8, 5);
+            var expected = new DateOnly(2011, 8, 5);
+            var actual = date.ToDateOnly();
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void ToDateOnly_NonGregorian()
+        {
+            // Julian calendar is 13 days behind Gregorian calendar in the 21st century
+            var date = new LocalDate(2011, 8, 5, CalendarSystem.Julian);
+            var expected = new DateOnly(2011, 8, 5, new JulianCalendar());
+            var actual = date.ToDateOnly();
+            Assert.AreEqual(expected, actual);
+            var expectedGregorian = new DateOnly(2011, 8, 18);
+            Assert.AreEqual(expectedGregorian, actual);
+        }
+
+        [Test]
+        public void ToDateOnly_OutOfRange()
+        {
+            var date = new LocalDate(0, 12, 31);
+            // While ArgumentOutOfRangeException may not be the absolute ideal exception, it conveys
+            // the right impression, and is consistent with what we do elsewhere.
+            Assert.Throws<ArgumentOutOfRangeException>(() => date.ToDateOnly());
+        }
+
+        [Test]
+        public void FromDateOnly()
+        {
+            var dateOnly = new DateOnly(2011, 8, 18);
+            var expected = new LocalDate(2011, 8, 18);
+            var actual = LocalDate.FromDateOnly(dateOnly);
+            Assert.AreEqual(expected, actual);
+        }
+#endif
     }
 }

--- a/src/NodaTime/Extensions/DateOnlyExtensions.cs
+++ b/src/NodaTime/Extensions/DateOnlyExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2022 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+#if NET6_0_OR_GREATER
+using System;
+
+namespace NodaTime.Extensions
+{
+    /// <summary>
+    /// Extension methods for <see cref="DateOnly"/>.
+    /// </summary>
+    public static class DateOnlyExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="DateOnly"/> to the equivalent <see cref="LocalDate"/>.
+        /// </summary>
+        /// <param name="date">The date to convert.</param>
+        /// <returns>The <see cref="LocalDate"/> equivalent, which is always in the ISO calendar system.</returns>
+        public static LocalDate ToLocalDate(this DateOnly date) => LocalDate.FromDateOnly(date);
+    }
+}
+#endif

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -871,5 +871,30 @@ namespace NodaTime
             writer.WriteString(LocalDatePattern.Iso.Format(this));
         }
         #endregion
+
+        #region DateOnly conversions (.NET 6 only)
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Converts this value to an equivalent <see cref="DateOnly"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="DateOnly"/> uses the Gregorian calendar by definition, so the value is implicitly converted
+        /// to the Gregorian calendar first. The result will be on the same physical day,
+        /// but the values returned by the Year/Month/Day properties of the <see cref="DateTime"/> may not
+        /// match the Year/Month/Day properties of this value.
+        /// </remarks>
+        /// <returns>A <see cref="DateOnly"/> value equivalent to this one.</returns>
+        [Pure]
+        public DateOnly ToDateOnly() => DateOnly.FromDayNumber(DaysSinceEpoch + NodaConstants.BclDaysAtUnixEpoch);
+
+        /// <summary>
+        /// Constructs a <see cref="LocalDate"/> from a <see cref="DateOnly"/>.
+        /// </summary>
+        /// <param name="date">The date to convert.</param>
+        /// <returns>The <see cref="LocalDate"/> equivalent, which is always in the ISO calendar system.</returns>
+        public static LocalDate FromDateOnly(DateOnly date) =>
+            new LocalDate(CalendarSystem.Iso.GetYearMonthDayCalendarFromDaysSinceEpoch(date.DayNumber - NodaConstants.BclDaysAtUnixEpoch));
+#endif
+#endregion
     }
 }


### PR DESCRIPTION
First part of #1635. (TimeOnly will be in a separate PR.)