### PR TITLE
Add unparsed value field to UnparsableValueException

### DIFF
--- a/src/NodaTime.Test/Text/ParseResultTest.cs
+++ b/src/NodaTime.Test/Text/ParseResultTest.cs
@@ -23,7 +23,8 @@ namespace NodaTime.Test.Text
         public void Value_Failure()
         {
             var exception = Assert.Throws<UnparsableValueException>(() => FailureResult.Value.GetHashCode());
-            Assert.AreEqual("^text", exception?.Value);
+            Assert.AreEqual("text", exception?.Value);
+            Assert.AreEqual(-1, exception?.Index);
         }
 
         [Test]
@@ -37,7 +38,8 @@ namespace NodaTime.Test.Text
         public void Exception_Failure()
         {
             Assert.IsInstanceOf<UnparsableValueException>(FailureResult.Exception);
-            Assert.AreEqual("^text", ((UnparsableValueException) FailureResult.Exception).Value);
+            Assert.AreEqual("text", ((UnparsableValueException) FailureResult.Exception).Value);
+            Assert.AreEqual(-1, ((UnparsableValueException) FailureResult.Exception).Index);
         }
 
         [Test]
@@ -51,7 +53,8 @@ namespace NodaTime.Test.Text
         public void GetValueOrThrow_Failure()
         {
             var exception = Assert.Throws<UnparsableValueException>(() => FailureResult.GetValueOrThrow());
-            Assert.AreEqual("^text", exception?.Value);
+            Assert.AreEqual("text", exception?.Value);
+            Assert.AreEqual(-1, exception?.Index);
         }
 
         [Test]
@@ -74,7 +77,8 @@ namespace NodaTime.Test.Text
         {
             ParseResult<string> converted = FailureResult.Convert(x => $"xx{x}xx");
             var exception = Assert.Throws<UnparsableValueException>(() => converted.GetValueOrThrow());
-            Assert.AreEqual("^text", exception?.Value);
+            Assert.AreEqual("text", exception?.Value);
+            Assert.AreEqual(-1, exception?.Index);
         }
 
         [Test]
@@ -90,7 +94,8 @@ namespace NodaTime.Test.Text
         {
             ParseResult<string> converted = FailureResult.ConvertError<string>();
             var exception = Assert.Throws<UnparsableValueException>(() => converted.GetValueOrThrow());
-            Assert.AreEqual("^text", exception?.Value);
+            Assert.AreEqual("text", exception?.Value);
+            Assert.AreEqual(-1, exception?.Index);
         }
 
         [Test]

--- a/src/NodaTime.Test/Text/ParseResultTest.cs
+++ b/src/NodaTime.Test/Text/ParseResultTest.cs
@@ -22,7 +22,8 @@ namespace NodaTime.Test.Text
         [Test]
         public void Value_Failure()
         {
-            Assert.Throws<UnparsableValueException>(() => FailureResult.Value.GetHashCode());
+            var exception = Assert.Throws<UnparsableValueException>(() => FailureResult.Value.GetHashCode());
+            Assert.AreEqual("^text", exception?.Value);
         }
 
         [Test]
@@ -36,6 +37,7 @@ namespace NodaTime.Test.Text
         public void Exception_Failure()
         {
             Assert.IsInstanceOf<UnparsableValueException>(FailureResult.Exception);
+            Assert.AreEqual("^text", ((UnparsableValueException) FailureResult.Exception).Value);
         }
 
         [Test]
@@ -48,7 +50,8 @@ namespace NodaTime.Test.Text
         [Test]
         public void GetValueOrThrow_Failure()
         {
-            Assert.Throws<UnparsableValueException>(() => FailureResult.GetValueOrThrow());
+            var exception = Assert.Throws<UnparsableValueException>(() => FailureResult.GetValueOrThrow());
+            Assert.AreEqual("^text", exception?.Value);
         }
 
         [Test]
@@ -70,7 +73,8 @@ namespace NodaTime.Test.Text
         public void Convert_ForFailureResult()
         {
             ParseResult<string> converted = FailureResult.Convert(x => $"xx{x}xx");
-            Assert.Throws<UnparsableValueException>(() => converted.GetValueOrThrow());
+            var exception = Assert.Throws<UnparsableValueException>(() => converted.GetValueOrThrow());
+            Assert.AreEqual("^text", exception?.Value);
         }
 
         [Test]
