### PR TITLE
Improve perf of LocalDate.WithCalendar if calendar is unchanged

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateBenchmarks.cs
+++ b/src/NodaTime.Benchmarks/NodaTimeTests/LocalDateBenchmarks.cs
@@ -139,6 +139,9 @@ namespace NodaTime.Benchmarks.NodaTimeTests
         [Benchmark]
         public bool LessThanOperator() => Sample < SampleBeforeEpoch;
 
+        [Benchmark]
+        public LocalDate WithCalendar_Unchanged() => Sample.WithCalendar(CalendarSystem.Iso);
+
 #if NET6_0_OR_GREATER
         [Benchmark]
         public DateOnly ToDateOnly() => Sample.ToDateOnly();

--- a/src/NodaTime.Test/LocalDateTest.Conversion.cs
+++ b/src/NodaTime.Test/LocalDateTest.Conversion.cs
@@ -87,6 +87,18 @@ namespace NodaTime.Test
             LocalDate start = new LocalDate(1, 1, 1);
             Assert.Throws<ArgumentOutOfRangeException>(() => start.WithCalendar(CalendarSystem.PersianSimple));
         }
+
+        [Test]
+        public void WithCalendar_Unchanged()
+        {
+            LocalDate isoEpoch = new LocalDate(1970, 1, 1);
+            LocalDate unchanged = isoEpoch.WithCalendar(CalendarSystem.Iso);
+            Assert.AreEqual(isoEpoch.Year, unchanged.Year);
+            Assert.AreEqual(isoEpoch.Month, unchanged.Month);
+            Assert.AreEqual(isoEpoch.Day, unchanged.Day);
+            Assert.AreSame(isoEpoch.Calendar, unchanged.Calendar);
+        }
+
 #if NET6_0_OR_GREATER
         [Test]
         public void ToDateOnly_Gregorian()

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -627,7 +627,9 @@ namespace NodaTime
         public LocalDate WithCalendar(CalendarSystem calendar)
         {
             Preconditions.CheckNotNull(calendar, nameof(calendar));
-            return new LocalDate(DaysSinceEpoch, calendar);
+            return ReferenceEquals(calendar, Calendar)
+                ? this
+                : new LocalDate(DaysSinceEpoch, calendar);
         }
 
         /// <summary>

--- a/src/NodaTime/LocalDate.cs
+++ b/src/NodaTime/LocalDate.cs
@@ -627,7 +627,7 @@ namespace NodaTime
         public LocalDate WithCalendar(CalendarSystem calendar)
         {
             Preconditions.CheckNotNull(calendar, nameof(calendar));
-            return ReferenceEquals(calendar, Calendar)
+            return calendar.Ordinal == CalendarOrdinal
                 ? this
                 : new LocalDate(DaysSinceEpoch, calendar);
         }


### PR DESCRIPTION
If the LocalDate.WithCalendar is called with the same calendar the cost of the DaysSinceEpoch math can be avoided.

BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3880/23H2/2023Update/SunValley3) 12th Gen Intel Core i7-1270P, 1 CPU, 16 logical and 12 physical cores .NET SDK 8.0.303
  [Host]     : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2

| Method                          | Mean     | Error     | StdDev    | Ratio |
|-------------------------------- |---------:|----------:|----------:|------:|
| WithCalendar_Unchanged_New      | 1.045 ns | 0.0150 ns | 0.0133 ns |  0.15 |
| WithCalendar_Unchanged_Previous | 7.043 ns | 0.0941 ns | 0.0880 ns |  1.00 |