### PR TITLE
Tidy up unreferenced test case source collections in `LocalTimePatternTest.cs`

### DIFF
--- a/src/NodaTime.Test/Text/LocalTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalTimePatternTest.cs
@@ -150,19 +150,6 @@ namespace NodaTime.Test.Text
             new Data(14, 15, 16) { Culture = Cultures.Invariant, Text = "14:15", Pattern = "t" },
         };
 
-        internal static Data[] DefaultPatternData = {
-            // Invariant culture uses HH:mm:ss for the "long" pattern
-            new Data(5, 0, 0, 0) { Text = "05:00:00" },
-            new Data(5, 12, 0, 0) { Text = "05:12:00" },
-            new Data(5, 12, 34, 0) { Text = "05:12:34" },
-
-            // US uses hh:mm:ss tt for the "long" pattern
-            new Data(17, 0, 0, 0) { Culture = Cultures.EnUs, Text = "5:00:00 PM" },
-            new Data(5, 0, 0, 0) { Culture = Cultures.EnUs, Text = "5:00:00 AM" },
-            new Data(5, 12, 0, 0) { Culture = Cultures.EnUs, Text = "5:12:00 AM" },
-            new Data(5, 12, 34, 0) { Culture = Cultures.EnUs, Text = "5:12:34 AM" },
-        };
-
         internal static readonly Data[] TemplateValueData = {
             // Pattern specifies nothing - template value is passed through
             new Data(LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5)) { Culture = Cultures.EnUs, Text = "X", Pattern = "'X'", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
@@ -256,6 +243,13 @@ namespace NodaTime.Test.Text
 
             new Data(14, 15, 16) { Culture = Cultures.DotTimeSeparator, Text = "14.15.16", Pattern = "T" },
             new Data(14, 15, 16) { Culture = Cultures.Invariant, Text = "14:15:16", Pattern = "T" },
+            new Data(5, 0, 0, 0) { Text = "05:00:00", Pattern = "T"},
+            new Data(5, 12, 0, 0) { Text = "05:12:00", Pattern = "T" },
+            new Data(5, 12, 34, 0) { Text = "05:12:34", Pattern = "T" },
+            new Data(17, 0, 0, 0) { Culture = Cultures.EnUs, Text = "5:00:00 PM", Pattern = "T" },
+            new Data(5, 0, 0, 0) { Culture = Cultures.EnUs, Text = "5:00:00 AM", Pattern = "T" },
+            new Data(5, 12, 0, 0) { Culture = Cultures.EnUs, Text = "5:12:00 AM", Pattern = "T" },
+            new Data(5, 12, 34, 0) { Culture = Cultures.EnUs, Text = "5:12:34 AM", Pattern = "T" },
 
             new Data(14, 15, 16, 789) { StandardPattern = LocalTimePattern.ExtendedIso, Culture = Cultures.DotTimeSeparator, Text = "14:15:16.789", Pattern = "o" },
             new Data(14, 15, 16, 789) { StandardPattern = LocalTimePattern.ExtendedIso, Culture = Cultures.EnUs, Text = "14:15:16.789", Pattern = "o" },

--- a/src/NodaTime.Test/Text/LocalTimePatternTest.cs
+++ b/src/NodaTime.Test/Text/LocalTimePatternTest.cs
@@ -150,25 +150,6 @@ namespace NodaTime.Test.Text
             new Data(14, 15, 16) { Culture = Cultures.Invariant, Text = "14:15", Pattern = "t" },
         };
 