@@ -85,7 +89,8 @@ namespace NodaTime.Test.Text
         public void ConvertError_ForFailureResult()
         {
             ParseResult<string> converted = FailureResult.ConvertError<string>();
-            Assert.Throws<UnparsableValueException>(() => converted.GetValueOrThrow());
+            var exception = Assert.Throws<UnparsableValueException>(() => converted.GetValueOrThrow());
+            Assert.AreEqual("^text", exception?.Value);
         }
 
         [Test]

--- a/src/NodaTime.Test/Text/PatternTestData.cs
+++ b/src/NodaTime.Test/Text/PatternTestData.cs
@@ -158,7 +158,7 @@ namespace NodaTime.Test.Text
                 Assert.IsTrue(e.Message.StartsWith(expectedMessage),
                     "Expected message to start with {0}; was actually {1}", expectedMessage, e.Message);
                 
-                Assert.AreEqual(Text, e.Value.Replace("^", ""), "Expected exception to include the text value");
+                Assert.AreEqual(Text, e.Value, "Expected exception to include the text value");
             }
         }
 

--- a/src/NodaTime.Test/Text/PatternTestData.cs
+++ b/src/NodaTime.Test/Text/PatternTestData.cs
@@ -157,6 +157,8 @@ namespace NodaTime.Test.Text
                 // We're not currently validating the bit that reproduces the bad value.
                 Assert.IsTrue(e.Message.StartsWith(expectedMessage),
                     "Expected message to start with {0}; was actually {1}", expectedMessage, e.Message);
+                
+                Assert.AreEqual(Text, e.Value.Replace("^", ""), "Expected exception to include the text value");
             }
         }
 

--- a/src/NodaTime.Test/Text/Patterns/SteppedPatternBuilderTest.cs
+++ b/src/NodaTime.Test/Text/Patterns/SteppedPatternBuilderTest.cs
@@ -55,7 +55,8 @@ namespace NodaTime.Test.Text.Patterns
             value.MoveNext();
             var result = SimpleOffsetPattern.ParsePartial(value);
             var exception = Assert.Throws<UnparsableValueException>(() => result.GetValueOrThrow());
-            Assert.AreEqual("x17:^y", exception?.Value);
+            Assert.AreEqual("x17:y", exception?.Value);
+            Assert.AreEqual(4, exception?.Index);
         }
 
         [Test]
@@ -71,12 +72,14 @@ namespace NodaTime.Test.Text.Patterns
             var result = pattern.ParsePartial(value);
             Assert.IsFalse(result.Success);
             Assert.IsInstanceOf<UnparsableValueException>(result.Exception);
-            Assert.AreEqual("^xyz",((UnparsableValueException) result.Exception).Value);
+            Assert.AreEqual("xyz",((UnparsableValueException) result.Exception).Value);
+            Assert.AreEqual(-1,((UnparsableValueException) result.Exception).Index);
             Assert.AreEqual(TextErrorMessages.FormatOnlyPattern, result.Exception.Message);
             result = pattern.Parse("xyz");
             Assert.IsFalse(result.Success);
             Assert.IsInstanceOf<UnparsableValueException>(result.Exception);
-            Assert.AreEqual("^xyz",((UnparsableValueException) result.Exception).Value);
+            Assert.AreEqual("xyz",((UnparsableValueException) result.Exception).Value);
+            Assert.AreEqual(-1 ,((UnparsableValueException) result.Exception).Index);
             Assert.AreEqual(TextErrorMessages.FormatOnlyPattern, result.Exception.Message);
         }
 

--- a/src/NodaTime.Test/Text/Patterns/SteppedPatternBuilderTest.cs
+++ b/src/NodaTime.Test/Text/Patterns/SteppedPatternBuilderTest.cs
@@ -54,7 +54,8 @@ namespace NodaTime.Test.Text.Patterns
             value.MoveNext();
             value.MoveNext();
             var result = SimpleOffsetPattern.ParsePartial(value);
-            Assert.Throws<UnparsableValueException>(() => result.GetValueOrThrow());
+            var exception = Assert.Throws<UnparsableValueException>(() => result.GetValueOrThrow());
+            Assert.AreEqual("x17:^y", exception?.Value);
         }
 
         [Test]
@@ -68,9 +69,15 @@ namespace NodaTime.Test.Text.Patterns
 
             var value = new ValueCursor("xyz");
             var result = pattern.ParsePartial(value);
