### PR TITLE
Use TimeProvider in .NET 8+ to implement IClock

### DIFF
--- a/src/NodaTime/IClock.cs
+++ b/src/NodaTime/IClock.cs
@@ -2,6 +2,11 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+#if NET8_0_OR_GREATER
+using NodaTime.Annotations;
+using NodaTime.Extensions;
+using NodaTime.Utility;
+#endif
 using System;
 
 namespace NodaTime
@@ -28,5 +33,38 @@ namespace NodaTime
         /// </summary>
         /// <returns>The current instant on the time line according to this clock.</returns>
         Instant GetCurrentInstant();
+
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// Convenience property for <see cref="SystemClock.Instance"/>.
+        /// </summary>
+        public static IClock System => SystemClock.Instance;
+#endif
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Creates a clock which delegates requests for the current time to <see cref="TimeProvider.GetUtcNow"/>
+        /// </summary>
+        /// <param name="timeProvider">The time provider to delegate to. Must not be null.</param>
+        /// <returns>A clock which delegates to the given time provider.</returns>
+        public static IClock FromTimeProvider(TimeProvider timeProvider) => new TimeProviderClock(timeProvider);
+
+        [Immutable]
+        private sealed class TimeProviderClock : IClock
+        {
+            private readonly TimeProvider timeProvider;
+
+            /// <summary>
+            /// Creates an instance from the given time provider, delegating
+            /// requests for the current time to <see cref="TimeProvider.GetUtcNow"/>
+            /// </summary>
+            /// <param name="timeProvider">The time provider to delegate to. Must not be null.</param>
+            public TimeProviderClock(TimeProvider timeProvider) =>
+                this.timeProvider = Preconditions.CheckNotNull(timeProvider, nameof(timeProvider));
+
+            /// <inheritdoc/>
+            public Instant GetCurrentInstant() => timeProvider.GetUtcNow().ToInstant();
+        }
+#endif
     }
 }

--- a/src/NodaTime/ZonedClock.cs
+++ b/src/NodaTime/ZonedClock.cs
@@ -5,6 +5,11 @@ using JetBrains.Annotations;
 using NodaTime.Annotations;
 using NodaTime.Utility;
 
+#if NET8_0_OR_GREATER
+using System;
+using NodaTime.TimeZones;
+#endif
+
 namespace NodaTime
 {
     /// <summary>
@@ -39,6 +44,31 @@ namespace NodaTime
             Zone = Preconditions.CheckNotNull(zone, nameof(zone));
             Calendar = Preconditions.CheckNotNull(calendar, nameof(calendar));
         }
+
+#if NET8_0_OR_GREATER
+        /// <summary>
+        /// Creates a <see cref="ZonedClock"/> from the given <see cref="TimeProvider"/>,
+        /// in the time zone returned by <see cref="TimeProvider.LocalTimeZone"/> and delegating
+        /// requests for the current time to <see cref="TimeProvider.GetUtcNow"/>, using the ISO
+        /// calendar system.
+        /// </summary>
+        /// <param name="timeProvider">The time provider to delegate to. Must not be null.</param>
+        /// <returns></returns>
+        public static ZonedClock FromTimeProvider(TimeProvider timeProvider) =>
+            FromTimeProvider(timeProvider, CalendarSystem.Iso);
+
+        /// <summary>
+        /// Creates a <see cref="ZonedClock"/> from the given <see cref="TimeProvider"/>,
+        /// in the time zone returned by <see cref="TimeProvider.LocalTimeZone"/> and delegating
+        /// requests for the current time to <see cref="TimeProvider.GetUtcNow"/>, using the ISO
+        /// calendar system.
+        /// </summary>
+        /// <param name="timeProvider">The time provider to delegate to. Must not be null.</param>
+        /// <param name="calendar">The calendar system to use. Must not be null.</param>
+        /// <returns></returns>
+        public static ZonedClock FromTimeProvider(TimeProvider timeProvider, CalendarSystem calendar) =>
+            new(IClock.FromTimeProvider(timeProvider), BclDateTimeZone.FromTimeZoneInfo(timeProvider.LocalTimeZone), calendar);
+#endif
 
         /// <summary>
         /// Returns the current instant provided by the underlying clock.


### PR DESCRIPTION
First part of #1751.

Using static methods/properties to return IClock instances feels like it's more discoverable than "knowing" about SystemClock etc (or having a separate Clocks class). It's not supported in .NET Framework though, hence the conditionality. Given that TimeProvider is only available in .NET 8 though, there's no need to expose the TimeProviderClock class at all, hence the private implementation.

The ZonedClock factory methods are just for convenience.

We *could* do all of this from a TimeProviderExtensions class instead:

- `IClock ToClock(this TimeProvider provider)`
- `ZonedClock ToZonedClock(this TimeProvider provider)`
- `ZonedClock ToZonedClock(this TimeProvider provider, CalendarSystem calendar)`

Or we could do that as well... thoughts welcome.

(No tests written yet until we've got the production API discussed.)