### PR TITLE
Release Noda Time version 3.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     - thing to change before performing a release.
     -->
   <PropertyGroup>
-    <Version>3.1.0-rc.2</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
   
   <!-- Common properties across all projects (or ones that at least aren't harmful) -->


### PR DESCRIPTION
Changes since 3.0.0:

- Added .NET 6.0 target
- Implemented `DateOnly` and `TimeOnly` conversions to/from
  `LocalDate` and `LocalTime`
- Fixed `BclDateTimeZone` support in .NET 6.0 on Unix
- Implemented `ToString` method for `YearMonth`
- Improved error messages for bad format specifiers
- Added `LocalDateTime.MinIsoValue` and `LocalDate.MaxIsoValue`
- Added `Period.Between` overload accepting `YearMonth` values
- Added `YearMonth.PlusMonths` method
- Added `Period.DaysBetween` method (previously internal)
- Various documentation improvements