-            Assert.AreEqual(ParseResult<LocalDate>.FormatOnlyPattern, result);
+            Assert.IsFalse(result.Success);
+            Assert.IsInstanceOf<UnparsableValueException>(result.Exception);
+            Assert.AreEqual("^xyz",((UnparsableValueException) result.Exception).Value);
+            Assert.AreEqual(TextErrorMessages.FormatOnlyPattern, result.Exception.Message);
             result = pattern.Parse("xyz");
-            Assert.AreEqual(ParseResult<LocalDate>.FormatOnlyPattern, result);
+            Assert.IsFalse(result.Success);
+            Assert.IsInstanceOf<UnparsableValueException>(result.Exception);
+            Assert.AreEqual("^xyz",((UnparsableValueException) result.Exception).Value);
+            Assert.AreEqual(TextErrorMessages.FormatOnlyPattern, result.Exception.Message);
         }
 
         [Test]

--- a/src/NodaTime.Test/Text/TypeConvertersTest.cs
+++ b/src/NodaTime.Test/Text/TypeConvertersTest.cs
@@ -36,7 +36,8 @@ namespace NodaTime.Test.Text
             Assert.True(converter.CanConvertTo(typeof(string)));
 
             Assert.Throws<NotSupportedException>(() => converter.ConvertFrom(null!));
-            Assert.Throws<UnparsableValueException>(() => converter.ConvertFrom(""));
+            var unparsableValueException = Assert.Throws<UnparsableValueException>(() => converter.ConvertFrom(""));
+            Assert.AreEqual(string.Empty, unparsableValueException?.Value);
 
             if (type.IsValueType)
             {

--- a/src/NodaTime.Test/Text/ValueCursorTest.cs
+++ b/src/NodaTime.Test/Text/ValueCursorTest.cs
@@ -437,8 +437,9 @@ namespace NodaTime.Test.Text
             value.Move(0);
             var parseResult = value.ParseInt64<string>(out long result);
             Assert.IsFalse(parseResult!.Success);
-            Assert.IsInstanceOf<UnparsableValueException>(parseResult.Exception);            
+            Assert.IsInstanceOf<UnparsableValueException>(parseResult.Exception);
             Assert.AreEqual(0, value.Index); // Cursor hasn't moved
+            Assert.AreEqual("^92233720368547758071", ((UnparsableValueException) parseResult.Exception).Value);
         }
     }
 }

--- a/src/NodaTime.Test/Text/ValueCursorTest.cs
+++ b/src/NodaTime.Test/Text/ValueCursorTest.cs
@@ -439,7 +439,8 @@ namespace NodaTime.Test.Text
             Assert.IsFalse(parseResult!.Success);
             Assert.IsInstanceOf<UnparsableValueException>(parseResult.Exception);
             Assert.AreEqual(0, value.Index); // Cursor hasn't moved
-            Assert.AreEqual("^92233720368547758071", ((UnparsableValueException) parseResult.Exception).Value);
+            Assert.AreEqual("92233720368547758071", ((UnparsableValueException) parseResult.Exception).Value);
+            Assert.AreEqual(0, ((UnparsableValueException) parseResult.Exception).Index);
         }
     }
 }

--- a/src/NodaTime/Text/ParseResult.cs
+++ b/src/NodaTime/Text/ParseResult.cs
@@ -170,7 +170,7 @@ namespace NodaTime.Text
                 string detailMessage = string.Format(CultureInfo.CurrentCulture, formatString, parameters);
                 // Format the overall message, containing the parse error and the value itself.
                 string overallMessage = string.Format(CultureInfo.CurrentCulture, TextErrorMessages.UnparsableValue, detailMessage, cursor);
-                return new UnparsableValueException(overallMessage, cursor.ToString());
+                return new UnparsableValueException(overallMessage, cursor.Value, cursor.Index);
             });
 
         internal static ParseResult<T> ForInvalidValuePostParse(string text, string formatString, params object[] parameters) =>
@@ -180,7 +180,7 @@ namespace NodaTime.Text
                 string detailMessage = string.Format(CultureInfo.CurrentCulture, formatString, parameters);
                 // Format the overall message, containing the parse error and the value itself.
                 string overallMessage = string.Format(CultureInfo.CurrentCulture, TextErrorMessages.UnparsableValuePostParse, detailMessage, text);
