### PR TITLE
Release Noda Time 3.2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
       - The most recently-released version. This is the last
       - thing to change before performing a release.
       -->
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
     <!--
       - The version we check for compatibility against. This is changed
       - immediately *after* a release.


### PR DESCRIPTION
Changes since 3.1.0

- Various minor docs/examples fixes
- More LocalDateTime ISO patterns with reduced precision (
- More LocalTime ISO formats
- Support for configurable "2 digit year max value" in patterns
- Fixed arguments passed to base constructors in AmbiguousTimeException and SkippedTimeException
- Add the unparsed value (and index) to UnparsableValueException
- Made previous UnparsableValueException constructors obsolete
- Optimizations for text handling
- Added .NET 8 target
- Added Instant.ToUnixTimeSecondsAndNanoseconds
- Added Duration.ToInt128Nanoseconds and Duration.FromNanoseconds(Int128) (.NET 8 only)
- Conditionalized the dependency on System.Runtime.CompilerServices.Unsafe
- Added Period.MinValue and Period.MaxValue
- Added generic math support (.NET 8 only)
- Added TimeProvider extension methods (.NET 8 only)