### PR TITLE
Remove nonsensical aspect of capture for invariant methods.

### DIFF
--- a/src/NodaTime/Text/AnnualDatePattern.cs
+++ b/src/NodaTime/Text/AnnualDatePattern.cs
@@ -173,9 +173,7 @@ namespace NodaTime.Text
         /// Creates a pattern for the given pattern text in the invariant culture.
         /// </summary>
         /// <remarks>
-        /// See the user guide for the available pattern text options. Note that the current culture
-        /// is captured at the time this method is called - it is not captured at the point of parsing
-        /// or formatting values.
+        /// See the user guide for the available pattern text options.
         /// </remarks>
         /// <param name="patternText">Pattern text to create the pattern for</param>
         /// <returns>A pattern for parsing and formatting annual dates.</returns>

--- a/src/NodaTime/Text/DurationPattern.cs
+++ b/src/NodaTime/Text/DurationPattern.cs
@@ -133,9 +133,7 @@ namespace NodaTime.Text
         /// Creates a pattern for the given pattern text in the invariant culture.
         /// </summary>
         /// <remarks>
-        /// See the user guide for the available pattern text options. Note that the current culture
-        /// is captured at the time this method is called - it is not captured at the point of parsing
-        /// or formatting values.
+        /// See the user guide for the available pattern text options.
         /// </remarks>
         /// <param name="patternText">Pattern text to create the pattern for</param>
         /// <returns>A pattern for parsing and formatting offsets.</returns>

--- a/src/NodaTime/Text/LocalDatePattern.cs
+++ b/src/NodaTime/Text/LocalDatePattern.cs
@@ -187,9 +187,7 @@ namespace NodaTime.Text
         /// Creates a pattern for the given pattern text in the invariant culture.
         /// </summary>
         /// <remarks>
-        /// See the user guide for the available pattern text options. Note that the current culture
-        /// is captured at the time this method is called - it is not captured at the point of parsing
-        /// or formatting values.
+        /// See the user guide for the available pattern text options.
         /// </remarks>
         /// <param name="patternText">Pattern text to create the pattern for</param>
         /// <returns>A pattern for parsing and formatting local dates.</returns>

--- a/src/NodaTime/Text/LocalTimePattern.cs
+++ b/src/NodaTime/Text/LocalTimePattern.cs
@@ -194,9 +194,7 @@ namespace NodaTime.Text
         /// Creates a pattern for the given pattern text in the invariant culture.
         /// </summary>
         /// <remarks>
-        /// See the user guide for the available pattern text options. Note that the current culture
-        /// is captured at the time this method is called - it is not captured at the point of parsing
-        /// or formatting values.
+        /// See the user guide for the available pattern text options.
         /// </remarks>
         /// <param name="patternText">Pattern text to create the pattern for</param>
         /// <returns>A pattern for parsing and formatting local times.</returns>

--- a/src/NodaTime/Text/OffsetPattern.cs
+++ b/src/NodaTime/Text/OffsetPattern.cs
@@ -130,9 +130,7 @@ namespace NodaTime.Text
         /// Creates a pattern for the given pattern text in the invariant culture.
         /// </summary>
         /// <remarks>
-        /// See the user guide for the available pattern text options. Note that the current culture
-        /// is captured at the time this method is called - it is not captured at the point of parsing
-        /// or formatting values.
+        /// See the user guide for the available pattern text options.
         /// </remarks>
         /// <param name="patternText">Pattern text to create the pattern for</param>
         /// <returns>A pattern for parsing and formatting offsets.</returns>

--- a/src/NodaTime/Text/YearMonthPattern.cs
+++ b/src/NodaTime/Text/YearMonthPattern.cs
@@ -178,9 +178,7 @@ namespace NodaTime.Text
         /// Creates a pattern for the given pattern text in the invariant culture.
         /// </summary>
         /// <remarks>
-        /// See the user guide for the available pattern text options. Note that the current culture
-        /// is captured at the time this method is called - it is not captured at the point of parsing
-        /// or formatting values.
+        /// See the user guide for the available pattern text options.
         /// </remarks>
         /// <param name="patternText">Pattern text to create the pattern for</param>
         /// <returns>A pattern for parsing and formatting year/month values.</returns>


### PR DESCRIPTION
Fixes #1804.

Equivalent to #1805, but on the 3.1.x branch.