### PR TITLE
Accept unambiguous, case-insensitive prefixes in TZDB month/day parsing

### DIFF
--- a/src/NodaTime.TzdbCompiler.Test/Tzdb/TzdbZoneInfoParserTest.cs
+++ b/src/NodaTime.TzdbCompiler.Test/Tzdb/TzdbZoneInfoParserTest.cs
@@ -240,6 +240,69 @@ namespace NodaTime.TzdbCompiler.Test.Tzdb
         }
 
         [Test]
+        public void ParseMonth_unambiguousPrefix()
+        {
+            Assert.AreEqual(8, TzdbZoneInfoParser.ParseMonth("Au")); // No other month starts with "Au"
+            Assert.AreEqual(9, TzdbZoneInfoParser.ParseMonth("Septe")); // Prefix of the long form "September"
+        }
+
+        [Test]
+        public void ParseMonth_ambiguousPrefix_exception()
+        {
+            // "Ju" matches both June and July.
+            Assert.Throws<InvalidDataException>(() => TzdbZoneInfoParser.ParseMonth("Ju"));
+        }
+
+        [Test]
+        public void ParseMonth_caseInsensitive()
+        {
+            Assert.AreEqual(1, TzdbZoneInfoParser.ParseMonth("jan"));
+            Assert.AreEqual(1, TzdbZoneInfoParser.ParseMonth("JANUARY"));
+            Assert.AreEqual(8, TzdbZoneInfoParser.ParseMonth("au"));
+        }
+
+        [Test]
+        public void ParseDayOfWeek_nullOrEmpty()
+        {
+            Assert.Throws<ArgumentException>(() => TzdbZoneInfoParser.ParseDayOfWeek(""));
+            Assert.Throws<ArgumentException>(() => TzdbZoneInfoParser.ParseDayOfWeek(null!));
+        }
+
+        [Test]
+        public void ParseDayOfWeek_invalidDay_exception()
+        {
+            Assert.Throws<InvalidDataException>(() => TzdbZoneInfoParser.ParseDayOfWeek("Able"));
+        }
+
+        [Test]
+        public void ParseDayOfWeek_shortNames()
+        {
+            Assert.AreEqual(1, TzdbZoneInfoParser.ParseDayOfWeek("Mon"));
+            Assert.AreEqual(7, TzdbZoneInfoParser.ParseDayOfWeek("Sun"));
+        }
+
+        [Test]
+        public void ParseDayOfWeek_unambiguousPrefix()
+        {
+            Assert.AreEqual(1, TzdbZoneInfoParser.ParseDayOfWeek("Mo")); // No other day starts with "Mo"
+            Assert.AreEqual(4, TzdbZoneInfoParser.ParseDayOfWeek("Th")); // No other day starts with "Th"
+        }
+
+        [Test]
+        public void ParseDayOfWeek_ambiguousPrefix_exception()
+        {
+            // "S" matches both Saturday and Sunday.
+            Assert.Throws<InvalidDataException>(() => TzdbZoneInfoParser.ParseDayOfWeek("S"));
+        }
+
+        [Test]
+        public void ParseDayOfWeek_caseInsensitive()
+        {
+            Assert.AreEqual(1, TzdbZoneInfoParser.ParseDayOfWeek("mon"));
+            Assert.AreEqual(7, TzdbZoneInfoParser.ParseDayOfWeek("SUN"));
+        }
+
+        [Test]
         public void ParseZone_badOffset_exception()
         {
             var parser = new TzdbZoneInfoParser();

--- a/src/NodaTime.TzdbCompiler/Tzdb/TzdbZoneInfoParser.cs
+++ b/src/NodaTime.TzdbCompiler/Tzdb/TzdbZoneInfoParser.cs
@@ -42,14 +42,10 @@ namespace NodaTime.TzdbCompiler.Tzdb
         private static readonly string[] DaysOfWeek = { "", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" };
 
         /// <summary>
-        /// The months of the year names as they appear in the TZDB zone files. They are
-        /// always the short name in US English.
-        /// </summary>
-        private static readonly string[] ShortMonths = { "", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
-
-        /// <summary>
-        /// ... except when they're actually the long month name, e.g. in Greece in 96d.
-        /// (This is basically only for old files.)
+        /// The months of the year names as they appear in the TZDB zone files. Entries are usually
+        /// abbreviated to (an unambiguous prefix of) the first three letters, e.g. "Jan", but older
+        /// files sometimes spell them out in full, e.g. "January" in Greece's 96d rule. As the short
+        /// form is always a prefix of the long form, matching against the long form alone covers both.
         /// </summary>
         private static readonly string[] LongMonths =
             { "", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" };
@@ -230,19 +226,12 @@ namespace NodaTime.TzdbCompiler.Tzdb
         }
 
         /// <summary>
-        /// Parses the day of week.
+        /// Parses the day of week, which may be any case-insensitive, unambiguous prefix of a day
+        /// name (matching the behavior of zic itself).
         /// </summary>
         /// <param name="text">The text.</param>
-        private static int ParseDayOfWeek(string text)
-        {
-            Preconditions.CheckArgument(!string.IsNullOrEmpty(text), nameof(text), "Value must not be empty or null");
-            int index = Array.IndexOf(DaysOfWeek, text, 1);
-            if (index == -1)
-            {
-                throw new InvalidDataException($"Invalid day of week: {text}");
-            }
-            return index;
-        }
+        internal static int ParseDayOfWeek(string text) =>
+            ParseUnambiguousNamePrefix(text, "day of week", DaysOfWeek);
 
         /// <summary>
         /// Parses a single line of an TZDB zone info file.
@@ -336,24 +325,39 @@ namespace NodaTime.TzdbCompiler.Tzdb
         }
 
         /// <summary>
-        /// Parses the month.
+        /// Parses the month, which may be any case-insensitive, unambiguous prefix of a month name
+        /// (matching the behavior of zic itself).
         /// </summary>
         /// <param name="text">The text.</param>
         /// <returns>The month number in the range 1 to 12.</returns>
-        /// <exception cref="InvalidDataException">The month name can't be parsed</exception>
-        internal static int ParseMonth(String text)
+        /// <exception cref="InvalidDataException">The month name can't be parsed, or is ambiguous.</exception>
+        internal static int ParseMonth(String text) => ParseUnambiguousNamePrefix(text, "month", LongMonths);
+
+        /// <summary>
+        /// Finds the index of the single entry in <paramref name="names"/> (which has an unused entry
+        /// at index 0) for which <paramref name="text"/> is a case-insensitive prefix. Throws
+        /// <see cref="InvalidDataException"/> if no entry matches, or if more than one does.
+        /// </summary>
+        private static int ParseUnambiguousNamePrefix(string text, string what, string[] names)
         {
             Preconditions.CheckArgument(!string.IsNullOrEmpty(text), nameof(text), "Value must not be empty or null");
-            int index = Array.IndexOf(ShortMonths, text, 1);
-            if (index == -1)
+            int match = 0;
+            for (int i = 1; i < names.Length; i++)
             {
-                index = Array.IndexOf(LongMonths, text, 1);
-                if (index == -1)
+                if (names[i].StartsWith(text, StringComparison.OrdinalIgnoreCase))
                 {
-                    throw new InvalidDataException($"Invalid month: {text}");
+                    if (match != 0)
+                    {
+                        throw new InvalidDataException($"Ambiguous {what}: {text}");
+                    }
+                    match = i;
                 }
             }
-            return index;
+            if (match == 0)
+            {
+                throw new InvalidDataException($"Invalid {what}: {text}");
+            }
+            return match;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #1813