### PR TITLE
Update coverage to use .NET 6.0

### DIFF
--- a/build/Coverage.proj
+++ b/build/Coverage.proj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JetBrains.dotCover.CommandLineTools$(DOTCOVER_PACKAGE_SUFFIX)" Version="$(DOTCOVER_VERSION)">

--- a/build/coverage.sh
+++ b/build/coverage.sh
@@ -6,8 +6,8 @@ set -e
 
 declare -r ROOT=$(realpath $(dirname $0)/..)
 declare -r TEST=$ROOT/src/NodaTime.Test
-declare -r DOTCOVER_VERSION=2021.1.3
-declare -r REPORTGENERATOR_VERSION=4.8.11
+declare -r DOTCOVER_VERSION=2021.3.3
+declare -r REPORTGENERATOR_VERSION=5.1.3
 
 export REPORTGENERATOR_VERSION
 export DOTCOVER_VERSION
@@ -25,7 +25,7 @@ mkdir $ROOT/coverage
 
 if [[ $1 == "--report" ]]
 then
-  declare -r REPORTGENERATOR=$ROOT/packages/reportgenerator/$REPORTGENERATOR_VERSION/tools/net5.0/ReportGenerator.dll
+  declare -r REPORTGENERATOR=$ROOT/packages/reportgenerator/$REPORTGENERATOR_VERSION/tools/net6.0/ReportGenerator.dll
   
   dotnet $REPORTGENERATOR \
    -reports:$ROOT/coverage/coverage.xml \


### PR DESCRIPTION
It doesn't look like this is actually required, but it's still good
to be on the latest.