-                return new UnparsableValueException(overallMessage, text);
+                return new UnparsableValueException(overallMessage, text, -1);
             });
 
         private static ParseResult<T> ForInvalidValue(Func<Exception> exceptionProvider) => new ParseResult<T>(exceptionProvider, true);
@@ -192,7 +192,7 @@ namespace NodaTime.Text
         // Special case: it's a fault with the value, but we still don't want to continue with multiple patterns.
         // Also, there's no point in including the text.
         internal static readonly ParseResult<T> ValueStringEmpty =
-            new ParseResult<T>(() => new UnparsableValueException(string.Format(CultureInfo.CurrentCulture, TextErrorMessages.ValueStringEmpty), string.Empty), false);
+            new ParseResult<T>(() => new UnparsableValueException(string.Format(CultureInfo.CurrentCulture, TextErrorMessages.ValueStringEmpty), string.Empty, -1), false);
 
         internal static ParseResult<T> ExtraValueCharacters(ValueCursor cursor, string remainder) => ForInvalidValue(cursor, TextErrorMessages.ExtraValueCharacters, remainder);
 
@@ -214,7 +214,7 @@ namespace NodaTime.Text
         /// This isn't really an issue with the value so much as the pattern... but the result is the same.
         /// </summary>
         internal static ParseResult<T> FormatOnlyPattern(ValueCursor cursor) =>
-            new ParseResult<T>(() => new UnparsableValueException(string.Format(CultureInfo.CurrentCulture, TextErrorMessages.FormatOnlyPattern), cursor.ToString()), true);
+            new ParseResult<T>(() => new UnparsableValueException(string.Format(CultureInfo.CurrentCulture, TextErrorMessages.FormatOnlyPattern), cursor.Value, cursor.Index), true);
 
         internal static ParseResult<T> MismatchedNumber(ValueCursor cursor, string pattern) => ForInvalidValue(cursor, TextErrorMessages.MismatchedNumber, pattern);
 

--- a/src/NodaTime/Text/ParseResult.cs
+++ b/src/NodaTime/Text/ParseResult.cs
@@ -170,7 +170,7 @@ namespace NodaTime.Text
                 string detailMessage = string.Format(CultureInfo.CurrentCulture, formatString, parameters);
                 // Format the overall message, containing the parse error and the value itself.
                 string overallMessage = string.Format(CultureInfo.CurrentCulture, TextErrorMessages.UnparsableValue, detailMessage, cursor);
-                return new UnparsableValueException(overallMessage);
+                return new UnparsableValueException(overallMessage, cursor.ToString());
             });
 
         internal static ParseResult<T> ForInvalidValuePostParse(string text, string formatString, params object[] parameters) =>
@@ -180,7 +180,7 @@ namespace NodaTime.Text
                 string detailMessage = string.Format(CultureInfo.CurrentCulture, formatString, parameters);
                 // Format the overall message, containing the parse error and the value itself.
                 string overallMessage = string.Format(CultureInfo.CurrentCulture, TextErrorMessages.UnparsableValuePostParse, detailMessage, text);
-                return new UnparsableValueException(overallMessage);
+                return new UnparsableValueException(overallMessage, text);
             });
 
         private static ParseResult<T> ForInvalidValue(Func<Exception> exceptionProvider) => new ParseResult<T>(exceptionProvider, true);
@@ -192,7 +192,7 @@ namespace NodaTime.Text
         // Special case: it's a fault with the value, but we still don't want to continue with multiple patterns.
         // Also, there's no point in including the text.
         internal static readonly ParseResult<T> ValueStringEmpty =
-            new ParseResult<T>(() => new UnparsableValueException(string.Format(CultureInfo.CurrentCulture, TextErrorMessages.ValueStringEmpty)), false);
+            new ParseResult<T>(() => new UnparsableValueException(string.Format(CultureInfo.CurrentCulture, TextErrorMessages.ValueStringEmpty), string.Empty), false);
 
         internal static ParseResult<T> ExtraValueCharacters(ValueCursor cursor, string remainder) => ForInvalidValue(cursor, TextErrorMessages.ExtraValueCharacters, remainder);
 
@@ -213,8 +213,8 @@ namespace NodaTime.Text
         /// <summary>
         /// This isn't really an issue with the value so much as the pattern... but the result is the same.
         /// </summary>
