### PR TITLE
Added generic math support.

### DIFF
--- a/src/NodaTime.Test/PeriodTest.cs
+++ b/src/NodaTime.Test/PeriodTest.cs
@@ -470,6 +470,14 @@ namespace NodaTime.Test
         }
 
         [Test]
+        public void UnaryNegation()
+        {
+            Period period = new Period(2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+            Period negation = -period;
+            Assert.AreEqual(new Period(-2, -3, -4, -5, -6, -7, -8, -9, -10, -11), negation);
+        }
+
+        [Test]
         public void Equality_WhenEqual()
         {
             Assert.AreEqual(Period.FromHours(10), Period.FromHours(10));

--- a/src/NodaTime/AnnualDate.cs
+++ b/src/NodaTime/AnnualDate.cs
@@ -8,6 +8,7 @@ using NodaTime.Utility;
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -35,6 +36,9 @@ namespace NodaTime
     [TypeConverter(typeof(AnnualDateTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct AnnualDate : IEquatable<AnnualDate>, IComparable<AnnualDate>, IComparable, IFormattable, IXmlSerializable
+#if NET8_0_OR_GREATER
+        , IComparisonOperators<AnnualDate, AnnualDate, bool>
+#endif
     {
         // The underlying value. We only care about the month and day, but for the sake of
         // compatibility with the default value, this ends up being in year 1. This would

--- a/src/NodaTime/DateInterval.cs
+++ b/src/NodaTime/DateInterval.cs
@@ -7,6 +7,7 @@ using NodaTime.Utility;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Numerics;
 using static System.FormattableString;
 
 namespace NodaTime
@@ -31,6 +32,9 @@ namespace NodaTime
     /// <threadsafety>This type is immutable reference type. See the thread safety section of the user guide for more information.</threadsafety>
     [Immutable]
     public sealed class DateInterval : IEquatable<DateInterval?>, IEnumerable<LocalDate>
+#if NET8_0_OR_GREATER
+        , IEqualityOperators<DateInterval, DateInterval, bool>
+#endif
     {
         /// <summary>
         /// Gets the start date of the interval.

--- a/src/NodaTime/Duration.cs
+++ b/src/NodaTime/Duration.cs
@@ -65,6 +65,15 @@ namespace NodaTime
     [TypeConverter(typeof(DurationTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct Duration : IEquatable<Duration>, IComparable<Duration>, IComparable, IXmlSerializable, IFormattable
+#if NET8_0_OR_GREATER
+        , IAdditionOperators<Duration, Duration, Duration>
+        , ISubtractionOperators<Duration, Duration, Duration>
+        , IUnaryNegationOperators<Duration, Duration>
+        , IUnaryPlusOperators<Duration, Duration>
+        , IComparisonOperators<Duration, Duration, bool>
+        , IMinMaxValue<Duration>
+        , IAdditiveIdentity<Duration, Duration>
+#endif
     {
         // This is one more bit than we really need, but it allows Instant.BeforeMinValue and Instant.AfterMaxValue
         // to be easily constructed with valid durations, even though the result is a deliberately-invalid instant.
@@ -92,6 +101,11 @@ namespace NodaTime
         /// </summary>
         /// <value>The zero <see cref="Duration"/> value.</value>
         public static Duration Zero => default;
+
+        /// <summary>
+        /// Gets the additive identity.
+        /// </summary>
+        public static Duration AdditiveIdentity => Zero;
 
         /// <summary>
         /// Gets a <see cref="Duration"/> value equal to 1 nanosecond; the smallest amount by which an instant can vary.
@@ -499,6 +513,13 @@ namespace NodaTime
                 return new Duration(newDays, newNanos);
             }
         }
+
+        /// <summary>
+        /// Implements the operator + (unary).
+        /// </summary>
+        /// <param name="duration">The duration.</param>
+        /// <returns>The same duration <see cref="Duration"/> as provided.</returns>
+        public static Duration operator +(Duration duration) => duration;
 
         /// <summary>
         /// Adds one duration to another. Friendly alternative to <c>operator+()</c>.

--- a/src/NodaTime/Instant.cs
+++ b/src/NodaTime/Instant.cs
@@ -9,6 +9,7 @@ using NodaTime.Utility;
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -36,6 +37,13 @@ namespace NodaTime
     [TypeConverter(typeof(InstantTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct Instant : IEquatable<Instant>, IComparable<Instant>, IFormattable, IComparable, IXmlSerializable
+#if NET8_0_OR_GREATER
+        , IAdditionOperators<Instant, Duration, Instant>
+        , ISubtractionOperators<Instant, Duration, Instant>
+        , ISubtractionOperators<Instant, Instant, Duration>
+        , IComparisonOperators<Instant, Instant, bool>
+        , IMinMaxValue<Instant>
+#endif
     {
         // These correspond to -9998-01-01 and 9999-12-31 respectively.
         internal const int MinDays = -4371222;

--- a/src/NodaTime/Interval.cs
+++ b/src/NodaTime/Interval.cs
@@ -6,6 +6,7 @@ using JetBrains.Annotations;
 using NodaTime.Text;
 using NodaTime.Utility;
 using System;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -36,6 +37,9 @@ namespace NodaTime
     /// <threadsafety>This type is an immutable value type. See the thread safety section of the user guide for more information.</threadsafety>
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct Interval : IEquatable<Interval>, IXmlSerializable
+#if NET8_0_OR_GREATER
+        , IEqualityOperators<Interval, Interval, bool>
+#endif
     {
         /// <summary>The start of the interval.</summary>
         private readonly Instant start;

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -11,6 +11,7 @@ using NodaTime.Utility;
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -37,6 +38,13 @@ namespace NodaTime
     [TypeConverter(typeof(LocalDateTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct LocalDate : IEquatable<LocalDate>, IComparable<LocalDate>, IComparable, IFormattable, IXmlSerializable
+#if NET8_0_OR_GREATER
+        , IAdditionOperators<LocalDate, Period, LocalDate>
+        , IAdditionOperators<LocalDate, LocalTime, LocalDateTime>
+        , ISubtractionOperators<LocalDate, Period, LocalDate>
+        , ISubtractionOperators<LocalDate, LocalDate, Period>
+        , IComparisonOperators<LocalDate, LocalDate, bool>
+#endif
     {
         private readonly YearMonthDayCalendar yearMonthDayCalendar;
 

--- a/src/NodaTime/LocalDateTime.cs
+++ b/src/NodaTime/LocalDateTime.cs
@@ -12,6 +12,7 @@ using NodaTime.Utility;
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -43,6 +44,12 @@ namespace NodaTime
     [TypeConverter(typeof(LocalDateTimeTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct LocalDateTime : IEquatable<LocalDateTime>, IComparable<LocalDateTime>, IComparable, IFormattable, IXmlSerializable
+#if NET8_0_OR_GREATER
+        , IAdditionOperators<LocalDateTime, Period, LocalDateTime>
+        , ISubtractionOperators<LocalDateTime, LocalDateTime, Period>
+        , ISubtractionOperators<LocalDateTime, Period, LocalDateTime>
+        , IComparisonOperators<LocalDateTime, LocalDateTime, bool>
+#endif
     {
         /// <summary>
         /// The maximum (latest) date and time representable in the ISO calendar system.

--- a/src/NodaTime/LocalTime.cs
+++ b/src/NodaTime/LocalTime.cs
@@ -10,6 +10,7 @@ using NodaTime.Utility;
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -35,6 +36,13 @@ namespace NodaTime
     [TypeConverter(typeof(LocalTimeTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct LocalTime : IEquatable<LocalTime>, IComparable<LocalTime>, IFormattable, IComparable, IXmlSerializable
+#if NET8_0_OR_GREATER
+        , IAdditionOperators<LocalTime, Period, LocalTime>
+        , ISubtractionOperators<LocalTime, LocalTime, Period>
+        , ISubtractionOperators<LocalTime, Period, LocalTime>
+        , IComparisonOperators<LocalTime, LocalTime, bool>
+        , IMinMaxValue<LocalTime>
+#endif
     {
         /// <summary>
         /// Local time at midnight, i.e. 0 hours, 0 minutes, 0 seconds.

--- a/src/NodaTime/Offset.cs
+++ b/src/NodaTime/Offset.cs
@@ -9,6 +9,7 @@ using NodaTime.Utility;
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -41,6 +42,15 @@ namespace NodaTime
     [TypeConverter(typeof(OffsetTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct Offset : IEquatable<Offset>, IComparable<Offset>, IFormattable, IComparable, IXmlSerializable
+#if NET8_0_OR_GREATER
+        , IAdditionOperators<Offset, Offset, Offset>
+        , ISubtractionOperators<Offset, Offset, Offset>
+        , IUnaryNegationOperators<Offset, Offset>
+        , IUnaryPlusOperators<Offset, Offset>
+        , IComparisonOperators<Offset, Offset, bool>
+        , IMinMaxValue<Offset>
+        , IAdditiveIdentity<Offset, Offset>
+#endif
     {
         // Note: these public fields are unfortunate; they really should be properties, like all other public constants.
         // Unfortunately that would now be a breaking change.
@@ -51,6 +61,11 @@ namespace NodaTime
         public static readonly Offset Zero = FromSeconds(0);
 
         /// <summary>
+        /// Gets the additive identity.
+        /// </summary>
+        public static Offset AdditiveIdentity => Zero;
+
+        /// <summary>
         /// The minimum permitted offset; 18 hours before UTC.
         /// </summary>
         public static readonly Offset MinValue = FromHours(-18);
@@ -58,6 +73,18 @@ namespace NodaTime
         /// The maximum permitted offset; 18 hours after UTC.
         /// </summary>
         public static readonly Offset MaxValue = FromHours(18);
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// The minimum permitted offset; 18 hours before UTC.
+        /// </summary>
+        static Offset IMinMaxValue<Offset>.MinValue => MinValue;
+
+        /// <summary>
+        /// The maximum permitted offset; 18 hours after UTC.
+        /// </summary>
+        static Offset IMinMaxValue<Offset>.MaxValue => MaxValue;
+#endif
 
         private const int MinHours = -18;
         private const int MaxHours = 18;

--- a/src/NodaTime/OffsetDate.cs
+++ b/src/NodaTime/OffsetDate.cs
@@ -9,6 +9,7 @@ using NodaTime.Utility;
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -32,6 +33,9 @@ namespace NodaTime
     [TypeConverter(typeof(OffsetDateTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct OffsetDate : IEquatable<OffsetDate>, IXmlSerializable, IFormattable
+#if NET8_0_OR_GREATER
+        , IEqualityOperators<OffsetDate, OffsetDate, bool>
+#endif
     {
         private readonly LocalDate date;
         private readonly Offset offset;

--- a/src/NodaTime/OffsetDateTime.cs
+++ b/src/NodaTime/OffsetDateTime.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -46,6 +47,11 @@ namespace NodaTime
     [TypeConverter(typeof(OffsetDateTimeTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct OffsetDateTime : IEquatable<OffsetDateTime>, IFormattable, IXmlSerializable
+#if NET8_0_OR_GREATER
+        , IAdditionOperators<OffsetDateTime, Duration, OffsetDateTime>
+        , ISubtractionOperators<OffsetDateTime, Duration, OffsetDateTime>
+        , IEqualityOperators<OffsetDateTime, OffsetDateTime, bool>
+#endif
     {
         private const int MinBclOffsetMinutes = -14 * MinutesPerHour;
         private const int MaxBclOffsetMinutes = 14 * MinutesPerHour;

--- a/src/NodaTime/OffsetTime.cs
+++ b/src/NodaTime/OffsetTime.cs
@@ -9,6 +9,7 @@ using NodaTime.Utility;
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -30,6 +31,9 @@ namespace NodaTime
     [TypeConverter(typeof(OffsetTimeTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct OffsetTime : IEquatable<OffsetTime>, IXmlSerializable, IFormattable
+#if NET8_0_OR_GREATER
+        , IEqualityOperators<OffsetTime, OffsetTime, bool>
+#endif
     {
         private const int NanosecondsBits = 47;
         private const long NanosecondsMask = (1L << NanosecondsBits) - 1;

--- a/src/NodaTime/Period.cs
+++ b/src/NodaTime/Period.cs
@@ -10,6 +10,7 @@ using NodaTime.Utility;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Numerics;
 using static NodaTime.NodaConstants;
 
 namespace NodaTime
@@ -57,6 +58,14 @@ namespace NodaTime
     [Immutable]
     [TypeConverter(typeof(PeriodTypeConverter))]
     public sealed class Period : IEquatable<Period?>
+#if NET8_0_OR_GREATER
+        , IAdditionOperators<Period, Period, Period>
+        , ISubtractionOperators<Period, Period, Period>
+        , IUnaryNegationOperators<Period, Period>
+        , IUnaryPlusOperators<Period, Period>
+        , IAdditiveIdentity<Period, Period>
+        , IMinMaxValue<Period>
+#endif
     {
         // General implementation note: operations such as normalization work out the total number of nanoseconds as an Int64
         // value. This can handle +/- 106,751 days, or 292 years. We could move to using BigInteger if we feel that's required,
@@ -80,6 +89,11 @@ namespace NodaTime
         /// </summary>
         /// <value>A period containing the minimum value for all properties.</value>
         public static Period MinValue { get; } = new Period(int.MinValue, int.MinValue, int.MinValue, int.MinValue, long.MinValue, long.MinValue, long.MinValue, long.MinValue, long.MinValue, long.MinValue);
+
+        /// <summary>
+        /// Gets the additive identity.
+        /// </summary>
+        public static Period AdditiveIdentity => Zero;
 
         /// <summary>
         /// Returns an equality comparer which compares periods by first normalizing them - so 24 hours is deemed equal to 1 day, and so on.
@@ -374,6 +388,13 @@ namespace NodaTime
                 minuend.Ticks - subtrahend.Ticks,
                 minuend.Nanoseconds - subtrahend.Nanoseconds);
         }
+
+        /// <summary>
+        /// Implements the unary negation operator.
+        /// </summary>
+        /// <param name="period">Period to negate</param>
+        /// <returns>The negative value of this period</returns>
+        public static Period operator -(Period period) => Zero - period;
 
         /// <summary>
         /// Subtracts one period from another, by simply subtracting each property value.
@@ -889,6 +910,13 @@ namespace NodaTime
         /// </summary>
         /// <returns>A formatted representation of this period.</returns>
         public override string ToString() => PeriodPattern.Roundtrip.Format(this);
+
+        /// <summary>
+        /// Implements the operator + (unary).
+        /// </summary>
+        /// <param name="period">The period.</param>
+        /// <returns>The same period <see cref="Period"/> as provided.</returns>
+        public static Period operator +(Period period) => period;
 
         /// <summary>
         /// Compares the given object for equality with this one, as per <see cref="Equals(Period?)"/>.

--- a/src/NodaTime/TimeZones/ZoneInterval.cs
+++ b/src/NodaTime/TimeZones/ZoneInterval.cs
@@ -6,6 +6,7 @@ using NodaTime.Annotations;
 using NodaTime.Utility;
 using System;
 using System.Diagnostics;
+using System.Numerics;
 using static System.FormattableString;
 
 namespace NodaTime.TimeZones
@@ -22,6 +23,9 @@ namespace NodaTime.TimeZones
     /// <threadsafety>This type is an immutable reference type. See the thread safety section of the user guide for more information.</threadsafety>
     [Immutable]
     public sealed class ZoneInterval : IEquatable<ZoneInterval?>
+#if NET8_0_OR_GREATER
+        , IEqualityOperators<ZoneInterval, ZoneInterval, bool>
+#endif
     {
 
         /// <summary>

--- a/src/NodaTime/YearMonth.cs
+++ b/src/NodaTime/YearMonth.cs
@@ -10,6 +10,7 @@ using NodaTime.Utility;
 using System;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -34,6 +35,9 @@ namespace NodaTime
     [XmlSchemaProvider(nameof(AddSchema))]
     [TypeConverter(typeof(YearMonthTypeConverter))]
     public struct YearMonth : IEquatable<YearMonth>, IComparable<YearMonth>, IComparable, IFormattable, IXmlSerializable
+#if NET8_0_OR_GREATER
+        , IComparisonOperators<YearMonth, YearMonth, bool>
+#endif
     {
         /// <summary>
         /// The start of month. This is used as our base representation as we already have

--- a/src/NodaTime/YearMonthDay.cs
+++ b/src/NodaTime/YearMonthDay.cs
@@ -3,6 +3,7 @@
 // as found in the LICENSE.txt file.
 using System;
 using System.Globalization;
+using System.Numerics;
 
 namespace NodaTime
 {
@@ -24,6 +25,9 @@ namespace NodaTime
     /// </para>
     /// </remarks>
     internal readonly struct YearMonthDay : IComparable<YearMonthDay>, IEquatable<YearMonthDay>
+#if NET8_0_OR_GREATER
+        , IComparisonOperators<YearMonthDay, YearMonthDay, bool>
+#endif
     {
         private const int DayMask = (1 << YearMonthDayCalendar.DayBits) - 1;
         private const int MonthMask = ((1 << YearMonthDayCalendar.MonthBits) - 1) << YearMonthDayCalendar.DayBits;

--- a/src/NodaTime/ZonedDateTime.cs
+++ b/src/NodaTime/ZonedDateTime.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Xml;
 using System.Xml.Schema;
@@ -51,6 +52,12 @@ namespace NodaTime
     [TypeConverter(typeof(ZonedDateTimeTypeConverter))]
     [XmlSchemaProvider(nameof(AddSchema))]
     public readonly struct ZonedDateTime : IEquatable<ZonedDateTime>, IFormattable, IXmlSerializable
+#if NET8_0_OR_GREATER
+        , IAdditionOperators<ZonedDateTime, Duration, ZonedDateTime>
+        , ISubtractionOperators<ZonedDateTime, ZonedDateTime, Duration>
+        , ISubtractionOperators<ZonedDateTime, Duration, ZonedDateTime>
+        , IEqualityOperators<ZonedDateTime, ZonedDateTime, bool>
+#endif
     {
         private readonly OffsetDateTime offsetDateTime;
         private readonly DateTimeZone zone;


### PR DESCRIPTION
Resolves https://github.com/nodatime/nodatime/issues/1693.

Choices made / possible discussion points:
- Ignored `internal` types.
- Added only a test for the `Period` unary negation operator, as that one actually has some implementation.
- Did not implement `IMultiplicativeIdentity`
  - `Duration` and `Period` are the most likely candidates to implement it as suggested [here](https://github.com/nodatime/nodatime/issues/1693#issue-1299781520), however I don't think there is a logical multiplicative identity for either of those (1 tick / 1 second / 1 hour / ....).
- Did not implement `IMinMaxValue` for `Period` as I could not figure out a logical `MaxValue`.
- Did not implement `IMinMaxValue` for `LocalDate` and `LocalDateTime`, as they both have `MinIsoValue` and `MaxIsoValue` already and they suggest requiring explicit usage of Iso. Let me know if implemention is desired anyway.
- Did not implement `IAdditiveIdentity` for `Instant`, as you cannot sum two Instants. However, following the rules of 'Additive Identity', I think using `new Instant(0, 0)` is technically correct.
- Implemented `IMinMaxValue` for `Offset`, however, as the interface requires properties, and the `Offset` types already has fields with the same name, I am unsure about the compatibility of this. I can remove implementing `IMinMaxValue` if desired.