### PR TITLE
Use the CLDR version for the WindowsZones Version property

### DIFF
--- a/src/NodaTime.TzdbCompiler.Test/Tzdb/CldrWindowsZonesParserTest.cs
+++ b/src/NodaTime.TzdbCompiler.Test/Tzdb/CldrWindowsZonesParserTest.cs
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License 2.0,
 // as found in the LICENSE.txt file.
 
+using System.IO;
 using NodaTime.TimeZones.Cldr;
 using NodaTime.TzdbCompiler.Tzdb;
 using NUnit.Framework;
@@ -11,8 +12,9 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
 {
     public class CldrWindowsZonesParserTest
     {
-        [Test]
-        public void Versions_Present()
+        [TestCase("windowsZones-38-1.xml", "38.1")]
+        [TestCase("windowsZones-47.xml", "47")]
+        public void Versions_Present(string fileName, string expectedVersion)
         {
             string xml = @"
 <supplementalData>
@@ -25,8 +27,8 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
 </supplementalData>
     ";
             var doc = XDocument.Parse(xml);
-            var parsed = CldrWindowsZonesParser.Parse(doc);
-            Assert.AreEqual("rev-version", parsed.Version);
+            var parsed = CldrWindowsZonesParser.Parse(doc, Path.Combine("..", fileName));
+            Assert.AreEqual(expectedVersion, parsed.Version);
             Assert.AreEqual("win-version", parsed.WindowsVersion);
             Assert.AreEqual("tzdb-version", parsed.TzdbVersion);
         }
@@ -44,7 +46,7 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
 </supplementalData>
     ";
             var doc = XDocument.Parse(xml);
-            var parsed = CldrWindowsZonesParser.Parse(doc);
+            var parsed = CldrWindowsZonesParser.Parse(doc, "");
             Assert.AreEqual("", parsed.Version);
             Assert.AreEqual("", parsed.WindowsVersion);
             Assert.AreEqual("", parsed.TzdbVersion);
@@ -65,7 +67,7 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
 </supplementalData>
     ";
             var doc = XDocument.Parse(xml);
-            var parsed = CldrWindowsZonesParser.Parse(doc);
+            var parsed = CldrWindowsZonesParser.Parse(doc, "");
             var mapZones = parsed.MapZones;
             Assert.AreEqual(3, mapZones.Count);
             Assert.AreEqual(new MapZone("X", "t0", new string[0]), mapZones[0]);

--- a/src/NodaTime.TzdbCompiler/Tzdb/CldrWindowsZonesParser.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/CldrWindowsZonesParser.cs
@@ -3,9 +3,9 @@
 // as found in the LICENSE.txt file.
 
 using NodaTime.TimeZones.Cldr;
-using NodaTime.Utility;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -18,7 +18,7 @@ namespace NodaTime.TzdbCompiler.Tzdb
     /// </summary>
     internal class CldrWindowsZonesParser
     {
-        internal static WindowsZones Parse(XDocument document)
+        internal static WindowsZones Parse(XDocument document, string file)
         {
             var root = document.Root;
             if (root is null)
@@ -26,13 +26,13 @@ namespace NodaTime.TzdbCompiler.Tzdb
                 throw new ArgumentException("XML document has no root element");
             }
             var mapZones = MapZones(root);
-            var windowsZonesVersion = FindVersion(root!);
+            var windowsZonesVersion = FindVersion(root, file);
             var tzdbVersion = root.Element("windowsZones")?.Element("mapTimezones")?.Attribute("typeVersion")?.Value ?? "";
             var windowsVersion = root.Element("windowsZones")?.Element("mapTimezones")?.Attribute("otherVersion")?.Value ?? "";
             return new WindowsZones(windowsZonesVersion, tzdbVersion, windowsVersion, mapZones);
         }
 
-        internal static WindowsZones Parse(string file) => Parse(LoadFile(file));
+        internal static WindowsZones Parse(string file) => Parse(LoadFile(file), file);
 
         private static XDocument LoadFile(string file)
         {
@@ -45,8 +45,13 @@ namespace NodaTime.TzdbCompiler.Tzdb
             }
         }
 
-        private static string FindVersion(XElement root)
+        private static string FindVersion(XElement root, string file)
         {
+            var cldrVersion = Path.GetFileNameWithoutExtension(file).Replace("windowsZones-", "").Replace("-", ".");
+            if (decimal.TryParse(cldrVersion, NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out _))
+            {
+                return cldrVersion;
+            }
             string? revision = (string?) root.Element("version")?.Attribute("number");
             if (revision is null)
             {

--- a/src/NodaTime/TimeZones/Cldr/WindowsZones.cs
+++ b/src/NodaTime/TimeZones/Cldr/WindowsZones.cs
@@ -26,10 +26,10 @@ namespace NodaTime.TimeZones.Cldr
         /// Gets the version of the Windows zones mapping data read from the original file.
         /// </summary>
         /// <remarks>
-        /// As with other IDs, this should largely be treated as an opaque string, but the current method for
-        /// generating this from the mapping file extracts a number from an element such as <c>&lt;version number="$Revision: 7825 $"/&gt;</c>.
-        /// This is a Subversion revision number, but that association should only be used for diagnostic curiosity, and never
-        /// assumed in code.
+        /// As with other IDs, this should largely be treated as an opaque string. Previously, it was
+        /// generated from the mapping file by extracting a number from an element such as <c>&lt;version number="$Revision: 7825 $"/&gt;</c>.
+        /// This used to be a Subversion revision number. Currently, the version is the <a href="https://cldr.unicode.org">CLDR</a> version from the original file.
+        /// That association should only be used for diagnostic curiosity and never assumed in code.
         /// </remarks>
         /// <value>The version of the Windows zones mapping data read from the original file.</value>
         public string Version { get; }


### PR DESCRIPTION
For many years, the Version property has been `$Revision$` which is not useful at all. There's no resolution in sight: https://unicode-org.atlassian.net/browse/CLDR-13931

This changes the Version property to the CLDR version of the windowsZones-*.xml file so it's at least somewhat useful.

Fixes #1559