-        internal static readonly Data[] TemplateValueData = {
-            // Pattern specifies nothing - template value is passed through
-            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5)) { Culture = Cultures.EnUs, Text = "X", Pattern = "'X'", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
-            // Tests for each individual field being propagated
-            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(1, 6, 7, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "mm:ss.FFFFFFF", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
-            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(6, 2, 7, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:ss.FFFFFFF", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
-            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(6, 7, 3, 8, 9)) { Culture = Cultures.EnUs, Text = "06:07.0080009", Pattern = "HH:mm.FFFFFFF", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
-            new Data(LocalTime.FromHourMinuteSecondMillisecondTick(6, 7, 8, 4, 5)) { Culture = Cultures.EnUs, Text = "06:07:08", Pattern = "HH:mm:ss", Template = LocalTime.FromHourMinuteSecondMillisecondTick(1, 2, 3, 4, 5) },
-
-            // Hours are tricky because of the ways they can be specified
-            new Data(new LocalTime(6, 2, 3)) { Culture = Cultures.EnUs, Text = "6", Pattern = "%h", Template = new LocalTime(1, 2, 3) },
-            new Data(new LocalTime(18, 2, 3)) { Culture = Cultures.EnUs, Text = "6", Pattern = "%h", Template = new LocalTime(14, 2, 3) },
-            new Data(new LocalTime(2, 2, 3)) { Culture = Cultures.EnUs, Text = "AM", Pattern = "tt", Template = new LocalTime(14, 2, 3) },
-            new Data(new LocalTime(14, 2, 3)) { Culture = Cultures.EnUs, Text = "PM", Pattern = "tt", Template = new LocalTime(14, 2, 3) },
-            new Data(new LocalTime(2, 2, 3)) { Culture = Cultures.EnUs, Text = "AM", Pattern = "tt", Template = new LocalTime(2, 2, 3) },
-            new Data(new LocalTime(14, 2, 3)) { Culture = Cultures.EnUs, Text = "PM", Pattern = "tt", Template = new LocalTime(2, 2, 3) },
-            new Data(new LocalTime(17, 2, 3)) { Culture = Cultures.EnUs, Text = "5 PM", Pattern = "h tt", Template = new LocalTime(1, 2, 3) },
-        };
-
         /// <summary>
         /// Common test data for both formatting and parsing. A test should be placed here unless is truly
         /// cannot be run both ways. This ensures that as many round-trip type tests are performed as possible.


### PR DESCRIPTION
Hello, my name is Chris. Towards the end of last year, I contacted Jon to more or less ask for his blessing to work on a [Python port of this library](https://github.com/chrisimcevoy/pyoda-time).

In that context, I noticed while reading `LocalTimePatternTest.cs` that there are a couple of historic `TestCaseSource` collections which have fallen into disuse, i.e. there are no remaining references to them.

- [`DefaultPatternData`](https://github.com/nodatime/nodatime/blob/8c41fe377b8ff8121b2942e749c2a3b81e797e20/src/NodaTime.Test/Text/LocalTimePatternTest.cs#L153-L164)
- [`TemplateValueData`](https://github.com/nodatime/nodatime/blob/8c41fe377b8ff8121b2942e749c2a3b81e797e20/src/NodaTime.Test/Text/LocalTimePatternTest.cs#L166-L183)

The last reference to `DefaultPatternData` was [removed in 2012](https://github.com/nodatime/nodatime/commit/74bf0896f65428351a46cd1bb0b9c7bcace72004#diff-28c4459b9497dc18d0893c4b399d0430bbd0eb97bb9b7e242e80a21038e81ee0L338-L351). I am not sure how beneficial it is to retain these test cases, but I have moved them into the `FormatAndParseData` collection for now.

The last reference to `TemplateValueData` was [removed in 2011](https://github.com/nodatime/nodatime/commit/d0013f3d67924fedcffc90bb701b9a7bc3808bc9#diff-1709b0cc502a466a88d57bdd64bd64fe5a2508871801be052c3116fd83ae4de7L39-L49), although the individual test cases live on, mostly unchanged, [here](https://github.com/nodatime/nodatime/blob/e913a53d2d20636bdc56dd2a8786976731792b0c/src/NodaTime.Test/Text/LocalTimePatternTest.cs#L269-L297). So it seems clear that the unreferenced collection can just be removed...?