### PR TITLE
Fix rounding errors when creating Durations from doubles

### DIFF
--- a/src/NodaTime.Test/DurationTest.cs
+++ b/src/NodaTime.Test/DurationTest.cs
@@ -371,5 +371,16 @@ namespace NodaTime.Test
             Assert.AreEqual(x, Duration.Min(Duration.MaxValue, x));
             Assert.AreEqual(x, Duration.Min(x, Duration.MaxValue));
         }
+
+        [Test]
+        public void DoubleConversionHandlesRoundingErrors()
+        {
+            // This value produces rounding errors when converting to nanoseconds
+            const double expectedSeconds = 4.1;
+
+            Duration duration = Duration.FromSeconds(expectedSeconds);
+
+            Assert.AreEqual(4100000000d, duration.TotalNanoseconds);
+        }
     }
 }

--- a/src/NodaTime.Test/DurationTest.cs
+++ b/src/NodaTime.Test/DurationTest.cs
@@ -373,14 +373,40 @@ namespace NodaTime.Test
         }
 
         [Test]
-        public void DoubleConversionHandlesRoundingErrors()
+        public void FromDaysHandlesRoundingErrors()
         {
-            // This value produces rounding errors when converting to nanoseconds
-            const double expectedSeconds = 4.1;
+            Duration duration = Duration.FromDays(2.53);
+            Assert.AreEqual(218592000000000d, duration.TotalNanoseconds);
+        }
 
-            Duration duration = Duration.FromSeconds(expectedSeconds);
+        [Test]
+        public void FromHoursHandlesRoundingErrors() {
+            Duration duration = Duration.FromHours(4.1);
+            Assert.AreEqual(14760000000000d, duration.TotalNanoseconds);
+        }
 
+        [Test]
+        public void FromMinutesHandlesRoundingErrors() {
+            Duration duration = Duration.FromMinutes(4.1);
+            Assert.AreEqual(246000000000d, duration.TotalNanoseconds);
+        }
+
+        [Test]
+        public void FromSecondsHandlesRoundingErrors() {
+            Duration duration = Duration.FromSeconds(4.1);
             Assert.AreEqual(4100000000d, duration.TotalNanoseconds);
+        }
+
+        [Test]
+        public void FromMillisecondsHandlesRoundingErrors() {
+            Duration duration = Duration.FromMilliseconds(4.1);
+            Assert.AreEqual(4100000d, duration.TotalNanoseconds);
+        }
+
+        [Test]
+        public void FromTicksHandlesRoundingErrors() {
+            Duration duration = Duration.FromTicks(4.1);
+            Assert.AreEqual(410d, duration.TotalNanoseconds);
         }
     }
 }

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -898,7 +898,7 @@ namespace NodaTime
                 days,
                 MinDays,
                 MaxDays);
-            return FromNanoseconds(days * NanosecondsPerDay);
+            return FromNanoseconds(Math.Round(days * NanosecondsPerDay));
         }
 
         /// <summary>
@@ -921,7 +921,7 @@ namespace NodaTime
                 hours,
                 (long) MinDays * HoursPerDay,
                 (MaxDays + 1L) * HoursPerDay - 1);
-            return FromNanoseconds(hours * NanosecondsPerHour);
+            return FromNanoseconds(Math.Round(hours * NanosecondsPerHour));
         }
 
         /// <summary>
@@ -944,7 +944,7 @@ namespace NodaTime
                 minutes,
                 (long) MinDays * MinutesPerDay,
                 (MaxDays + 1L) * MinutesPerDay - 1);
-            return FromNanoseconds(minutes * NanosecondsPerMinute);
+            return FromNanoseconds(Math.Round(minutes * NanosecondsPerMinute));
         }
 
         /// <summary>
@@ -967,7 +967,7 @@ namespace NodaTime
                 seconds,
                 (long) MinDays * SecondsPerDay,
                 (MaxDays + 1L) * SecondsPerDay - 1);
-            return FromNanoseconds(seconds * NanosecondsPerSecond);
+            return FromNanoseconds(Math.Round(seconds * NanosecondsPerSecond));
         }
 
         /// <summary>
@@ -990,7 +990,7 @@ namespace NodaTime
                 milliseconds,
                 (long) MinDays * MillisecondsPerDay,
                 (MaxDays + 1L) * MillisecondsPerDay - 1);
-            return FromNanoseconds(milliseconds * NanosecondsPerMillisecond);
+            return FromNanoseconds(Math.Round(milliseconds * NanosecondsPerMillisecond));
         }
 
         /// <summary>
@@ -1017,7 +1017,7 @@ namespace NodaTime
                 ticks,
                 MinDays * (double) TicksPerDay,
                 (MaxDays + 1d) * TicksPerDay - 1);
-            return FromNanoseconds(ticks * NanosecondsPerTick);
+            return FromNanoseconds(Math.Round(ticks * NanosecondsPerTick));
         }
 
         /// <summary>


### PR DESCRIPTION
Duration methods that take doubles (such as `FromSeconds`) can produce values with rounding errors due to precision issues with the underlying `double` type. For example, `Duration.FromSeconds(4.1)` produces a duration with a value of `0:00:00:04.099999999`. This is confusing from a user perspective.

This proposed solution uses rounding after converting to nanoseconds, which preserves the original user intent. `FromNanoseconds` is untouched, since its comment states "Any fractional parts of the value are truncated towards zero."

Fixes #1695