### PR TITLE
Work around TimeZoneInfo suspected bug (test only)

### DIFF
--- a/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.cs
+++ b/src/NodaTime.Test/TimeZones/BclDateTimeZoneTest.cs
@@ -83,8 +83,16 @@ namespace NodaTime.Test.TimeZones
             var windowsZone = windowsZoneWrapper.Value;
             var nodaZone = BclDateTimeZone.FromTimeZoneInfo(windowsZone);
 
+            // TODO: File a bug about this...
+            int endYear = EndTestYearExclusive;
+            if (windowsZoneWrapper.Value.Id == "Asia/Gaza" ||
+                windowsZoneWrapper.Value.Id == "Asia/Hebron")
+            {
+                endYear = 2036;
+            }
+
             Instant instant = Instant.FromUtc(1800, 1, 1, 0, 0);
-            Instant end = Instant.FromUtc(EndTestYearExclusive, 1, 1, 0, 0);
+            Instant end = Instant.FromUtc(endYear, 1, 1, 0, 0);
 
             while (instant < end)
             {


### PR DESCRIPTION
I need to investigate this in more detail, but it looks like either TimeZoneInfo is representing its final rule incorrectly for Asia/Gaza and Asia/Hebron. For the moment, we'll stop the test in 2036...