### PR TITLE
Remove IZoneIntervalMapWithMinMax

### DIFF
--- a/src/NodaTime/DateTimeZone.cs
+++ b/src/NodaTime/DateTimeZone.cs
@@ -86,7 +86,7 @@ namespace NodaTime
     /// avoid this if possible.
     /// </threadsafety>
     [Immutable]
-    public abstract class DateTimeZone : IZoneIntervalMapWithMinMax
+    public abstract class DateTimeZone : IZoneIntervalMap
     {
         /// <summary>
         /// The ID of the UTC (Coordinated Universal Time) time zone. This ID is always valid, whatever provider is
@@ -207,6 +207,13 @@ namespace NodaTime
         /// </returns>
         public virtual Offset GetUtcOffset(Instant instant) => GetZoneInterval(instant).WallOffset;
 
+        // Note for CA2119:
+        // IZoneIntervalMap is primarily used while *building* time zones, but is also implemented by DateTimeZone for simplicity
+        // of caching. (BclDateTimeZone always returns a cached date time zone having created an IZoneIntervalMap.)
+        // While a regular user can create their own DateTimeZone implementation, that would never end up being cached
+        // because CachedDateTimeZone.ForZone is internal anyway.
+        // In other words: we don't believe this can be exploited.
+
         /// <summary>
         /// Gets the zone interval for the given instant; the range of time around the instant in which the same Offset
         /// applies (with the same split between standard time and daylight saving time, and with the same offset).
@@ -217,7 +224,9 @@ namespace NodaTime
         /// <param name="instant">The <see cref="NodaTime.Instant" /> to query.</param>
         /// <returns>The defined <see cref="NodaTime.TimeZones.ZoneInterval" />.</returns>
         /// <seealso cref="GetZoneIntervals(Interval)"/>
+#pragma warning disable CA2119 // Seal methods that satisfy private interfaces - see note above
         public abstract ZoneInterval GetZoneInterval(Instant instant);
+#pragma warning restore CA2119
 
         /// <summary>
         /// Returns complete information about how the given <see cref="LocalDateTime" /> is mapped in this time zone.

--- a/src/NodaTime/TimeZones/CachingZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/CachingZoneIntervalMap.cs
@@ -48,6 +48,9 @@ namespace NodaTime.TimeZones
             // result will always be in the range [0, CacheSize).
             private const int CachePeriodMask = CacheSize - 1;
 
+            public Offset MinOffset => map.MinOffset;
+            public Offset MaxOffset => map.MaxOffset;
+
             /// <summary>
             /// Defines the number of bits to shift an instant's "days since epoch" to get the period. This
             /// converts an instant into a number of 32 day periods.

--- a/src/NodaTime/TimeZones/IZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/IZoneIntervalMap.cs
@@ -16,14 +16,6 @@ namespace NodaTime.TimeZones
     internal interface IZoneIntervalMap
     {
         ZoneInterval GetZoneInterval(Instant instant);
-    }
-
-    // TODO: How hard would it be to add these on to IZoneIntervalMap and implement them everywhere?
-
-    // This is slightly ugly, but it allows us to use any time zone as the tail
-    // zone for PrecalculatedDateTimeZone, which is handy for testing.
-    internal interface IZoneIntervalMapWithMinMax : IZoneIntervalMap
-    {
         Offset MinOffset { get; }
         Offset MaxOffset { get; }
     }

--- a/src/NodaTime/TimeZones/PartialZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/PartialZoneIntervalMap.cs
@@ -5,6 +5,7 @@
 using NodaTime.Utility;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace NodaTime.TimeZones
 {
@@ -175,9 +176,14 @@ namespace NodaTime.TimeZones
         {
             private readonly PartialZoneIntervalMap[] partialMaps;
 
+            public Offset MinOffset { get; }
+            public Offset MaxOffset { get; }
+
             internal CombinedPartialZoneIntervalMap(PartialZoneIntervalMap[] partialMaps)
             {
                 this.partialMaps = partialMaps;
+                MinOffset = partialMaps.Aggregate(Offset.MaxValue, (min, partialMap) => Offset.Min(min, partialMap.map.MinOffset));
+                MaxOffset = partialMaps.Aggregate(Offset.MinValue, (max, partialMap) => Offset.Max(max, partialMap.map.MaxOffset));
             }
 
             public ZoneInterval GetZoneInterval(Instant instant)

--- a/src/NodaTime/TimeZones/PrecalculatedDateTimeZone.cs
+++ b/src/NodaTime/TimeZones/PrecalculatedDateTimeZone.cs
@@ -18,7 +18,7 @@ namespace NodaTime.TimeZones
     internal sealed class PrecalculatedDateTimeZone : DateTimeZone
     {
         private readonly ZoneInterval[] periods;
-        private readonly IZoneIntervalMapWithMinMax? tailZone;
+        private readonly IZoneIntervalMap? tailZone;
         /// <summary>
         /// The first instant covered by the tail zone, or Instant.AfterMaxValue if there's no tail zone.
         /// </summary>
@@ -33,7 +33,7 @@ namespace NodaTime.TimeZones
         /// <param name="tailZone">The tail zone - which can be any IZoneIntervalMap for normal operation,
         /// but must be a StandardDaylightAlternatingMap if the result is to be serialized.</param>
         [VisibleForTesting]
-        internal PrecalculatedDateTimeZone(string id, ZoneInterval[] intervals, IZoneIntervalMapWithMinMax? tailZone)
+        internal PrecalculatedDateTimeZone(string id, ZoneInterval[] intervals, IZoneIntervalMap? tailZone)
             : base(id, false,
                    ComputeOffset(intervals, tailZone, Offset.Min),
                    ComputeOffset(intervals, tailZone, Offset.Max))
@@ -179,7 +179,7 @@ namespace NodaTime.TimeZones
         // Reasonably simple way of computing the maximum/minimum offset
         // from either periods or transitions, with or without a tail zone.
         private static Offset ComputeOffset(ZoneInterval[] intervals,
-            IZoneIntervalMapWithMinMax? tailZone,
+            IZoneIntervalMap? tailZone,
             OffsetAggregator aggregator)
         {
             Preconditions.CheckNotNull(intervals, nameof(intervals));

--- a/src/NodaTime/TimeZones/SingleZoneIntervalMap.cs
+++ b/src/NodaTime/TimeZones/SingleZoneIntervalMap.cs
@@ -12,6 +12,9 @@ namespace NodaTime.TimeZones
     {
         private readonly ZoneInterval interval;
 
+        public Offset MinOffset => interval.WallOffset;
+        public Offset MaxOffset => interval.WallOffset;
+
         internal SingleZoneIntervalMap(ZoneInterval interval)
         {
             this.interval = interval;

--- a/src/NodaTime/TimeZones/StandardDaylightAlternatingMap.cs
+++ b/src/NodaTime/TimeZones/StandardDaylightAlternatingMap.cs
@@ -30,7 +30,7 @@ namespace NodaTime.TimeZones
     /// only be used as part of a zone which will only ask it for values within the right
     /// portion of the timeline.
     /// </remarks>
-    internal sealed class StandardDaylightAlternatingMap : IEquatable<StandardDaylightAlternatingMap?>, IZoneIntervalMapWithMinMax
+    internal sealed class StandardDaylightAlternatingMap : IEquatable<StandardDaylightAlternatingMap?>, IZoneIntervalMap
     {
         private readonly Offset standardOffset;
         private readonly ZoneRecurrence standardRecurrence;


### PR DESCRIPTION
Instead, make sure we implement MinOffset and MaxOffset everywhere, and just put the properties into IZoneIntervalMap

Additionally, suppress and explain CA2119 for DateTimeZone.