### PR TITLE
Release v3.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
       - The most recently-released version. This is the last
       - thing to change before performing a release.
       -->
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <!--
       - The version we check for compatibility against. This is changed
       - immediately *after* a release.


### PR DESCRIPTION
Changes since 3.2.0:

- Removal of the net6.0 target framework, as .NET 6.0 has been EOL for over a year
- Added Period.NanosecondsBetween method
- Documentation fixes
- Added a new namespace, NodaTime.HighPerformance, containing Duration64 and Instant64 types (for high-performance scenarios where the larger size (in memory) of Duration and Instant is problematic