### PR TITLE
`Period.Between()` test should cover `LocalDateTime` overload

### DIFF
--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -310,8 +310,8 @@ namespace NodaTime.Test
         [Test]
         public void BetweenLocalDateTimes_InvalidUnits()
         {
-            Assert.Throws<ArgumentException>(() => Period.Between(TestDate1, TestDate2, 0));
-            Assert.Throws<ArgumentException>(() => Period.Between(TestDate1, TestDate2, (PeriodUnits)(-1)));
+            Assert.Throws<ArgumentException>(() => Period.Between(TestDateTime1, TestDateTime2, 0));
+            Assert.Throws<ArgumentException>(() => Period.Between(TestDateTime1, TestDateTime2, (PeriodUnits)(-1)));
         }
 
         [Test]


### PR DESCRIPTION
In `PeriodTest.cs`, there are four similar tests which are intended to test different `Period.Between()` overloads:

- [BetweenLocalDates_InvalidUnits](https://github.com/nodatime/nodatime/blob/8c41fe377b8ff8121b2942e749c2a3b81e797e20/src/NodaTime.Test/PeriodTest.cs#L104-L111)
- [BetweenLocalTimes_InvalidUnits](https://github.com/nodatime/nodatime/blob/8c41fe377b8ff8121b2942e749c2a3b81e797e20/src/NodaTime.Test/PeriodTest.cs#L317-L326)
- [BetweenLocalDateTimes_InvalidUnits](https://github.com/nodatime/nodatime/blob/8c41fe377b8ff8121b2942e749c2a3b81e797e20/src/NodaTime.Test/PeriodTest.cs#L310-L315)
- [BetweenYearMonth_InvalidUnits](https://github.com/nodatime/nodatime/blob/8c41fe377b8ff8121b2942e749c2a3b81e797e20/src/NodaTime.Test/PeriodTest.cs#L988-L1000)

However, it turns out that `BetweenLocalDateTimes_InvalidUnits` is testing the `LocalDate` overload.

I imagine `Period.Between(LocalDateTime, LocalDateTime)` is covered pretty extensively anyway, but I thought it worth raising nonetheless.