### PR TITLE
Restore previously-removed constructors

### DIFF
--- a/src/NodaTime.Test/ExceptionConstructorTests.cs
+++ b/src/NodaTime.Test/ExceptionConstructorTests.cs
@@ -21,12 +21,24 @@ namespace NodaTime.Test
             Assert.AreEqual(new FormatException().Message, exception.Message);
         }
 
-        // We never actually use this constructor, but it's in the public API and it's harmless...
-        [Test]
-        public void UnparsableValueExceptionParameterlessConstructor()
+        // We never actually use these constructors, but they're in the public API and we don't want to create
+        // a breaking change. They're obsolete to discourage external use though, as we want an UnparsableValueException
+        // to always have a value.
+        [Test, Obsolete]
+        public void UnparsableValueObsoleteConstructors()
         {
-            var exception = new UnparsableValueException();
-            Assert.AreEqual(new FormatException().Message, exception.Message);
+            var exceptions = new[]
+            {
+                new UnparsableValueException(),
+                new UnparsableValueException("message"),
+                new UnparsableValueException("message", new Exception())
+            };
+
+            foreach (var exception in exceptions)
+            {
+                Assert.IsEmpty(exception.Value);
+                Assert.AreEqual(-1, exception.Index);
+            }
         }
     }
 }

--- a/src/NodaTime/Text/UnparsableValueException.cs
+++ b/src/NodaTime/Text/UnparsableValueException.cs
@@ -20,7 +20,33 @@ namespace NodaTime.Text
         /// Creates a new UnparsableValueException with no message, value or index.
         /// <see cref="Value"/> will be an empty string, and <see cref="Index"/> will have a value of -1.
         /// </summary>
+        [Obsolete("Use constructors accepting a value")]
         public UnparsableValueException()
+        {
+            Value = "";
+            Index = -1;
+        }
+
+        /// <summary>
+        /// Creates a new UnparsableValueException with the given message, but no value or index.
+        /// <see cref="Value"/> will be an empty string, and <see cref="Index"/> will have a value of -1.
+        /// </summary>
+        /// <param name="message">The failure message</param>
+        [Obsolete("Use constructors accepting a value")]
+        public UnparsableValueException(string message) : base(message)
+        {
+            Value = "";
+            Index = -1;
+        }
+
+        /// <summary>
+        /// Creates a new UnparsableValueException with the given message and base exception, but no value or index.
+        /// <see cref="Value"/> will be an empty string, and <see cref="Index"/> will have a value of -1.
+        /// </summary>
+        /// <param name="message">The failure message</param>
+        /// <param name="innerException">The inner exception</param>
+        [Obsolete("Use constructors accepting a value")]
+        public UnparsableValueException(string message, Exception innerException) : base(message, innerException)
         {
             Value = "";
             Index = -1;


### PR DESCRIPTION
This was a breaking change in #1760 that I didn't spot at the time.