### PR TITLE
Remove NodaTime.Testing dependency from benchmarks

### DIFF
--- a/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
+++ b/src/NodaTime.Benchmarks/NodaTime.Benchmarks.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
-    <ProjectReference Include="..\NodaTime.Testing\NodaTime.Testing.csproj" />
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Collections.Immutable" />


### PR DESCRIPTION
For some reason this causes a failure for Int128-based benchmarks under .NET 8.0. The details aren't clear, and I can't reproduce the problem outside Benchmark.NET, but this fixes the issue.

Fixes #1853