### PR TITLE
Add Duration.ToInt128Nanoseconds and Duration.FromNanoseconds(Int128)

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
+++ b/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net471;net6.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NodaTime.Benchmarks/NodaTimeTests/DurationBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/DurationBenchmarks.cs
@@ -32,6 +32,12 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         private static readonly BigInteger BigInteger50Years = 50L * 365 * NodaConstants.NanosecondsPerDay;
         private static readonly BigInteger BigInteger3000Years = ((BigInteger) 365 * NodaConstants.NanosecondsPerDay) * 3000;
 
+#if NET7_0_OR_GREATER
+        private static readonly Int128 Int128_50 = 50;
+        private static readonly Int128 Int128_50Years = 50L * 365 * NodaConstants.NanosecondsPerDay;
+        private static readonly Int128 Int128_3000Years = ((Int128) 365 * NodaConstants.NanosecondsPerDay) * 3000;
+#endif
+
         [Benchmark]
         public Duration FromDays() =>
 #if !V1
@@ -107,7 +113,17 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         public Duration FromNanoseconds_LargeBigInteger() => Duration.FromNanoseconds(BigInteger3000Years);
 
         // No equivalent for Int64 as it won't fit...
+#endif
 
+#if NET7_0_OR_GREATER
+        [Benchmark]
+        public Duration FromNanoseconds_TinyInt128() => Duration.FromNanoseconds(Int128_50);
+
+        [Benchmark]
+        public Duration FromNanoseconds_MediumInt128() => Duration.FromNanoseconds(Int128_50Years);
+
+        [Benchmark]
+        public Duration FromNanoseconds_LargeInt128() => Duration.FromNanoseconds(Int128_3000Years);
 #endif
 
         [Benchmark]
@@ -166,6 +182,17 @@ namespace NodaTime.Benchmarks.NodaTimeTests
 
         [Benchmark]
         public BigInteger ToBigIntegerNanoseconds_Large() => LargeDuration.ToBigIntegerNanoseconds();
+
+#if NET7_0_OR_GREATER
+        [Benchmark]
+        public BigInteger ToInt128Nanoseconds_Small() => SmallDuration.ToInt128Nanoseconds();
+
+        [Benchmark]
+        public BigInteger ToInt128Nanoseconds_Medium() => MediumDuration.ToInt128Nanoseconds();
+
+        [Benchmark]
+        public BigInteger ToInt128Nanoseconds_Large() => LargeDuration.ToInt128Nanoseconds();
+#endif
 
         [Benchmark]
         public double TotalNanoseconds_Small() => SmallDuration.TotalNanoseconds;

--- a/src/NodaTime.Test/DurationTest.cs
+++ b/src/NodaTime.Test/DurationTest.cs
@@ -85,6 +85,34 @@ namespace NodaTime.Test
             Assert.AreEqual(bigIntegerNanos, nanoseconds.ToBigIntegerNanoseconds());
         }
 
+#if NET7_0_OR_GREATER
+        [Test]
+        [TestCase(long.MinValue)]
+        [TestCase(long.MinValue + 1)]
+        [TestCase(-NodaConstants.NanosecondsPerDay - 1)]
+        [TestCase(-NodaConstants.NanosecondsPerDay)]
+        [TestCase(-NodaConstants.NanosecondsPerDay + 1)]
+        [TestCase(-1)]
+        [TestCase(0)]
+        [TestCase(1)]
+        [TestCase(NodaConstants.NanosecondsPerDay - 1)]
+        [TestCase(NodaConstants.NanosecondsPerDay)]
+        [TestCase(NodaConstants.NanosecondsPerDay + 1)]
+        [TestCase(long.MaxValue - 1)]
+        [TestCase(long.MaxValue)]
+        public void Int128Conversions(long int64Nanos)
+        {
+            Int128 int128Nanos = int64Nanos;
+            var nanoseconds = Duration.FromNanoseconds(int128Nanos);
+            Assert.AreEqual(int128Nanos, nanoseconds.ToInt128Nanoseconds());
+
+            // And multiply it by 100, which proves we still work for values out of the range of Int64
+            int128Nanos *= 100;
+            nanoseconds = Duration.FromNanoseconds(int128Nanos);
+            Assert.AreEqual(int128Nanos, nanoseconds.ToInt128Nanoseconds());
+        }
+#endif
+
         [Test]
         public void ConstituentParts_Positive()
         {


### PR DESCRIPTION
These are only available for the .NET 8 build (although in source code they're .NET 7+ as that's when Int128 was introduced; this is just in case we introduce a .NET 7 build).

Fixes #1777.

Benchmarks show that the Int128 operations are about the same as BigInteger in the worst cases, and about twice as fast in better cases.