### PR TITLE
Validate AOT compatibility with both analyzers and a test app

### DIFF
--- a/build/ci.sh
+++ b/build/ci.sh
@@ -13,3 +13,7 @@ dotnet test -c Release -f net6.0 src/NodaTime.Test
 
 dotnet build -c Release src/NodaTime.TzdbCompiler
 dotnet test -c Release -f net8.0 src/NodaTime.TzdbCompiler.Test
+
+# Publish the AOT compatibility app as an additional step to
+# find any AOT-problematic code.
+dotnet publish src/NodaTime.AotCompatibilityTestApp

--- a/src/NodaTime.AotCompatibilityTestApp/NodaTime.AotCompatibilityTestApp.csproj
+++ b/src/NodaTime.AotCompatibilityTestApp/NodaTime.AotCompatibilityTestApp.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NodaTime.Testing\NodaTime.Testing.csproj" />
+    <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
+    <TrimmerRootAssembly Include="NodaTime" />
+    <TrimmerRootAssembly Include="NodaTime.Testing" />
+  </ItemGroup>
+
+</Project>

--- a/src/NodaTime.AotCompatibilityTestApp/Program.cs
+++ b/src/NodaTime.AotCompatibilityTestApp/Program.cs
@@ -1,0 +1,4 @@
+﻿// Copyright 2024 The Noda Time Authors. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+Console.WriteLine("This app is purely for AOT publication testing.");

--- a/src/NodaTime.sln
+++ b/src/NodaTime.sln
@@ -35,7 +35,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MSBuild", "MSBuild", "{33DA
 		..\global.json = ..\global.json
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NodaTime.Benchmarks.Custom", "NodaTime.Benchmarks.Custom\NodaTime.Benchmarks.Custom.csproj", "{BDF553CC-28F5-48C3-98BF-D6500709DC25}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NodaTime.Benchmarks.Custom", "NodaTime.Benchmarks.Custom\NodaTime.Benchmarks.Custom.csproj", "{BDF553CC-28F5-48C3-98BF-D6500709DC25}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NodaTime.AotCompatibilityTestApp", "NodaTime.AotCompatibilityTestApp\NodaTime.AotCompatibilityTestApp.csproj", "{93531D32-B11A-4D85-A7ED-CABC389CE43C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -215,6 +217,18 @@ Global
 		{BDF553CC-28F5-48C3-98BF-D6500709DC25}.Release|x64.Build.0 = Release|Any CPU
 		{BDF553CC-28F5-48C3-98BF-D6500709DC25}.Release|x86.ActiveCfg = Release|Any CPU
 		{BDF553CC-28F5-48C3-98BF-D6500709DC25}.Release|x86.Build.0 = Release|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Debug|x64.Build.0 = Debug|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Debug|x86.Build.0 = Debug|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Release|x64.ActiveCfg = Release|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Release|x64.Build.0 = Release|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Release|x86.ActiveCfg = Release|Any CPU
+		{93531D32-B11A-4D85-A7ED-CABC389CE43C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -9,6 +9,7 @@
     <IsPackable>True</IsPackable>
     <PackageTags>date;time;timezone;calendar;nodatime</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
No changes to the main library are required (somewhat surprisingly) - I'm expecting the serialization libraries to be somewhat trickier.

See https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/

Fixes #1779