### PR TITLE
Remove locks when reading cached fields of NodaFormatInfo

### DIFF
--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -115,6 +115,12 @@ namespace NodaTime.Globalization
 
             lock (fieldLock)
             {
+                // Check again in case it has been initialized in another thread
+                if (longMonthNames != null)
+                {
+                    return;
+                }
+
                 // Turn month names into 1-based read-only lists
                 longMonthNames = ConvertMonthArray(DateTimeFormat.MonthNames);
                 shortMonthNames = ConvertMonthArray(DateTimeFormat.AbbreviatedMonthNames);
@@ -142,6 +148,12 @@ namespace NodaTime.Globalization
 
             lock (fieldLock)
             {
+                // Check again in case it has been initialized in another thread
+                if (longDayNames != null)
+                {
+                    return;
+                }
+                
                 longDayNames = ConvertDayArray(DateTimeFormat.DayNames);
                 shortDayNames = ConvertDayArray(DateTimeFormat.AbbreviatedDayNames);
             }
@@ -234,7 +246,7 @@ namespace NodaTime.Globalization
                 {
                     field = localConstruction;
                 }
-                return field!;
+                return field;
             }
         }
 

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -108,7 +108,7 @@ namespace NodaTime.Globalization
 
         private void EnsureMonthsInitialized()
         {
-            if (longMonthNames != null)
+            if (longMonthNames != null && shortMonthNames != null && longMonthGenitiveNames != null && shortMonthGenitiveNames != null)
             {
                 return;
             }
@@ -141,7 +141,7 @@ namespace NodaTime.Globalization
 
         private void EnsureDaysInitialized()
         {
-            if (longDayNames != null)
+            if (longDayNames != null && shortDayNames != null)
             {
                 return;
             }

--- a/src/NodaTime/Globalization/NodaFormatInfo.cs
+++ b/src/NodaTime/Globalization/NodaFormatInfo.cs
@@ -108,12 +108,13 @@ namespace NodaTime.Globalization
 
         private void EnsureMonthsInitialized()
         {
+            if (longMonthNames != null)
+            {
+                return;
+            }
+
             lock (fieldLock)
             {
-                if (longMonthNames != null)
-                {
-                    return;
-                }
                 // Turn month names into 1-based read-only lists
                 longMonthNames = ConvertMonthArray(DateTimeFormat.MonthNames);
                 shortMonthNames = ConvertMonthArray(DateTimeFormat.AbbreviatedMonthNames);
@@ -134,12 +135,13 @@ namespace NodaTime.Globalization
 
         private void EnsureDaysInitialized()
         {
+            if (longDayNames != null)
+            {
+                return;
+            }
+
             lock (fieldLock)
             {
-                if (longDayNames != null)
-                {
-                    return;
-                }
                 longDayNames = ConvertDayArray(DateTimeFormat.DayNames);
                 shortDayNames = ConvertDayArray(DateTimeFormat.AbbreviatedDayNames);
             }
@@ -217,13 +219,11 @@ namespace NodaTime.Globalization
         private FixedFormatInfoPatternParser<T> EnsureFixedFormatInitialized<T>(ref FixedFormatInfoPatternParser<T>? field,
             Func<IPatternParser<T>> patternParserFactory)
         {
-            lock (fieldLock)
+            if (field != null)
             {
-                if (field != null)
-                {
-                    return field;
-                }
+                return field;
             }
+
             // Construct the cache outside the lock to avoid possible deadlocks. The locally constructed
             // version is ignored if another thread has set the field in-between: this returns a consistent result,
             // but can occasionally perform redundant work.


### PR DESCRIPTION
Fixes #1757.

Since these fields are initialized only in the `EnsureInitialized` methods, they can never be overwritten once a not-null value has been read. Therefore, locking shouldn't be necessary around the reads. 
