### PR TITLE
Remove SharpCompress in NodaTime tools

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,6 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="XmlSchemaClassGenerator-beta" Version="3.0.1270" />
-    <PackageVersion Include="SharpCompress" Version="0.48.0" />
     <PackageVersion Include="SauceControl.InheritDoc" Version="2.0.2" />
     <!-- Packages for tools -->
     <PackageVersion Include="Google.Protobuf" Version="3.33.2" />

--- a/src/NodaTime.NzdPrinter/NodaTime.NzdPrinter.csproj
+++ b/src/NodaTime.NzdPrinter/NodaTime.NzdPrinter.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
     <ProjectReference Include="..\NodaTime.Tools.Common\NodaTime.Tools.Common.csproj" />
-    <PackageReference Include="SharpCompress" />
   </ItemGroup>
 
 </Project>

--- a/src/NodaTime.NzdPrinter/Program.cs
+++ b/src/NodaTime.NzdPrinter/Program.cs
@@ -28,7 +28,7 @@ namespace NodaTime.NzdPrinter
                 Console.WriteLine("Usage: NodaTime.NzdPrinter <path/url to nzd file>");
                 return 1;
             }
-            var stream = new MemoryStream(await FileUtility.LoadFileOrUrlAsync(args[0]));
+            await using var stream = await FileUtility.LoadFileOrUrlAsync(args[0]);
             int version = new BinaryReader(stream).ReadInt32();
             Console.WriteLine($"File format version: {version}");
             string[]? stringPool = null; // In a valid file, this will be non-null before it's used for any non-string-pool field.

--- a/src/NodaTime.Tools.Common/FileUtility.cs
+++ b/src/NodaTime.Tools.Common/FileUtility.cs
@@ -2,7 +2,9 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using System;
 using System.IO;
+using System.IO.Compression;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -10,15 +12,20 @@ namespace NodaTime.Tools.Common
 {
     public static class FileUtility
     {
-        public static async Task<byte[]> LoadFileOrUrlAsync(string source)
+        public static async Task<Stream> LoadFileOrUrlAsync(string source)
         {
             if (source.StartsWith("http://") || source.StartsWith("https://") || source.StartsWith("ftp://"))
             {
                 using var client = new HttpClient();
-                var response = await client.GetAsync(source);
-                return await response.EnsureSuccessStatusCode().Content.ReadAsByteArrayAsync();
+                var response = await client.GetAsync(source, HttpCompletionOption.ResponseHeadersRead);
+                var stream = await response.EnsureSuccessStatusCode().Content.ReadAsStreamAsync();
+
+                var mediaType = response.Content.Headers.ContentType?.MediaType;
+                var gzip = string.Equals(mediaType, "application/gzip", StringComparison.OrdinalIgnoreCase) ||
+                           string.Equals(mediaType, "application/x-gzip", StringComparison.OrdinalIgnoreCase);
+                return gzip ? new GZipStream(stream, CompressionMode.Decompress) : stream;
             }
-            return File.ReadAllBytes(source);
+            return File.OpenRead(source);
         }
     }
 }

--- a/src/NodaTime.TzValidate.NodaDump/Program.cs
+++ b/src/NodaTime.TzValidate.NodaDump/Program.cs
@@ -55,8 +55,8 @@ namespace NodaTime.TzValidate.NodaDump
             }
             if (source.EndsWith(".nzd"))
             {
-                var data = await FileUtility.LoadFileOrUrlAsync(source);
-                return TzdbDateTimeZoneSource.FromStream(new MemoryStream(data));
+                await using var stream = await FileUtility.LoadFileOrUrlAsync(source);
+                return TzdbDateTimeZoneSource.FromStream(stream);
             }
             else
             {

--- a/src/NodaTime.TzValidate.NzdCompatibility/Program.cs
+++ b/src/NodaTime.TzValidate.NzdCompatibility/Program.cs
@@ -7,7 +7,6 @@ using NodaTime.TimeZones;
 using NodaTime.Tools.Common;
 using System;
 using System.IO;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace NodaTime.TzValidate.NzdCompatibility
@@ -26,8 +25,8 @@ namespace NodaTime.TzValidate.NzdCompatibility
             {
                 return 1;
             }
-            var data = await FileUtility.LoadFileOrUrlAsync(options.Source);
-            TzdbDateTimeZoneSource source = TzdbDateTimeZoneSource.FromStream(new MemoryStream(data));
+            using var stream = await FileUtility.LoadFileOrUrlAsync(options.Source);
+            TzdbDateTimeZoneSource source = TzdbDateTimeZoneSource.FromStream(stream);
             var dumper = new ZoneDumper(source, options);
             try
             {

--- a/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
+++ b/src/NodaTime.TzdbCompiler/NodaTime.TzdbCompiler.csproj
@@ -7,6 +7,5 @@
   <ItemGroup>
     <ProjectReference Include="..\NodaTime\NodaTime.csproj" />
     <ProjectReference Include="..\NodaTime.Tools.Common\NodaTime.Tools.Common.csproj" />
-    <PackageReference Include="SharpCompress" />
   </ItemGroup>
 </Project>

--- a/src/NodaTime.TzdbCompiler/Tzdb/FileSource.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/FileSource.cs
@@ -2,9 +2,9 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
-using SharpCompress.Readers.Tar;
 using System;
 using System.Collections.Generic;
+using System.Formats.Tar;
 using System.IO;
 using System.Linq;
 
@@ -42,18 +42,17 @@ namespace NodaTime.TzdbCompiler.Tzdb
         internal static FileSource FromArchive(Stream archiveData, string fullOrigin)
         {
             var entries = new Dictionary<string, byte[]>();
-            using (var reader = TarReader.OpenReader(archiveData))
+            using (var reader = new TarReader(archiveData))
             {
-                while (reader.MoveToNextEntry())
+                while (reader.GetNextEntry() is {} entry)
                 {
-                    if (reader.Entry.IsDirectory)
+                    if (entry.DataStream != null)
                     {
-                        continue;
+                        using var entryStream = new MemoryStream();
+                        entry.DataStream.CopyTo(entryStream);
+                        // The lzip file puts everything into a subdirectory. Let's just take the filename...
+                        entries[Path.GetFileName(entry.Name)] = entryStream.ToArray();
                     }
-                    var entryStream = new MemoryStream();
-                    reader.WriteEntryTo(entryStream);
-                    // The lzip file puts everything into a subdirectory. Let's just take the filename...
-                    entries[Path.GetFileName(reader.Entry.Key!)] = entryStream.ToArray();
                 }
             }
             return new FileSource(entries.Keys.ToList(), file => new MemoryStream(entries[file]), fullOrigin);

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbZoneInfoCompiler.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbZoneInfoCompiler.cs
@@ -116,8 +116,8 @@ namespace NodaTime.TzdbCompiler.Tzdb
             if (path.StartsWith("ftp://") || path.StartsWith("http://") || path.StartsWith("https://"))
             {
                 log?.WriteLine($"Downloading {path}");
-                var data = await FileUtility.LoadFileOrUrlAsync(path);
-                return FileSource.FromArchive(new MemoryStream(data), path);
+                await using var stream = await FileUtility.LoadFileOrUrlAsync(path);
+                return FileSource.FromArchive(stream, path);
             }
             if (Directory.Exists(path))
             {


### PR DESCRIPTION
Use the built-in System.IO.Compression.GZipStream + System.Formats.Tar.TarReader (available since .NET 7) instead.