### PR TITLE
fix: Fix the arguments passed up to exception base classes

### DIFF
--- a/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
+++ b/src/NodaTime.Test/DateTimeZoneTest.LocalConversions.cs
@@ -111,7 +111,9 @@ namespace NodaTime.Test
             var e = Assert.Throws<SkippedTimeException>(() => mapping.Single())!;
             Assert.AreEqual(localTime, e.LocalDateTime);
             Assert.AreEqual(zone, e.Zone);
-            
+            Assert.Null(e.ParamName);
+            StringAssert.Contains(zone.Id, e.Message);
+
             e = Assert.Throws<SkippedTimeException>(() => mapping.First())!;
             Assert.AreEqual(localTime, e.LocalDateTime);
             Assert.AreEqual(zone, e.Zone);
@@ -136,6 +138,8 @@ namespace NodaTime.Test
             Assert.AreEqual(zone, e.Zone);
             Assert.AreEqual(earlier, e.EarlierMapping);
             Assert.AreEqual(later, e.LaterMapping);
+            Assert.Null(e.ParamName);
+            StringAssert.Contains(zone.Id, e.Message);
 
             Assert.AreEqual(earlier, mapping.First());
             Assert.AreEqual(later, mapping.Last());

--- a/src/NodaTime/AmbiguousTimeException.cs
+++ b/src/NodaTime/AmbiguousTimeException.cs
@@ -83,7 +83,7 @@ namespace NodaTime
         /// <param name="earlierMapping">The earlier possible mapping</param>
         /// <param name="laterMapping">The later possible mapping</param>
         public AmbiguousTimeException(ZonedDateTime earlierMapping, ZonedDateTime laterMapping)
-            : base($"Local time {earlierMapping.LocalDateTime} is ambiguous in time zone {earlierMapping.Zone.Id}")
+            : base(paramName: null, message: $"Local time {earlierMapping.LocalDateTime} is ambiguous in time zone {earlierMapping.Zone.Id}")
         {
             EarlierMapping = earlierMapping;
             LaterMapping = laterMapping;

--- a/src/NodaTime/SkippedTimeException.cs
+++ b/src/NodaTime/SkippedTimeException.cs
@@ -65,7 +65,7 @@ namespace NodaTime
         /// <param name="localDateTime">The local date/time which is skipped in the specified time zone.</param>
         /// <param name="zone">The time zone in which the local date/time does not exist.</param>
         public SkippedTimeException(LocalDateTime localDateTime, DateTimeZone zone)
-            : base($"Local time {localDateTime} is invalid in time zone {Preconditions.CheckNotNull(zone, nameof(zone)).Id}")
+            : base(paramName: null, message: $"Local time {localDateTime} is invalid in time zone {Preconditions.CheckNotNull(zone, nameof(zone)).Id}")
         {
             this.LocalDateTime = localDateTime;
             this.Zone = zone;


### PR DESCRIPTION
Fixes #1761

This could theoretically break someone relying on ParamName actually containing the message - but since that's *clearly* a bug, I'd have hoped folks would at least have reported it at the same time, in which case we'd have fixed it earlier.