-        internal static readonly ParseResult<T> FormatOnlyPattern =
-            new ParseResult<T>(() => new UnparsableValueException(string.Format(CultureInfo.CurrentCulture, TextErrorMessages.FormatOnlyPattern)), true);
+        internal static ParseResult<T> FormatOnlyPattern(ValueCursor cursor) =>
+            new ParseResult<T>(() => new UnparsableValueException(string.Format(CultureInfo.CurrentCulture, TextErrorMessages.FormatOnlyPattern), cursor.ToString()), true);
 
         internal static ParseResult<T> MismatchedNumber(ValueCursor cursor, string pattern) => ForInvalidValue(cursor, TextErrorMessages.MismatchedNumber, pattern);
 

--- a/src/NodaTime/Text/Patterns/SteppedPatternBuilder.cs
+++ b/src/NodaTime/Text/Patterns/SteppedPatternBuilder.cs
@@ -624,7 +624,7 @@ namespace NodaTime.Text.Patterns
             {
                 if (parseActions is null)
                 {
-                    return ParseResult<TResult>.FormatOnlyPattern;
+                    return ParseResult<TResult>.FormatOnlyPattern(new ValueCursor(text));
                 }
                 if (text is null)
                 {
@@ -666,7 +666,7 @@ namespace NodaTime.Text.Patterns
                 // let's guard against it for the future.
                 if (parseActions is null)
                 {
-                    return ParseResult<TResult>.FormatOnlyPattern;
+                    return ParseResult<TResult>.FormatOnlyPattern(cursor);
                 }
 
                 TBucket bucket = bucketProvider();

--- a/src/NodaTime/Text/UnparsableValueException.cs
+++ b/src/NodaTime/Text/UnparsableValueException.cs
@@ -21,24 +21,34 @@ namespace NodaTime.Text
         /// </summary>
         public UnparsableValueException()
         {
+            Value = string.Empty;
         }
 
         /// <summary>
         /// Creates a new UnparsableValueException with the given message.
         /// </summary>
         /// <param name="message">The failure message</param>
-        public UnparsableValueException(string message)
+        /// <param name="value">The value which could not be parsed</param>
+        public UnparsableValueException(string message, string value)
             : base(message)
         {
+            Value = value;
         }
 
         /// <summary>
         /// Creates a new UnparsableValueException with the given message and inner exception
         /// </summary>
         /// <param name="message">The failure message</param>
+        /// <param name="value">The value which could not be parsed</param>
         /// <param name="innerException">The inner exception</param>
-        public UnparsableValueException(string message, Exception innerException) : base(message, innerException)
+        public UnparsableValueException(string message, string value, Exception innerException) : base(message, innerException)
         {
+            Value = value;
         }
+        
+        /// <summary>
+        /// The value which could not be parsed.
+        /// </summary>
+        public string Value { get; private set; }
     }
 }

--- a/src/NodaTime/Text/UnparsableValueException.cs
+++ b/src/NodaTime/Text/UnparsableValueException.cs
@@ -29,10 +29,12 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="message">The failure message</param>
         /// <param name="value">The value which could not be parsed</param>
-        public UnparsableValueException(string message, string value)
+        /// <param name="index">The index within the value where parsing failed</param>
+        public UnparsableValueException(string message, string value, int index)
             : base(message)
         {
             Value = value;
+            Index = index;
         }
 
         /// <summary>
@@ -40,15 +42,22 @@ namespace NodaTime.Text
         /// </summary>
         /// <param name="message">The failure message</param>
         /// <param name="value">The value which could not be parsed</param>
+        /// <param name="index">The index within the value where parsing failed</param>
         /// <param name="innerException">The inner exception</param>
-        public UnparsableValueException(string message, string value, Exception innerException) : base(message, innerException)
+        public UnparsableValueException(string message, string value, int index, Exception innerException) : base(message, innerException)
         {
             Value = value;
+            Index = index;
         }
         
         /// <summary>
         /// The value which could not be parsed.
         /// </summary>
         public string Value { get; private set; }
+        
+        /// <summary>
+        /// The index within the value where parsing failed.
+        /// </summary>
+        public int Index { get; private set; }
     }
 }


### PR DESCRIPTION
Having access to the raw value makes it easier to both log it better, and to hide the value from the original message by replacing it with `*****` on critical systems.