### PR TITLE
Add hard-coded mapping for Turkey time zone standard name on Windows

### DIFF
--- a/src/NodaTime.TzdbCompiler.Test/Tzdb/NameIdMappingSupportTest.cs
+++ b/src/NodaTime.TzdbCompiler.Test/Tzdb/NameIdMappingSupportTest.cs
@@ -42,7 +42,7 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
         public void AllDetectedNamesAreMappedCorrectly()
         {
             var incorrectMappings = DetectedMapping.Keys
-                .Where(key => NameIdMappingSupport.StandardNameToIdMap.ContainsKey(key))
+                .Where(NameIdMappingSupport.StandardNameToIdMap.ContainsKey)
                 .Where(key => DetectedMapping[key] != NameIdMappingSupport.StandardNameToIdMap[key])
                 .Select(key => $"Expected {key} => {DetectedMapping[key]}; was {NameIdMappingSupport.StandardNameToIdMap[key]}")
                 .ToList();

--- a/src/NodaTime.TzdbCompiler/Tzdb/NameIdMappingSupport.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/NameIdMappingSupport.cs
@@ -37,6 +37,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
                 { "Cabo Verde Standard Time", "Cape Verde Standard Time" },
                 { "West Bank Gaza Standard Time", "West Bank Standard Time" },
                 { "Novosibirsk Standard Time", "N. Central Asia Standard Time" },
+                { "Türkiye Standard Time", "Turkey Standard Time" },
                 // Difference here is just the case of "and"!
                 { "Turks and Caicos Standard Time", "Turks And Caicos Standard Time" },
                 // The following name/ID mappings give an ID which then isn't present in CLDR


### PR DESCRIPTION
(This will only affect users of Noda Time 1.x - hopefully there aren't many of those left now...)