### PR TITLE
Fix declaration of AOT compatibility for .NET 8 target

### DIFF
--- a/src/NodaTime/NodaTime.csproj
+++ b/src/NodaTime/NodaTime.csproj
@@ -11,7 +11,7 @@
     <ApiCompatEnableRuleCannotChangeParameterName>true</ApiCompatEnableRuleCannotChangeParameterName>
     <PackageTags>date;time;timezone;calendar;nodatime</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
(Backported to 3.3.x)