### PR TITLE
Sign NuGet packages created as part of updating TZDB

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,4 +36,6 @@ jobs:
 
     - name: Push to NuGet
       run: |
-        for file in nuget/*.nupkg; do dotnet nuget push -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} $file; done
+        echo "Pushing to NuGet from GitHub disabled until we've got signing sorted"
+        exit 1
+        # for file in nuget/*.nupkg; do dotnet nuget push -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}} $file; done


### PR DESCRIPTION
New minor versions still need more work... we'll probably need to revert back to building locally, for now. (Certificate management confuses me... I'm just happy if it works *somehow*!)