### PR TITLE
Add missing double*Duration methods

### DIFF
--- a/src/NodaTime.Test/DurationTest.Operators.cs
+++ b/src/NodaTime.Test/DurationTest.Operators.cs
@@ -184,12 +184,15 @@ namespace NodaTime.Test
             var actual = start * rightOperand;
             var expected = new Duration(expectedDays, expectedNanos);
             Assert.AreEqual(expected, actual);
+            actual = rightOperand * start;
+            Assert.AreEqual(expected, actual);
         }
-        
+
         [Test]
         public void Commutation()
         {
             Assert.AreEqual(threeMillion * 5, 5 * threeMillion);
+            Assert.AreEqual(threeMillion * 5.5, 5.5 * threeMillion);
         }
 
         [Test]
@@ -198,6 +201,7 @@ namespace NodaTime.Test
             Assert.AreEqual(Duration.FromNanoseconds(-50000) * 1000, Duration.Multiply(Duration.FromNanoseconds(-50000), 1000));
             Assert.AreEqual(1000 * Duration.FromNanoseconds(-50000), Duration.Multiply(1000, Duration.FromNanoseconds(-50000)));
             Assert.AreEqual(Duration.FromNanoseconds(-50000) * 1000d, Duration.Multiply(Duration.FromNanoseconds(-50000), 1000d));
+            Assert.AreEqual(1000d * Duration.FromNanoseconds(-50000), Duration.Multiply(1000d, Duration.FromNanoseconds(-50000)));
         }
         #endregion
 

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -698,6 +698,15 @@ namespace NodaTime
         /// <param name="right">The right hand side of the operator.</param>
         /// <returns>A new <see cref="Duration"/> representing the result of multiplying <paramref name="left"/> by
         /// <paramref name="right"/>.</returns>
+        public static Duration operator *(double left, Duration right) => right * left;
+
+        /// <summary>
+        /// Implements the operator * (multiplication).
+        /// </summary>
+        /// <param name="left">The left hand side of the operator.</param>
+        /// <param name="right">The right hand side of the operator.</param>
+        /// <returns>A new <see cref="Duration"/> representing the result of multiplying <paramref name="left"/> by
+        /// <paramref name="right"/>.</returns>
         public static Duration operator *(long left, Duration right) => right * left;
 
         /// <summary>
@@ -723,6 +732,14 @@ namespace NodaTime
         /// <param name="right">The right hand side of the operator.</param>
         /// <returns>A new <see cref="Duration"/> representing the product of the given values.</returns>
         public static Duration Multiply(long left, Duration right) => left * right;
+
+        /// <summary>
+        /// Multiplies a duration by a number. Friendly alternative to <c>operator*()</c>.
+        /// </summary>
+        /// <param name="left">The left hand side of the operator.</param>
+        /// <param name="right">The right hand side of the operator.</param>
+        /// <returns>A new <see cref="Duration"/> representing the product of the given values.</returns>
+        public static Duration Multiply(double left, Duration right) => left * right;
 
         /// <summary>
         /// Implements the operator == (equality).


### PR DESCRIPTION
There are already methods for `Duration * long`, `long * Duration`, and `Duration * double` . The one variant missing is `double * Duration`. This PR adds those, along with unit tests.